### PR TITLE
Raiding with Leashes IV

### DIFF
--- a/app/data/pets.json
+++ b/app/data/pets.json
@@ -3852,7 +3852,7 @@
         ]
       },
       {
-        "name": "IV: Wrath of the Lich King", 
+        "name": "IV: Wrath of the Lick King", 
         "items": [
           {
             "spellid": "229093",


### PR DESCRIPTION
Raiding with Leashes IV should read "Lick" and not "Lich".

Looks like typo, but just a play on words.