### PR TITLE
mounts: add a separate section for Aviana's mount under the PvP section

### DIFF
--- a/app/data/mounts.json
+++ b/app/data/mounts.json
@@ -154,11 +154,6 @@
             "icon": "inv_spidermount"
           },
           {
-            "spellid": "230401",
-            "itemId": "142369",
-            "icon": "inv_ability_mount_cockatricemount_white"
-          },
-          {
             "spellid": 253007,
             "itemId": 152797,
             "icon": "inv_argustalbukmount_blue"
@@ -3415,6 +3410,17 @@
           }
         ],
         "id": "3eba27c1"
+      },
+      {
+        "name": "Talon's Vengeance",
+        "items": [
+          {
+            "spellid": "230401",
+            "itemId": "142369",
+            "icon": "inv_ability_mount_cockatricemount_white"
+          }
+        ],
+        "id": "b5e5edfb"
       },
       {
         "name": "Prestige",


### PR DESCRIPTION
It's weird to have the Timeless Isle's one under PvP but not the one for Talon's Vengeance.