### PR TITLE
Add a Toys section

### DIFF
--- a/app/data/toys.json
+++ b/app/data/toys.json
@@ -1,0 +1,3086 @@
+[
+  {
+    "id": "8610320b",
+    "items": [],
+    "name": "Toys",
+    "subcats": [
+      {
+        "id": "9740234c",
+        "items": [
+          {
+            "icon": "ability_siege_engineer_magnetic_crush",
+            "itemId": "119215",
+            "name": "Robo-Gnomebulator"
+          }
+        ],
+        "name": "Collect"
+      }
+    ]
+  },
+  {
+    "id": "eafdc953",
+    "items": [],
+    "name": "Legion",
+    "subcats": [
+      {
+        "id": "3d583414",
+        "items": [
+          {
+            "icon": "inv_misc_herb_felblossom",
+            "itemId": "139773",
+            "name": "Emerald Winds"
+          },
+          {
+            "icon": "inv_misc_horn_01",
+            "itemId": "143660",
+            "name": "Mrgrglhjorn"
+          },
+          {
+            "icon": "inv_misc_cat_trinket06",
+            "itemId": "156833",
+            "name": "Katy's Stampwhistle"
+          }
+        ],
+        "name": "Achievements"
+      },
+      {
+        "id": "00dec590",
+        "items": [
+          {
+            "icon": "achievement_guildperk_everyones-a-hero",
+            "itemId": "143727",
+            "name": "Champion's Salute"
+          },
+          {
+            "allowableClasses": [
+              7
+            ],
+            "icon": "ability_shaman_watershield",
+            "itemId": "138490",
+            "name": "Waterspeaker's Totem"
+          },
+          {
+            "allowableClasses": [
+              7
+            ],
+            "icon": "inv_waepon_bow_zulgrub_d_01",
+            "itemId": "136937",
+            "name": "Vol'jin's Serpent Totem"
+          },
+          {
+            "allowableClasses": [
+              7
+            ],
+            "icon": "inv_wand_22",
+            "itemId": "136935",
+            "name": "Tadpole Cloudseeder"
+          },
+          {
+            "allowableClasses": [
+              7
+            ],
+            "icon": "inv_pet_scorchedstone",
+            "itemId": "136934",
+            "name": "Raging Elemental Stone"
+          },
+          {
+            "allowableClasses": [
+              7
+            ],
+            "icon": "ability_shaman_echooftheelements",
+            "itemId": "140632",
+            "name": "Lava Fountain"
+          },
+          {
+            "allowableClasses": [
+              5
+            ],
+            "icon": "spell_holy_dizzy",
+            "itemId": "136928",
+            "name": "Thaumaturgist's Orb"
+          },
+          {
+            "allowableClasses": [
+              5
+            ],
+            "icon": "ability_priest_bindingprayers",
+            "itemId": "136927",
+            "name": "Scarlet Confessional Book"
+          },
+          {
+            "allowableClasses": [
+              4
+            ],
+            "icon": "inv_crate_01",
+            "itemId": "139587",
+            "name": "Suspicious Crate"
+          },
+          {
+            "allowableClasses": [
+              4
+            ],
+            "icon": "inv_cask_03",
+            "itemId": "151877",
+            "name": "Barrel of Eyepatches"
+          },
+          {
+            "allowableClasses": [
+              1
+            ],
+            "icon": "inv_misc_horn_05",
+            "itemId": "140160",
+            "name": "Stormforged Vrykul Horn"
+          },
+          {
+            "allowableClasses": [
+              11
+            ],
+            "icon": "ability_druid_manatree",
+            "itemId": "136849",
+            "name": "Nature's Beacon"
+          },
+          {
+            "allowableClasses": [
+              8
+            ],
+            "icon": "creatureportrait_nexus_floating_disc",
+            "itemId": "147832",
+            "name": "Magical Saucer"
+          },
+          {
+            "allowableClasses": [
+              8
+            ],
+            "icon": "inv_helmet_120",
+            "itemId": "147838",
+            "name": "Akazamzarak's Spare Hat"
+          },
+          {
+            "allowableClasses": [
+              8
+            ],
+            "icon": "inv_misc_enchantedpearl",
+            "itemId": "136846",
+            "name": "Familiar Stone"
+          },
+          {
+            "allowableClasses": [
+              3
+            ],
+            "icon": "ability_hunter_bestialdiscipline",
+            "itemId": "136855",
+            "name": "Hunter's Call"
+          },
+          {
+            "allowableClasses": [
+              12
+            ],
+            "icon": "ability_demonhunter_chaosstrike",
+            "itemId": "147537",
+            "name": "A Tiny Set of Warglaives"
+          }
+        ],
+        "name": "Order Hall"
+      },
+      {
+        "id": "80555f20",
+        "items": [
+          {
+            "icon": "ability_shaman_multitotemactivation",
+            "itemId": "152556",
+            "name": "Trawler Totem"
+          },
+          {
+            "icon": "spell_shaman_totemrecall",
+            "itemId": "147310",
+            "name": "Floating Totem"
+          },
+          {
+            "icon": "creatureportrait_darkshoreboat",
+            "itemId": "147311",
+            "name": "Replica Gondola"
+          },
+          {
+            "icon": "ability_druid_improvedtreeform",
+            "itemId": "147309",
+            "name": "Face of the Forest"
+          },
+          {
+            "icon": "achievement_character_nightelf_female",
+            "itemId": "147308",
+            "name": "Enchanted Bobber"
+          },
+          {
+            "icon": "ability_warlock_demonicempowerment",
+            "itemId": "147312",
+            "name": "Demon Noggin"
+          },
+          {
+            "icon": "ability_hunter_murderofcrows",
+            "itemId": "152574",
+            "name": "Corbyn's Beacon"
+          },
+          {
+            "icon": "inv_helm_plate_pvppaladin_c_01",
+            "itemId": "147307",
+            "name": "Carved Wooden Helm"
+          }
+        ],
+        "name": "Fisherfriends"
+      },
+      {
+        "id": "5ccacd12",
+        "items": [
+          {
+            "icon": "inv_misc_emberweavecloth",
+            "itemId": "130169",
+            "name": "Tournament Favor"
+          },
+          {
+            "icon": "inv_misc_gem_crystal_02",
+            "itemId": "129165",
+            "name": "Barnacle-Encrusted Gem"
+          }
+        ],
+        "name": "Missions"
+      },
+      {
+        "id": "d7104590",
+        "items": [
+          {
+            "icon": "inv_stone_grindingstone_04",
+            "itemId": "138876",
+            "name": "Runas' Crystal Grinder"
+          },
+          {
+            "icon": "trade_archaeology_antleredcloakclasp",
+            "itemId": "129093",
+            "name": "Ravenbear Disguise",
+            "side": "H"
+          },
+          {
+            "icon": "inv_helm_cloth_witchhat_b_01",
+            "itemId": "138873",
+            "name": "Mystical Frosh Hat"
+          },
+          {
+            "icon": "inv_misc_note_01",
+            "itemId": "138878",
+            "name": "Copy of Daglop's Contract"
+          },
+          {
+            "icon": "inv_weapon_rifle_41",
+            "itemId": "131933",
+            "name": "Critter Hand Cannon"
+          },
+          {
+            "icon": "inv_pet_bluemurlocegg",
+            "itemId": "141879",
+            "name": "Berglrgl Perrgl Girggrlf"
+          },
+          {
+            "icon": "garrison_bronzechest",
+            "itemId": "130209",
+            "name": "Never Ending Toy Chest"
+          },
+          {
+            "icon": "inv_misc_bag_07",
+            "itemId": "142497",
+            "name": "Tiny Pack"
+          },
+          {
+            "icon": "inv_misc_flower_04",
+            "itemId": "142494",
+            "name": "Purple Blossom"
+          },
+          {
+            "icon": "inv_misc_bone_06",
+            "itemId": "142495",
+            "name": "Fake Teeth"
+          },
+          {
+            "icon": "inv_misc_1h_pa_spoon_a_01",
+            "itemId": "142496",
+            "name": "Dirty Spoon"
+          }
+        ],
+        "name": "Quest"
+      },
+      {
+        "id": "c8a37c8f",
+        "items": [
+          {
+            "icon": "inv_misc_discoball_01",
+            "itemId": "143534",
+            "name": "Wand of Simulated Life"
+          },
+          {
+            "icon": "inv_box_04",
+            "itemId": "129055",
+            "name": "Shoe Shine Kit"
+          },
+          {
+            "icon": "inv_misc_book_09",
+            "itemId": "122681",
+            "name": "Sternfathom's Pet Journal"
+          },
+          {
+            "icon": "inv_misc_herb_goldthorn_bramble",
+            "itemId": "130147",
+            "name": "Thistleleaf Branch"
+          },
+          {
+            "icon": "ability_mount_pandarenkitemount",
+            "itemId": "131811",
+            "name": "Rocfeather Skyhorn Kite"
+          },
+          {
+            "icon": "inv_misc_enggizmos_16",
+            "itemId": "147867",
+            "name": "Pilfered Sweeper"
+          }
+        ],
+        "name": "Treasure"
+      },
+      {
+        "id": "7af98bd8",
+        "items": [
+          {
+            "icon": "inv_misc_toy_01",
+            "itemId": "130214",
+            "name": "Worn Doll"
+          },
+          {
+            "icon": "archaeology_5_0_carvedbronzemirror",
+            "itemId": "130171",
+            "name": "Cursed Orb"
+          },
+          {
+            "icon": "ability_warstomp",
+            "itemId": "131900",
+            "name": "Majestic Elderhorn Hoof"
+          },
+          {
+            "icon": "inv_misc_beer_01",
+            "itemId": "129113",
+            "name": "Faintly Glowing Flagon of Mead"
+          },
+          {
+            "icon": "inv_knife_1h_saurok_01",
+            "itemId": "140314",
+            "name": "Crab Shank"
+          },
+          {
+            "icon": "inv_potion_22",
+            "itemId": "141331",
+            "name": "Vial of Green Goo"
+          },
+          {
+            "icon": "inv_misc_enggizmos_07",
+            "itemId": "142265",
+            "name": "Big Red Raygun"
+          },
+          {
+            "icon": "inv_plate_belt_eredarargus_d_01",
+            "itemId": "153124",
+            "name": "Spire of Spite"
+          },
+          {
+            "icon": "sha_ability_rogue_bloodyeye_nightborne",
+            "itemId": "153293",
+            "name": "Sightless Eye"
+          },
+          {
+            "icon": "spell_fire_felpyroblast",
+            "itemId": "153126",
+            "name": "Micro-Artillery Controller"
+          },
+          {
+            "icon": "ability_felarakkoa_feldetonation_green",
+            "itemId": "153253",
+            "name": "S.F.E. Interceptor"
+          },
+          {
+            "icon": "inv_icon_shadowcouncilorb_green",
+            "itemId": "153194",
+            "name": "Legion Communication Orb"
+          },
+          {
+            "icon": "inv_inscription_runescrolloffortitude_yellow",
+            "itemId": "153180",
+            "name": "Yellow Conservatory Scroll"
+          },
+          {
+            "icon": "inv_inscription_runescrolloffortitude_red",
+            "itemId": "153181",
+            "name": "Red Conservatory Scroll"
+          },
+          {
+            "icon": "inv_inscription_runescrolloffortitude_blue",
+            "itemId": "153179",
+            "name": "Blue Conservatory Scroll"
+          },
+          {
+            "icon": "inv_misc_foot_centaur",
+            "itemId": "153193",
+            "name": "Baarut the Brisk"
+          },
+          {
+            "icon": "spell_fire_twilightfireward",
+            "itemId": "153183",
+            "name": "Barrier Generator"
+          },
+          {
+            "icon": "inv_helmet_44",
+            "itemId": "134831",
+            "name": "Doomsayer's Robes"
+          },
+          {
+            "icon": "ability_bossfellord_felfissure",
+            "itemId": "140363",
+            "name": "Pocket Fel Spreader"
+          }
+        ],
+        "name": "Rare"
+      },
+      {
+        "id": "4e8c67af",
+        "items": [
+          {
+            "icon": "inv_misc_map09",
+            "itemId": "150744",
+            "name": "Walking Kalimdor with the Earthmother",
+            "side": "H"
+          },
+          {
+            "icon": "inv_misc_map09",
+            "itemId": "150743",
+            "name": "Surviving Kalimdor",
+            "side": "A"
+          },
+          {
+            "icon": "icon_treasuremap",
+            "itemId": "150745",
+            "name": "The Azeroth Campaign",
+            "side": "H"
+          },
+          {
+            "icon": "icon_treasuremap",
+            "itemId": "150746",
+            "name": "To Modernize the Provisioning of Azeroth",
+            "side": "A"
+          },
+          {
+            "icon": "inv_7_0raid_trinket_010a",
+            "itemId": "140231",
+            "name": "Narcissa's Mirror"
+          },
+          {
+            "icon": "inv_offhand_ulduarraid_d_03",
+            "itemId": "141862",
+            "name": "Mote of Light"
+          },
+          {
+            "icon": "ability_warrior_criticalblock",
+            "itemId": "129057",
+            "name": "Dalaran Disc"
+          },
+          {
+            "icon": "inv_trinket_naxxramas02",
+            "itemId": "137294",
+            "name": "Dalaran Initiates' Pin"
+          },
+          {
+            "icon": "inv_misc_bandage_16",
+            "itemId": "44820",
+            "name": "Red Ribbon Pet Leash"
+          },
+          {
+            "icon": "inv_enchant_prismaticsphere",
+            "itemId": "140309",
+            "name": "Prismatic Bauble"
+          },
+          {
+            "icon": "misc_drogbartotem02",
+            "itemId": "140336",
+            "name": "Brulfist Idol"
+          },
+          {
+            "icon": "inv_misc_food_lunchbox_devilsaur",
+            "itemId": "130151",
+            "name": "The 'Devilsaur' Lunchbox"
+          },
+          {
+            "icon": "trade_alchemy_dpotion_a24",
+            "itemId": "142452",
+            "name": "Lingering Wyrmtongue Essence"
+          },
+          {
+            "icon": "inv_pet_inquisitoreye",
+            "itemId": "153204",
+            "name": "All-Seer's Eye"
+          }
+        ],
+        "name": "Vendor"
+      },
+      {
+        "id": "4d739f21",
+        "items": [
+          {
+            "icon": "inv_misc_treasurechest05d",
+            "itemId": "152982",
+            "name": "Vixx's Chest of Tricks"
+          },
+          {
+            "icon": "spell_priest_void-blast",
+            "itemId": "153004",
+            "name": "Unstable Portal Emitter"
+          }
+        ],
+        "name": "Dungeon"
+      },
+      {
+        "id": "f74583f5",
+        "items": [
+          {
+            "allowableClasses": [
+              12
+            ],
+            "icon": "inv_helm_laughingskull_01",
+            "itemId": "143544",
+            "name": "Skull of Corruption"
+          },
+          {
+            "icon": "item_hearthstone_card_purple",
+            "itemId": "119211",
+            "name": "Golden Hearthstone Card: Lord Jaraxxus"
+          },
+          {
+            "icon": "ability_mage_massinvisibility",
+            "itemId": "142536",
+            "name": "Memory Cube"
+          }
+        ],
+        "name": "Raid"
+      },
+      {
+        "id": "f28f9043",
+        "items": [
+          {
+            "icon": "garrison_silverchest",
+            "itemId": "130191",
+            "name": "Trapped Treasure Chest Kit"
+          },
+          {
+            "icon": "inv_rod_titanium",
+            "itemId": "130157",
+            "name": "Syxsehnz Rod"
+          },
+          {
+            "icon": "inv_rod_enchantedadamantite",
+            "itemId": "129279",
+            "name": "Enchanted Stone Whistle"
+          },
+          {
+            "icon": "inv_holiday_summerfest_petals",
+            "itemId": "130158",
+            "name": "Path of Elothir"
+          },
+          {
+            "icon": "inv_misc_gem_pearl_13",
+            "itemId": "130170",
+            "name": "Tear of the Green Aspect"
+          },
+          {
+            "icon": "inv_misc_petmoonkinta",
+            "itemId": "130232",
+            "name": "Moonfeather Statue"
+          },
+          {
+            "icon": "inv_misc_fish_42",
+            "itemId": "131814",
+            "name": "Whitewater Carp"
+          },
+          {
+            "icon": "inv_datacrystal12",
+            "itemId": "131812",
+            "name": "Darkshard Fragment"
+          },
+          {
+            "icon": "trade_archaeology_vrykul_runestick",
+            "itemId": "129367",
+            "name": "Vrykul Toy Boat Kit"
+          },
+          {
+            "icon": "inv_crystallized_water",
+            "itemId": "129149",
+            "name": "Death's Door Charm"
+          },
+          {
+            "icon": "inv_rod_titanium",
+            "itemId": "140324",
+            "name": "Mobile Telemancy Beacon"
+          },
+          {
+            "icon": "inv_helm_mask_fittedalpha_b_01_nightborne_01",
+            "itemId": "140325",
+            "name": "Home Made Party Mask"
+          },
+          {
+            "icon": "spell_warlock_demonicportal_green",
+            "itemId": "130199",
+            "name": "Legion Pocket Portal"
+          },
+          {
+            "icon": "ability_felarakkoa_focusedblast",
+            "itemId": "147708",
+            "name": "Legion Invasion Simulator"
+          },
+          {
+            "icon": "oshugun_crystalfragments",
+            "itemId": "153039",
+            "name": "Crystalline Campfire"
+          }
+        ],
+        "name": "Reputation"
+      },
+      {
+        "id": "67341afe",
+        "items": [
+          {
+            "icon": "inv_tabard_a_86warden",
+            "itemId": "147843",
+            "name": "Sira's Extra Cloak"
+          },
+          {
+            "icon": "paladin_holy",
+            "itemId": "153182",
+            "name": "Holy Lightsphere"
+          }
+        ],
+        "name": "Paragon Reputation"
+      },
+      {
+        "id": "6c5b8038",
+        "items": [
+          {
+            "icon": "trade_alchemy_potione2",
+            "itemId": "141306",
+            "name": "Wisp in a Bottle"
+          },
+          {
+            "icon": "inv_misc_enggizmos_18",
+            "itemId": "141301",
+            "name": "Unstable Powder Box"
+          },
+          {
+            "icon": "inv_fishing_innards_eggs",
+            "itemId": "140786",
+            "name": "Ley Spider Eggs"
+          },
+          {
+            "icon": "inv_misc_cat_trinket09",
+            "itemId": "140780",
+            "name": "Fal'dorei Egg"
+          },
+          {
+            "icon": "inv_enchant_philostone_lv2",
+            "itemId": "141298",
+            "name": "Displacer Meditation Stone"
+          },
+          {
+            "icon": "ability_shaman_fortifyingwaters",
+            "itemId": "141297",
+            "name": "Arcano-Shower"
+          },
+          {
+            "icon": "inv_drink_27_bluesoup",
+            "itemId": "141296",
+            "name": "Ancient Mana Basin"
+          },
+          {
+            "icon": "ability_malkorok_blightofyshaarj_yellow",
+            "itemId": "141299",
+            "name": "Kal'dorei Light Globe"
+          }
+        ],
+        "name": "Falanaar"
+      }
+    ]
+  },
+  {
+    "id": "68b5472f",
+    "items": [],
+    "name": "Draenor",
+    "subcats": [
+      {
+        "id": "a54a5fe4",
+        "items": [
+          {
+            "icon": "inv_cask_02",
+            "itemId": "119001",
+            "name": "Mystery Keg"
+          },
+          {
+            "icon": "trade_archaeology_dignified-draenei-portrait",
+            "itemId": "119144",
+            "name": "Touch of the Naaru",
+            "side": "A"
+          },
+          {
+            "icon": "spell_fel_incinerate",
+            "itemId": "119134",
+            "name": "Sargerei Disguise"
+          },
+          {
+            "icon": "inv_misc_-selfiecamera_01",
+            "itemId": "122674",
+            "name": "S.E.L.F.I.E. Camera MkII"
+          },
+          {
+            "icon": "spell_frost_fireresistancetotem",
+            "itemId": "119145",
+            "name": "Firefury Totem",
+            "side": "H"
+          },
+          {
+            "icon": "inv_jewelry_necklace_103",
+            "itemId": "115503",
+            "name": "Blazing Diamond Pendant",
+            "side": "H"
+          }
+        ],
+        "name": "Quest"
+      },
+      {
+        "id": "57823347",
+        "items": [
+          {
+            "icon": "spell_nature_invisibilitytotem",
+            "itemId": "119160",
+            "name": "Tickle Totem",
+            "side": "H"
+          },
+          {
+            "icon": "inv_datacrystal01",
+            "itemId": "119182",
+            "name": "Soul Evacuation Crystal",
+            "side": "A"
+          },
+          {
+            "icon": "trade_archaeology_draenei_artifactfragment",
+            "itemId": "119421",
+            "name": "Sha'tari Defender's Medallion",
+            "side": "A"
+          },
+          {
+            "icon": "spell_frost_frost",
+            "itemId": "115468",
+            "name": "Permanent Frost Essence",
+            "side": "H"
+          },
+          {
+            "icon": "creatureportrait_bubble",
+            "itemId": "115472",
+            "name": "Permanent Time Bubble",
+            "side": "A"
+          },
+          {
+            "icon": "inv_chest_cloth_draenei_c_01",
+            "itemId": "128462",
+            "name": "Karabor Councilor's Attire",
+            "side": "A"
+          },
+          {
+            "icon": "inv_frostwolfpup",
+            "itemId": "128471",
+            "name": "Frostwolf Grunt's Battlegear",
+            "side": "H"
+          },
+          {
+            "icon": "inv_jewelry_necklace_109",
+            "itemId": "122283",
+            "name": "Rukhmar's Sacred Memory"
+          }
+        ],
+        "name": "Reputation"
+      },
+      {
+        "id": "55d9f63f",
+        "items": [
+          {
+            "icon": "inv_staff_45",
+            "itemId": "118191",
+            "name": "Archmage Vargoth's Spare Staff"
+          },
+          {
+            "icon": "inv_sword_2h_pvpcataclysms3_c_01",
+            "itemId": "128310",
+            "name": "Burning Blade (toy)"
+          },
+          {
+            "icon": "item_hearthstone_card",
+            "itemId": "118427",
+            "name": "Autographed Hearthstone Card"
+          }
+        ],
+        "name": "Mission"
+      },
+      {
+        "id": "83e29cf8",
+        "items": [
+          {
+            "icon": "item_hearthstone_card",
+            "itemId": "119212",
+            "name": "Winning Hand"
+          },
+          {
+            "icon": "inv_misc_tolbaradsearchlight",
+            "itemId": "127864",
+            "name": "Personal Spotlight"
+          },
+          {
+            "icon": "inv_misc_coin_12",
+            "itemId": "127707",
+            "name": "Indestructible Bone"
+          },
+          {
+            "icon": "inv_misc_stonetablet_03",
+            "itemId": "119210",
+            "name": "Hearthstone Board"
+          },
+          {
+            "icon": "spell_mage_temporalshield",
+            "itemId": "127696",
+            "name": "Magic Pet Mirror"
+          },
+          {
+            "icon": "inv_wand_16",
+            "itemId": "127695",
+            "name": "Spirit Wand"
+          },
+          {
+            "icon": "ability_druid_disembowel",
+            "itemId": "113096",
+            "name": "Bloodmane Charm"
+          },
+          {
+            "icon": "inv_misc_bag_09_black",
+            "itemId": "128328",
+            "name": "Skoller's Bag of Squirrel Treats"
+          }
+        ],
+        "name": "Vendor"
+      },
+      {
+        "id": "95bf5c7b",
+        "items": [
+          {
+            "icon": "inv_gizmo_goblinboombox_01",
+            "itemId": "122700",
+            "name": "Portable Audiophone"
+          },
+          {
+            "icon": "ability_siege_engineer_magnetic_lasso",
+            "itemId": "122298",
+            "name": "Bodyguard Miniaturization Device"
+          },
+          {
+            "icon": "inv_banner_03",
+            "itemId": "119217",
+            "name": "Alliance Flag of Victory",
+            "side": "A"
+          },
+          {
+            "icon": "inv_banner_03",
+            "itemId": "119218",
+            "name": "Horde Flag of Victory",
+            "side": "H"
+          },
+          {
+            "icon": "inv_banner_03",
+            "itemId": "119219",
+            "name": "Warlord's Flag of Victory"
+          },
+          {
+            "icon": "ability_rogue_disguise",
+            "itemId": "115506",
+            "name": "Treessassin's Guise"
+          },
+          {
+            "icon": "ability_priest_angelicfeather",
+            "itemId": "119093",
+            "name": "Aviana's Feather"
+          },
+          {
+            "icon": "inv_misc_pelt_15",
+            "itemId": "118937",
+            "name": "Gamon's Braid"
+          },
+          {
+            "icon": "spell_nature_groundingtotem",
+            "itemId": "119003",
+            "name": "Void Totem"
+          },
+          {
+            "icon": "spell_nature_resistnature",
+            "itemId": "118935",
+            "name": "Ever-Blooming Frond"
+          },
+          {
+            "icon": "inv_misc_basket_02",
+            "itemId": "119083",
+            "name": "Fruit Basket"
+          },
+          {
+            "icon": "inv_misc_cat_trinket05",
+            "itemId": "118938",
+            "name": "Manastorm's Duplicator"
+          },
+          {
+            "icon": "inv_potion_86",
+            "itemId": "119092",
+            "name": "Moroes' Famous Polish"
+          },
+          {
+            "icon": "trade_archaeology_orc_bloodtext",
+            "itemId": "119039",
+            "name": "Lilian's Warning Sign"
+          },
+          {
+            "icon": "inv_summerfest_firespirit",
+            "itemId": "117573",
+            "name": "Wayfarer's Bonfire"
+          }
+        ],
+        "name": "Garrison"
+      },
+      {
+        "id": "13bcded2",
+        "items": [
+          {
+            "icon": "inv_misc_legarmorkit",
+            "itemId": "113375",
+            "name": "Vindicator's Armor Polish Kit"
+          },
+          {
+            "icon": "spell_nature_insect_swarm2",
+            "itemId": "117550",
+            "name": "Angry Beehive"
+          },
+          {
+            "icon": "spell_arcane_starfire",
+            "itemId": "109739",
+            "name": "Star Chart"
+          },
+          {
+            "icon": "inv_misc_gem_pearl_08",
+            "itemId": "108739",
+            "name": "Pretty Draenor Pearl"
+          },
+          {
+            "icon": "inv_misc_horn_01",
+            "itemId": "108735",
+            "name": "Arena Master's War Horn"
+          },
+          {
+            "icon": "inv_misc_stonetablet_06",
+            "itemId": "118716",
+            "name": "Goren Garb"
+          },
+          {
+            "icon": "inv_misc_monsterspidercarapace_01",
+            "itemId": "117569",
+            "name": "Giant Deathweb Egg"
+          },
+          {
+            "icon": "inv_boots_mail_pvpshaman_e_01",
+            "itemId": "108743",
+            "name": "Deceptia's Smoldering Boots"
+          },
+          {
+            "icon": "inv_misc_food_115_condorsoup",
+            "itemId": "116120",
+            "name": "Tasty Talador Lunch"
+          },
+          {
+            "icon": "inv_podling_red",
+            "itemId": "127394",
+            "name": "Podling Camouflage"
+          },
+          {
+            "icon": "inv_tradeskillitem_sorcerersfire",
+            "itemId": "127668",
+            "name": "Jewel of Hellfire"
+          },
+          {
+            "icon": "inv_wand_21",
+            "itemId": "127859",
+            "name": "Dazzling Rod"
+          },
+          {
+            "icon": "ability_warlock_ancientgrimoire",
+            "itemId": "127670",
+            "name": "Accursed Tome of the Sargerei"
+          },
+          {
+            "icon": "ability_vehicle_plaguebarrel",
+            "itemId": "128223",
+            "name": "Bottomless Stygana Mushroom Brew"
+          },
+          {
+            "icon": "inv_misc_bone_orcskull_01",
+            "itemId": "127669",
+            "name": "Skull of the Mad Chief"
+          },
+          {
+            "icon": "inv_misc_herb_felblossom",
+            "itemId": "127766",
+            "name": "The Perfect Blossom"
+          },
+          {
+            "icon": "ability_deathwing_bloodcorruption_earth",
+            "itemId": "127709",
+            "name": "Throbbing Blood Orb"
+          }
+        ],
+        "name": "Treasure"
+      },
+      {
+        "id": "b69b5a54",
+        "items": [
+          {
+            "icon": "inv_misc_foot_centaur",
+            "itemId": "113543",
+            "name": "Spirit of Shinri"
+          },
+          {
+            "icon": "inv_elemental_mote_air01",
+            "itemId": "113542",
+            "name": "Whispers of Rai'Vosh"
+          },
+          {
+            "icon": "inv_helmet_goggles_pandariatradeskill_d_01",
+            "itemId": "113631",
+            "name": "Hypnosis Goggles"
+          },
+          {
+            "icon": "ability_druid_cyclone",
+            "itemId": "119178",
+            "name": "Black Whirlwind"
+          },
+          {
+            "icon": "ability_druid_manatree",
+            "itemId": "113570",
+            "name": "Ancient's Bloom"
+          },
+          {
+            "icon": "creature_sporemushroom",
+            "itemId": "113540",
+            "name": "Ba'ruun's Bountiful Bloom"
+          },
+          {
+            "icon": "spell_frost_wisp",
+            "itemId": "111476",
+            "name": "Stolen Breath"
+          },
+          {
+            "icon": "inv_misc_leather_shellfragment",
+            "itemId": "119180",
+            "name": "Goren 'Log' Roller"
+          },
+          {
+            "icon": "warlock_spelldrain",
+            "itemId": "119163",
+            "name": "Soul Inhaler"
+          },
+          {
+            "icon": "ability_druid_forceofnature",
+            "itemId": "118222",
+            "name": "Spirit of Bashiok"
+          },
+          {
+            "icon": "creatureportrait_altarofearth_01",
+            "itemId": "118221",
+            "name": "Petrification Stone"
+          },
+          {
+            "icon": "inv_wand_05",
+            "itemId": "114227",
+            "name": "Bubble Wand"
+          },
+          {
+            "icon": "achievement_dungeon_everbloom",
+            "itemId": "119432",
+            "name": "Botani Camouflage"
+          },
+          {
+            "icon": "inv_cask_02",
+            "itemId": "118224",
+            "name": "Ogre Brewing Kit"
+          },
+          {
+            "icon": "achievement_boss_murmur",
+            "itemId": "113670",
+            "name": "Mournful Moan of Murmur"
+          },
+          {
+            "icon": "ability_druid_manatree",
+            "itemId": "116125",
+            "name": "Klikixx's Webspinner"
+          },
+          {
+            "icon": "ability_druid_galewinds",
+            "itemId": "116113",
+            "name": "Breath of Talador"
+          },
+          {
+            "icon": "creatureportrait_illidancrystal01",
+            "itemId": "116122",
+            "name": "Burning Legion Missive (toy)"
+          },
+          {
+            "icon": "inv_misc_trinket6oih_wolf1",
+            "itemId": "120276",
+            "name": "Outrider's Bridle Chain"
+          },
+          {
+            "icon": "inv_helmet_66",
+            "itemId": "118244",
+            "name": "Iron Buccaneer's Hat"
+          },
+          {
+            "icon": "inv_helmet_66",
+            "itemId": "127659",
+            "name": "Ghostly Iron Buccaneer's Hat"
+          },
+          {
+            "icon": "spell_fire_felfire",
+            "itemId": "127652",
+            "name": "Felflame Campfire"
+          },
+          {
+            "icon": "inv_misc_ancientarrakoafeather",
+            "itemId": "122117",
+            "name": "Cursed Feather of Ikzan"
+          },
+          {
+            "icon": "spell_shadow_summonimp",
+            "itemId": "127655",
+            "name": "Sassy Imp"
+          },
+          {
+            "icon": "ability_garrosh_siege_engine",
+            "itemId": "108631",
+            "name": "Crashin' Thrashin' Roller Controller"
+          },
+          {
+            "icon": "ability_ironmaidens_incindiarydevice",
+            "itemId": "108634",
+            "name": "Crashin' Thrashin' Mortar Controller"
+          },
+          {
+            "icon": "ability_ironmaidens_bombardment",
+            "itemId": "108633",
+            "name": "Crashin' Thrashin' Cannon Controller"
+          },
+          {
+            "icon": "inv_potion_52",
+            "itemId": "127666",
+            "name": "Vial of Red Goo"
+          }
+        ],
+        "name": "Rare"
+      },
+      {
+        "id": "93e6ce5d",
+        "items": [
+          {
+            "icon": "icon_orangebird_toy",
+            "itemId": "122293",
+            "name": "Trans-Dimensional Bird Whistle"
+          }
+        ],
+        "name": "Achievement"
+      }
+    ]
+  },
+  {
+    "id": "8338119e",
+    "items": [],
+    "name": "Mists of Pandaria",
+    "subcats": [
+      {
+        "id": "61218b17",
+        "items": [
+          {
+            "icon": "inv_elemental_mote_air01",
+            "itemId": "88381",
+            "name": "Silversage Incense"
+          },
+          {
+            "icon": "inv_drink_04",
+            "itemId": "88531",
+            "name": "Lao Chin's Last Mug"
+          },
+          {
+            "icon": "inv_cask_04",
+            "itemId": "88579",
+            "name": "Jin Warmkeg's Brew"
+          },
+          {
+            "icon": "spell_totem_wardofdraining",
+            "itemId": "88385",
+            "name": "Hozen Idol"
+          },
+          {
+            "icon": "spell_shaman_totemrecall",
+            "itemId": "88584",
+            "name": "Totem of Harmony"
+          },
+          {
+            "icon": "inv_chest_leather_04",
+            "itemId": "82467",
+            "name": "Ruthers' Harness"
+          },
+          {
+            "icon": "inv_torch_lit",
+            "itemId": "88589",
+            "name": "Cremating Torch"
+          },
+          {
+            "icon": "achievement_reputation_kirintor_offensive",
+            "itemId": "95567",
+            "name": "Kirin Tor Beacon",
+            "side": "A"
+          },
+          {
+            "icon": "achievement_faction_sunreaveronslaught",
+            "itemId": "95568",
+            "name": "Sunreaver Beacon",
+            "side": "H"
+          },
+          {
+            "icon": "inv_misc_food_41",
+            "itemId": "88377",
+            "name": "Turnip Paint 'Gun'"
+          },
+          {
+            "icon": "inv_jewelcrafting_goldenhare",
+            "itemId": "88370",
+            "name": "Puntable Marmot"
+          },
+          {
+            "icon": "inv_misc_food_56",
+            "itemId": "88375",
+            "name": "Turnip Punching Bag"
+          },
+          {
+            "icon": "inv_misc_food_24",
+            "itemId": "80822",
+            "name": "The Golden Banana"
+          },
+          {
+            "icon": "inv_drink_17",
+            "itemId": "88387",
+            "name": "Shushen's Spittoon"
+          },
+          {
+            "icon": "inv_mask_01",
+            "itemId": "88580",
+            "name": "Ken-Ken's Mask"
+          },
+          {
+            "icon": "inv_misc_abyssalclam",
+            "itemId": "88417",
+            "name": "Gokk'lok's Shell"
+          }
+        ],
+        "name": "Quest"
+      },
+      {
+        "id": "cc677be7",
+        "items": [
+          {
+            "icon": "trade_archaeology_troll_voodoodoll",
+            "itemId": "89869",
+            "name": "Pandaren Scarecrow"
+          },
+          {
+            "icon": "inv_weapon_shortblade_37",
+            "itemId": "90175",
+            "name": "Gin-Ji Knife Set"
+          },
+          {
+            "icon": "ability_monk_surgingmist",
+            "itemId": "89222",
+            "name": "Cloud Ring"
+          },
+          {
+            "icon": "achievement_faction_sunreaveronslaught",
+            "itemId": "95590",
+            "name": "Glorious Standard of the Sunreaver Onslaught",
+            "side": "H"
+          },
+          {
+            "icon": "achievement_reputation_kirintor_offensive",
+            "itemId": "95589",
+            "name": "Glorious Standard of the Kirin Tor Offensive",
+            "side": "A"
+          },
+          {
+            "icon": "inv_misc_trinketpanda_07",
+            "itemId": "103685",
+            "name": "Celestial Defender's Medallion"
+          }
+        ],
+        "name": "Reputation"
+      },
+      {
+        "id": "4e2b953c",
+        "items": [
+          {
+            "icon": "trade_archaeology_antleredcloakclasp",
+            "itemId": "91904",
+            "name": "Stackable Stag"
+          },
+          {
+            "icon": "inv_gizmo_goblingtonkcontroller",
+            "itemId": "88802",
+            "name": "Foxicopter Controller"
+          },
+          {
+            "icon": "ability_warrior_rampage",
+            "itemId": "88801",
+            "name": "Flippable Table"
+          },
+          {
+            "icon": "inv_offhand_1h_pvpcataclysms3_c_01",
+            "itemId": "102467",
+            "name": "Censer of Eternal Agony"
+          }
+        ],
+        "name": "Vendor"
+      },
+      {
+        "id": "29472edf",
+        "items": [
+          {
+            "icon": "inv_holiday_brewfestbuff_01",
+            "itemId": "87528",
+            "name": "Honorary Brewmaster Keg"
+          }
+        ],
+        "name": "Scenario"
+      },
+      {
+        "id": "27fc6bfc",
+        "items": [
+          {
+            "icon": "inv_misc_flute_01",
+            "itemId": "13379",
+            "name": "Piccolo of the Flaming Fire"
+          },
+          {
+            "icon": "inv_misc_bag_11",
+            "itemId": "88566",
+            "name": "Krastinov's Bag of Horrors"
+          }
+        ],
+        "name": "Dungeon"
+      },
+      {
+        "id": "0d723c48",
+        "items": [
+          {
+            "icon": "inv_weapon_rifle_33",
+            "itemId": "98132",
+            "name": "Shado-Pan Geyser Gun"
+          },
+          {
+            "icon": "inv_misc_shell_04",
+            "itemId": "98136",
+            "name": "Gastropod Shell"
+          }
+        ],
+        "name": "Raid"
+      },
+      {
+        "id": "b32ed347",
+        "items": [
+          {
+            "icon": "inv_stone_15",
+            "itemId": "86573",
+            "name": "Shard of Archstone"
+          },
+          {
+            "icon": "inv_shield_18",
+            "itemId": "86584",
+            "name": "Hardened Shell"
+          },
+          {
+            "icon": "inv_musket_04",
+            "itemId": "86588",
+            "name": "Pandaren Firework Launcher"
+          },
+          {
+            "icon": "inv_misc_coin_14",
+            "itemId": "86581",
+            "name": "Farwater Conch"
+          },
+          {
+            "icon": "inv_valentinescardtornright",
+            "itemId": "90067",
+            "name": "B. F. F. Necklace"
+          },
+          {
+            "icon": "inv_misc_throwingball_01",
+            "itemId": "86593",
+            "name": "Hozen Beach Ball"
+          },
+          {
+            "icon": "trade_archaeology_highbornesoulmirror",
+            "itemId": "86589",
+            "name": "Ai-Li's Skymirror"
+          },
+          {
+            "icon": "inv_jewelry_ring_39",
+            "itemId": "86578",
+            "name": "Eternal Warrior's Sigil"
+          },
+          {
+            "icon": "inv_banner_03",
+            "itemId": "86583",
+            "name": "Salyin Battle Banner"
+          },
+          {
+            "icon": "inv_offhand_pvealliance_d_01",
+            "itemId": "86575",
+            "name": "Chalice of Secrets"
+          },
+          {
+            "icon": "inv_qiraj_jewelglyphed",
+            "itemId": "86582",
+            "name": "Aqua Jewel"
+          },
+          {
+            "icon": "ability_druid_galewinds",
+            "itemId": "134023",
+            "name": "Bottled Tornado"
+          },
+          {
+            "icon": "inv_misc_volatileair",
+            "itemId": "86590",
+            "name": "Essence of the Breeze"
+          },
+          {
+            "icon": "ability_hunter_beastcall",
+            "itemId": "86594",
+            "name": "Helpful Wikky's Whistle"
+          },
+          {
+            "icon": "inv_misc_flute_01",
+            "itemId": "86586",
+            "name": "Panflute of Pandaria"
+          },
+          {
+            "icon": "inv_misc_cat_trinket10",
+            "itemId": "86568",
+            "name": "Mr. Smite's Brass Compass"
+          },
+          {
+            "icon": "inv_misc_stonetablet_04",
+            "itemId": "86571",
+            "name": "Kang's Bindstone"
+          },
+          {
+            "icon": "inv_misc_monsterhorn_02",
+            "itemId": "104329",
+            "name": "Ash-Covered Horn"
+          },
+          {
+            "icon": "inv_misc_horn_01",
+            "itemId": "86565",
+            "name": "Battle Horn"
+          },
+          {
+            "icon": "inv_knife_1h_grimbatolraid_d_03",
+            "itemId": "104302",
+            "name": "Blackflame Daggers"
+          },
+          {
+            "icon": "spell_warlock_soulburn",
+            "itemId": "104294",
+            "name": "Rime of the Time-Lost Mariner"
+          },
+          {
+            "icon": "inv_misc_enchantedpearld",
+            "itemId": "104262",
+            "name": "Odd Polished Stone"
+          },
+          {
+            "icon": "inv_summerfest_firedrink",
+            "itemId": "104309",
+            "name": "Eternal Kiln"
+          },
+          {
+            "icon": "trade_archaeology_vrykul_runestick",
+            "itemId": "104331",
+            "name": "Warning Sign"
+          }
+        ],
+        "name": "Rare"
+      },
+      {
+        "id": "5dbd69b7",
+        "items": [
+          {
+            "icon": "inv_helmet_49",
+            "itemId": "134024",
+            "name": "Cursed Swabby Helmet"
+          }
+        ],
+        "name": "Treasure"
+      },
+      {
+        "id": "f9885138",
+        "items": [
+          {
+            "icon": "inv_crate_02",
+            "itemId": "144072",
+            "name": "Adopted Puppy Crate"
+          },
+          {
+            "icon": "inv_misc_1h_bucket_c_01",
+            "itemId": "144393",
+            "name": "Portable Yak Wash"
+          }
+        ],
+        "name": "Timewalking"
+      }
+    ]
+  },
+  {
+    "id": "eaf843e2",
+    "items": [],
+    "name": "Cataclysm",
+    "subcats": [
+      {
+        "id": "9a7b6427",
+        "items": [
+          {
+            "icon": "inv_misc_tolbaradsearchlight",
+            "itemId": "64997",
+            "name": "Tol Barad Searchlight#Horde",
+            "side": "H"
+          },
+          {
+            "icon": "inv_misc_tolbaradsearchlight",
+            "itemId": "63141",
+            "name": "Tol Barad Searchlight",
+            "side": "A"
+          },
+          {
+            "icon": "inv_misc_necklace_firelands_2",
+            "itemId": "71259",
+            "name": "Leyara's Locket"
+          },
+          {
+            "icon": "inv_mushroom_05",
+            "itemId": "70161",
+            "name": "Mushroom Chair"
+          },
+          {
+            "icon": "inv_misc_flute_01",
+            "itemId": "70159",
+            "name": "Mylune's Call"
+          }
+        ],
+        "name": "Reputation"
+      },
+      {
+        "id": "904c30d3",
+        "items": [
+          {
+            "allowableClasses": [
+              11
+            ],
+            "icon": "inv_misc_bag_herbpouch",
+            "itemId": "122304",
+            "name": "Fandral's Seed Pouch"
+          }
+        ],
+        "name": "Raid"
+      },
+      {
+        "id": "65142e9b",
+        "items": [
+          {
+            "icon": "inv_helmet_66",
+            "itemId": "134022",
+            "name": "Burgy Blackheart's Handsome Hat"
+          }
+        ],
+        "name": "Rare"
+      },
+      {
+        "id": "0e758c11",
+        "items": [
+          {
+            "icon": "inv_helmet_170",
+            "itemId": "133542",
+            "name": "Tosselwrench's Mega-Accurate Simulation Viewfinder"
+          },
+          {
+            "icon": "inv_misc_enchantedpearlf",
+            "itemId": "133511",
+            "name": "Gurboggle's Gleaming Bauble"
+          }
+        ],
+        "name": "Timewalking"
+      }
+    ]
+  },
+  {
+    "id": "83edd0e1",
+    "items": [],
+    "name": "Wrath of the Lich King",
+    "subcats": [
+      {
+        "id": "fc1b841b",
+        "items": [
+          {
+            "icon": "inv_misc_book_11",
+            "itemId": "43824",
+            "name": "The Schools of Arcane Magic - Mastery"
+          }
+        ],
+        "name": "Achievement"
+      },
+      {
+        "id": "82ae2000",
+        "items": [
+          {
+            "icon": "inv_drink_01",
+            "itemId": "43499",
+            "name": "Iron Boot Flask"
+          }
+        ],
+        "name": "Vendor"
+      },
+      {
+        "id": "9dd84695",
+        "items": [
+          {
+            "icon": "inv_drink_04",
+            "itemId": "44719",
+            "name": "Frenzyheart Brew"
+          }
+        ],
+        "name": "Reputation"
+      },
+      {
+        "id": "7f2dc1de",
+        "items": [
+          {
+            "icon": "inv_misc_tournaments_banner_human",
+            "itemId": "45011",
+            "name": "Stormwind Banner",
+            "side": "A"
+          },
+          {
+            "icon": "inv_misc_tournaments_banner_dwarf",
+            "itemId": "45018",
+            "name": "Ironforge Banner",
+            "side": "A"
+          },
+          {
+            "icon": "inv_misc_tournaments_banner_gnome",
+            "itemId": "45019",
+            "name": "Gnomeregan Banner",
+            "side": "A"
+          },
+          {
+            "icon": "inv_misc_tournaments_banner_draenei",
+            "itemId": "45020",
+            "name": "Exodar Banner",
+            "side": "A"
+          },
+          {
+            "icon": "inv_misc_tournaments_banner_nightelf",
+            "itemId": "45021",
+            "name": "Darnassus Banner",
+            "side": "A"
+          },
+          {
+            "icon": "inv_misc_tournaments_banner_scourge",
+            "itemId": "45016",
+            "name": "Undercity Banner",
+            "side": "H"
+          },
+          {
+            "icon": "inv_misc_tournaments_banner_tauren",
+            "itemId": "45013",
+            "name": "Thunder Bluff Banner",
+            "side": "H"
+          },
+          {
+            "icon": "inv_misc_tournaments_banner_bloodelf",
+            "itemId": "45017",
+            "name": "Silvermoon City Banner",
+            "side": "H"
+          },
+          {
+            "icon": "inv_misc_tournaments_banner_troll",
+            "itemId": "45015",
+            "name": "Sen'jin Banner",
+            "side": "H"
+          },
+          {
+            "icon": "inv_misc_tournaments_banner_orc",
+            "itemId": "45014",
+            "name": "Orgrimmar Banner",
+            "side": "H"
+          },
+          {
+            "icon": "achievement_reputation_argentchampion",
+            "itemId": "46843",
+            "name": "Argent Crusader's Banner"
+          }
+        ],
+        "name": "Argent Tournament"
+      },
+      {
+        "id": "a21a12b2",
+        "items": [
+          {
+            "icon": "inv_misc_enggizmos_18",
+            "itemId": "52253",
+            "name": "Sylvanas' Music Box"
+          },
+          {
+            "icon": "spell_frost_frostward",
+            "itemId": "52201",
+            "name": "Muradin's Favor"
+          }
+        ],
+        "name": "Raid"
+      },
+      {
+        "id": "ca6a8f11",
+        "items": [
+          {
+            "icon": "inv_misc_orb_03",
+            "itemId": "37254",
+            "name": "Super Simian Sphere"
+          }
+        ],
+        "name": "World Drop"
+      },
+      {
+        "id": "691d3ec4",
+        "items": [
+          {
+            "icon": "inv_jewelry_trinket_04",
+            "itemId": "129938",
+            "name": "Will of Northrend"
+          },
+          {
+            "icon": "inv_gizmo_khoriumpowercore",
+            "itemId": "129952",
+            "name": "Hourglass of Eternity (toy)"
+          },
+          {
+            "icon": "ability_hunter_pet_wolf",
+            "itemId": "129965",
+            "name": "Grizzlesnout's Fang"
+          }
+        ],
+        "name": "Timewalking"
+      }
+    ]
+  },
+  {
+    "id": "dc9c771e",
+    "items": [],
+    "name": "The Burning Crusade",
+    "subcats": [
+      {
+        "id": "a04f9ee8",
+        "items": [
+          {
+            "icon": "inv_misc_cutgemnormal2",
+            "itemId": "134007",
+            "name": "Eternal Black Diamond Ring"
+          },
+          {
+            "icon": "inv_jewelry_ring_72",
+            "itemId": "134004",
+            "name": "Noble's Eternal Elementium Signet"
+          }
+        ],
+        "name": "Vendor"
+      },
+      {
+        "id": "75915685",
+        "items": [
+          {
+            "icon": "inv_battery_02",
+            "itemId": "30690",
+            "name": "Power Converter"
+          },
+          {
+            "icon": "inv_helmet_49",
+            "itemId": "134021",
+            "name": "X-52 Rocket Helmet"
+          }
+        ],
+        "name": "Quest"
+      },
+      {
+        "id": "b0d717db",
+        "items": [
+          {
+            "icon": "inv_qirajidol_war",
+            "itemId": "32782",
+            "name": "Time-Lost Figurine"
+          }
+        ],
+        "name": "Rare"
+      },
+      {
+        "id": "edab994e",
+        "items": [
+          {
+            "icon": "inv_helmet_50",
+            "itemId": "134019",
+            "name": "Don Carlos' Famous Hat"
+          },
+          {
+            "icon": "inv_misc_orb_02",
+            "itemId": "35275",
+            "name": "Orb of the Sin'dorei"
+          }
+        ],
+        "name": "Dungeon"
+      },
+      {
+        "id": "f33390b3",
+        "items": [
+          {
+            "icon": "spell_fire_felflamering",
+            "itemId": "151184",
+            "name": "Verdant Throwing Sphere"
+          },
+          {
+            "icon": "inv_misc_bone_orcskull_01",
+            "itemId": "151016",
+            "name": "Fractured Necrolyte Skull"
+          },
+          {
+            "icon": "trade_archaeology_highbornesoulmirror",
+            "itemId": "129929",
+            "name": "Ever-Shifting Mirror"
+          },
+          {
+            "icon": "achievement_reputation_ashtonguedeathsworn",
+            "itemId": "129926",
+            "name": "Mark of the Ashtongue"
+          }
+        ],
+        "name": "Timewalking"
+      }
+    ]
+  },
+  {
+    "id": "265d4351",
+    "items": [],
+    "name": "Classic",
+    "subcats": [
+      {
+        "id": "305ab753",
+        "items": [
+          {
+            "icon": "inv_misc_cutgemnormal2",
+            "itemId": "133997",
+            "name": "Black Ice"
+          },
+          {
+            "icon": "inv_misc_gem_variety_02",
+            "itemId": "133998",
+            "name": "Rainbow Generator"
+          },
+          {
+            "icon": "inv_helmet_29",
+            "itemId": "53057",
+            "side": "H",
+            "name": "Faded Wizard Hat"
+          }
+        ],
+        "name": "Quest"
+      },
+      {
+        "id": "0614794e",
+        "items": [
+          {
+            "icon": "inv_wand_01",
+            "itemId": "66888",
+            "name": "Stave of Fur and Claw"
+          }
+        ],
+        "name": "Reputation"
+      },
+      {
+        "id": "a7b3d242",
+        "items": [
+          {
+            "icon": "inv_misc_toy_03",
+            "itemId": "54437",
+            "name": "Tiny Green Ragdoll"
+          },
+          {
+            "icon": "inv_misc_toy_02",
+            "itemId": "54438",
+            "name": "Tiny Blue Ragdoll"
+          },
+          {
+            "icon": "inv_gizmo_goblingtonkcontroller",
+            "itemId": "54343",
+            "name": "Blue Crashin' Thrashin' Racer Controller"
+          },
+          {
+            "icon": "inv_misc_head_clockworkgnome_01",
+            "itemId": "45057",
+            "name": "Wind-Up Train Wrecker"
+          },
+          {
+            "icon": "inv_misc_toy_10",
+            "itemId": "44606",
+            "name": "Toy Train Set"
+          },
+          {
+            "icon": "inv_sword_139",
+            "itemId": "137663",
+            "name": "Soft Foam Sword"
+          },
+          {
+            "icon": "item_icecrownnecklaced",
+            "itemId": "68806",
+            "name": "Kalytha's Haunted Locket"
+          },
+          {
+            "icon": "inv_misc_flute_01",
+            "itemId": "98552",
+            "name": "Xan'tish's Flute",
+            "side": "H"
+          },
+          {
+            "icon": "inv_hand_1h_trollshaman_c_01",
+            "itemId": "97919",
+            "name": "Whole-Body Shrinka'",
+            "side": "H"
+          },
+          {
+            "icon": "inv_misc_archaeology_trolldrum",
+            "itemId": "97942",
+            "name": "Sen'jin Spirit Drum",
+            "side": "H"
+          },
+          {
+            "icon": "inv_potion_107",
+            "itemId": "97921",
+            "name": "Bom'bay's Color-Seein' Sauce"
+          }
+        ],
+        "name": "Vendor"
+      },
+      {
+        "id": "2b03cbb4",
+        "items": [
+          {
+            "icon": "inv_misc_orb_02",
+            "itemId": "1973",
+            "name": "Orb of Deception"
+          }
+        ],
+        "name": "World Drop"
+      }
+    ]
+  },
+  {
+    "id": "f92313b8",
+    "items": [],
+    "name": "Professions",
+    "subcats": [
+      {
+        "id": "dddb23ea",
+        "items": [
+          {
+            "icon": "trade_archaeology_theinnkeepersdaughter",
+            "itemId": "64488",
+            "name": "The Innkeeper's Daughter"
+          },
+          {
+            "icon": "trade_archaeology_chalice-of-mountainkings",
+            "itemId": "64373",
+            "name": "Chalice of the Mountain Kings"
+          },
+          {
+            "icon": "trade_archaeology_insect-in-amber",
+            "itemId": "69776",
+            "name": "Ancient Amber"
+          },
+          {
+            "icon": "trade_archaeology_kaldoreiwindchimes",
+            "itemId": "64383",
+            "name": "Kaldorei Wind Chimes"
+          },
+          {
+            "icon": "trade_archaeology_highbornesoulmirror",
+            "itemId": "64358",
+            "name": "Highborne Soul Mirror"
+          },
+          {
+            "icon": "trade_archaeology_druidprieststatueset",
+            "itemId": "64361",
+            "name": "Druid and Priest Statue Set"
+          },
+          {
+            "icon": "trade_archaeology_bones-of-transformation",
+            "itemId": "64646",
+            "name": "Bones of Transformation"
+          },
+          {
+            "icon": "trade_archaeology_wispamulet",
+            "itemId": "64651",
+            "name": "Wisp Amulet"
+          },
+          {
+            "icon": "inv_misc_archaeology_trolldrum",
+            "itemId": "69777",
+            "name": "Haunted War Drum"
+          },
+          {
+            "icon": "trade_archaeology_naarucrystal",
+            "itemId": "64456",
+            "name": "Arrival of the Naaru"
+          },
+          {
+            "icon": "trade_archaeology_cthunspuzzlebox",
+            "itemId": "64482",
+            "name": "Puzzle Box of Yogg-Saron"
+          },
+          {
+            "icon": "trade_archaeology_oldgodtrinket",
+            "itemId": "64481",
+            "name": "Blessing of the Old God"
+          },
+          {
+            "icon": "inv_misc_archaeology_vrykuldrinkinghorn",
+            "itemId": "69775",
+            "name": "Vrykul Drinking Horn"
+          },
+          {
+            "icon": "trade_archaeology_pendant-of-the-aqir",
+            "itemId": "64881",
+            "name": "Pendant of the Scarab Storm"
+          },
+          {
+            "icon": "archaeology_5_0_anatomicaldummy",
+            "itemId": "89614",
+            "name": "Anatomical Dummy"
+          },
+          {
+            "icon": "inv_archaeology_70_crystallineeyeofundravius",
+            "itemId": "131724",
+            "name": "Crystalline Eye of Undravius"
+          }
+        ],
+        "name": "Archaeology"
+      },
+      {
+        "id": "34d351da",
+        "items": [
+          {
+            "icon": "inv_leatherworking_70_petleash",
+            "itemId": "129958",
+            "name": "Leather Pet Leash"
+          },
+          {
+            "icon": "inv_leatherworking_70_petbed",
+            "itemId": "129960",
+            "name": "Leather Pet Bed"
+          },
+          {
+            "icon": "inv_leatherworking_70_loveseat",
+            "itemId": "129956",
+            "name": "Leather Love Seat"
+          },
+          {
+            "icon": "inv_leatherworking_70_flaminghoop",
+            "itemId": "129961",
+            "name": "Flaming Hoop"
+          }
+        ],
+        "name": "Leatherworking"
+      },
+      {
+        "id": "f7b3ce90",
+        "items": [
+          {
+            "icon": "inv_jewelcrafting_70_jeweltoy",
+            "itemId": "130251",
+            "name": "JewelCraft"
+          },
+          {
+            "icon": "inv_jewelcrafting_70_songcrystal",
+            "itemId": "130254",
+            "name": "Chatterstone"
+          }
+        ],
+        "name": "Jewelcrafting"
+      },
+      {
+        "id": "9bf8d5f8",
+        "items": [
+          {
+            "icon": "achievement_faction_celestials",
+            "itemId": "108745",
+            "name": "Personal Hologram"
+          },
+          {
+            "icon": "inv_misc_idol_02",
+            "itemId": "23767",
+            "name": "Crashin' Thrashin' Robot"
+          },
+          {
+            "icon": "inv_eng_mechanicalboomerang",
+            "itemId": "109167",
+            "name": "Findle's Loot-A-Rang"
+          },
+          {
+            "icon": "inv_misc_bomb_01",
+            "itemId": "123851",
+            "name": "Photo B.O.M.B."
+          },
+          {
+            "icon": "inv_engineering_blingtronscircuitdesigntutorial",
+            "itemId": "132518",
+            "name": "Blingtron's Circuit Design Tutorial"
+          },
+          {
+            "icon": "inv_misc_enggizmos_09",
+            "itemId": "109183",
+            "name": "World Shrinker"
+          },
+          {
+            "icon": "inv_misc_enggizmos_08",
+            "itemId": "18660",
+            "name": "World Enlarger"
+          },
+          {
+            "icon": "inv_eng_mechanicalboomerang2",
+            "itemId": "60854",
+            "name": "Loot-A-Rang"
+          },
+          {
+            "icon": "spell_frost_windwalkon",
+            "itemId": "17716",
+            "name": "Snowmaster 9000"
+          },
+          {
+            "icon": "inv_gnomish_xray_specs",
+            "itemId": "40895",
+            "name": "Gnomish X-Ray Specs"
+          },
+          {
+            "icon": "inv_misc_molle",
+            "itemId": "40768",
+            "name": "MOLL-E"
+          },
+          {
+            "icon": "inv_misc_enggizmos_23",
+            "itemId": "40727",
+            "name": "Gnomish Gravity Well"
+          },
+          {
+            "icon": "inv_pet_lilsmoky",
+            "itemId": "87214",
+            "name": "Blingtron 4000"
+          },
+          {
+            "icon": "inv_misc_blingtron",
+            "itemId": "111821",
+            "name": "Blingtron 5000"
+          },
+          {
+            "icon": "inv_misc_enggizmos_12",
+            "itemId": "18986",
+            "name": "Ultrasafe Transporter: Gadgetzan"
+          },
+          {
+            "icon": "inv_misc_enggizmos_15",
+            "itemId": "18984",
+            "name": "Dimensional Ripper - Everlook"
+          },
+          {
+            "icon": "inv_misc_blizzcon09_graphicscard",
+            "itemId": "30544",
+            "name": "Ultrasafe Transporter: Toshley's Station"
+          },
+          {
+            "icon": "inv_misc_enggizmos_07",
+            "itemId": "30542",
+            "name": "Dimensional Ripper - Area 52"
+          },
+          {
+            "icon": "spell_fire_bluefirenova",
+            "itemId": "48933",
+            "name": "Wormhole Generator: Northrend"
+          },
+          {
+            "icon": "sha_spell_fire_felfirenova",
+            "itemId": "87215",
+            "name": "Wormhole Generator: Pandaria"
+          },
+          {
+            "icon": "ability_siege_engineer_pattern_recognition",
+            "itemId": "112059",
+            "name": "Wormhole Centrifuge"
+          },
+          {
+            "icon": "spell_shadow_demoniccircleteleport",
+            "itemId": "151652",
+            "name": "Wormhole Generator: Argus"
+          }
+        ],
+        "name": "Engineering"
+      },
+      {
+        "id": "f5098ee7",
+        "items": [
+          {
+            "icon": "spell_fire_twilightfire",
+            "itemId": "128536",
+            "name": "Leylight Brazier"
+          }
+        ],
+        "name": "Enchanting"
+      },
+      {
+        "id": "01d8754d",
+        "items": [
+          {
+            "icon": "inv_misc_book_10",
+            "itemId": "129211",
+            "name": "Steamy Romance Novel Kit"
+          }
+        ],
+        "name": "Inscription"
+      },
+      {
+        "id": "bd30e8a9",
+        "items": [
+          {
+            "icon": "ability_garrison_orangebird",
+            "itemId": "143662",
+            "name": "Crate of Bobbers: Wooden Pepe"
+          },
+          {
+            "icon": "inv_garrison_cargoship",
+            "itemId": "142530",
+            "name": "Crate of Bobbers: Tugboat"
+          },
+          {
+            "icon": "inv_g_fishingbobber_05",
+            "itemId": "142531",
+            "name": "Crate of Bobbers: Squeaky Duck"
+          },
+          {
+            "icon": "inv_misc_head_murloc_01",
+            "itemId": "142532",
+            "name": "Crate of Bobbers: Murloc Head"
+          },
+          {
+            "icon": "trade_archaeology_catstatueemeraldeyes",
+            "itemId": "142529",
+            "name": "Crate of Bobbers: Cat Head"
+          },
+          {
+            "icon": "ability_hunter_pet_worm",
+            "itemId": "142528",
+            "name": "Crate of Bobbers: Can of Worms"
+          },
+          {
+            "icon": "inv_mace_27",
+            "itemId": "85973",
+            "name": "Ancient Pandaren Fishing Charm"
+          },
+          {
+            "icon": "inv_misc_fishing_raft",
+            "itemId": "85500",
+            "name": "Anglers Fishing Raft"
+          },
+          {
+            "icon": "inv_misc_coin_18",
+            "itemId": "44430",
+            "name": "Titanium Seal of Dalaran"
+          },
+          {
+            "icon": "inv_fishingchair",
+            "itemId": "86596",
+            "name": "Nat's Fishing Chair"
+          },
+          {
+            "icon": "inv_misc_idol_05",
+            "itemId": "45984",
+            "name": "Unusual Compass"
+          }
+        ],
+        "name": "Fishing"
+      },
+      {
+        "id": "4e4ffd58",
+        "items": [
+          {
+            "icon": "achievement_profession_chefhat",
+            "itemId": "134020",
+            "name": "Chef's Hat"
+          }
+        ],
+        "name": "Cooking"
+      },
+      {
+        "id": "79a66987",
+        "items": [
+          {
+            "allowableClasses": [
+              4
+            ],
+            "icon": "inv_cask_03",
+            "itemId": "120857",
+            "name": "Barrel of Bandanas"
+          },
+          {
+            "allowableClasses": [
+              4
+            ],
+            "icon": "inv_misc_dice_01",
+            "itemId": "36863",
+            "name": "Decahedral Dwarven Dice"
+          },
+          {
+            "allowableClasses": [
+              4
+            ],
+            "icon": "inv_misc_dice_02",
+            "itemId": "63269",
+            "name": "Loaded Gnomish Dice"
+          },
+          {
+            "allowableClasses": [
+              4
+            ],
+            "icon": "inv_misc_dice_02",
+            "itemId": "36862",
+            "name": "Worn Troll Dice"
+          }
+        ],
+        "name": "Pickpocketing"
+      },
+      {
+        "id": "b2f64016",
+        "items": [
+          {
+            "icon": "inv_knife_1h_common_b_01green",
+            "itemId": "130102",
+            "name": "Mother's Skinning Knife"
+          }
+        ],
+        "name": "Skinning"
+      }
+    ]
+  },
+  {
+    "id": "a87924b0",
+    "items": [],
+    "name": "Pet battles",
+    "subcats": [
+      {
+        "id": "a2d95134",
+        "items": [
+          {
+            "icon": "inv_belt_18",
+            "itemId": "89139",
+            "name": "Chain Pet Leash"
+          },
+          {
+            "icon": "inv_misc_bandage_15",
+            "itemId": "37460",
+            "name": "Rope Pet Leash"
+          },
+          {
+            "icon": "inv_helm_cloth_petsafari_a_01",
+            "itemId": "92738",
+            "name": "Safari Hat"
+          }
+        ],
+        "name": "Pet battles"
+      }
+    ]
+  },
+  {
+    "id": "c80f9e30",
+    "items": [],
+    "name": "PVP",
+    "subcats": [
+      {
+        "id": "1d8ed9dc",
+        "items": [
+          {
+            "icon": "achievement_bg_3flagcap_nodeaths",
+            "itemId": "134026",
+            "name": "Honorable Pennant"
+          },
+          {
+            "icon": "achievement_bg_3flagcap_nodeaths",
+            "itemId": "134031",
+            "name": "Prestigious Pennant"
+          },
+          {
+            "icon": "achievement_bg_3flagcap_nodeaths",
+            "itemId": "134032",
+            "name": "Elite Pennant"
+          },
+          {
+            "icon": "achievement_bg_3flagcap_nodeaths",
+            "itemId": "134034",
+            "name": "Esteemed Pennant"
+          }
+        ],
+        "name": "Prestige"
+      }
+    ]
+  },
+  {
+    "name": "World Events",
+    "subcats": [
+      {
+        "id": "f7dc4327",
+        "items": [
+          {
+            "icon": "inv_misc_lantern_01",
+            "itemId": "21540",
+            "name": "Elune's Lantern"
+          },
+          {
+            "icon": "inv_misc_missilelarge_blue",
+            "itemId": "89999",
+            "name": "Everlasting Alliance Firework"
+          },
+          {
+            "icon": "inv_misc_missilelarge_red",
+            "itemId": "90000",
+            "name": "Everlasting Horde Firework"
+          },
+          {
+            "icon": "inv_misc_dragoncostume_front",
+            "itemId": "143827",
+            "name": "Dragon Head Costume"
+          },
+          {
+            "icon": "inv_misc_dragoncostume_mid",
+            "itemId": "143828",
+            "name": "Dragon Body Costume"
+          },
+          {
+            "icon": "inv_misc_dragoncostume_tail",
+            "itemId": "143829",
+            "name": "Dragon Tail  Costume"
+          }
+        ],
+        "name": "Lunar Festival"
+      },
+      {
+        "id": "e5a61b6b",
+        "items": [
+          {
+            "icon": "inv_misc_basket_01",
+            "itemId": "34480",
+            "name": "Romantic Picnic Basket"
+          },
+          {
+            "icon": "inv_staff_52",
+            "itemId": "116651",
+            "name": "True Love Prism"
+          },
+          {
+            "icon": "ability_deathknight_heartstopaura",
+            "itemId": "144339",
+            "name": "Sturdy Love Fool"
+          },
+          {
+            "icon": "inv_misc_love_gondola",
+            "itemId": "142341",
+            "name": "Love Boat"
+          },
+          {
+            "icon": "spell_brokenheart",
+            "itemId": "50471",
+            "name": "The Heartbreaker"
+          }
+        ],
+        "name": "Love is in the Air"
+      },
+      {
+        "id": "39f1544a",
+        "items": [
+          {
+            "icon": "inv_misc_food_45",
+            "itemId": "69895",
+            "name": "Green Balloon"
+          },
+          {
+            "icon": "inv_misc_throwingball_01",
+            "itemId": "69896",
+            "name": "Yellow Balloon"
+          }
+        ],
+        "name": "Children's Week"
+      },
+      {
+        "id": "0b1ab958",
+        "items": [
+          {
+            "icon": "inv_misc_firedancer_01",
+            "itemId": "34686",
+            "name": "Brazier of Dancing Flames"
+          },
+          {
+            "icon": "spell_fire_fire",
+            "itemId": "116435",
+            "name": "Cozy Bonfire"
+          },
+          {
+            "icon": "inv_neck_firelands_03",
+            "itemId": "116440",
+            "name": "Burning Defender's Medallion"
+          },
+          {
+            "icon": "inv_misc_matchbook",
+            "itemId": "141649",
+            "name": "Set of Matches"
+          }
+        ],
+        "name": "Midsummer"
+      },
+      {
+        "id": "7ac8c92a",
+        "items": [
+          {
+            "icon": "inv_holiday_brewfestbuff_01",
+            "itemId": "116758",
+            "name": "Brewfest Banner"
+          },
+          {
+            "icon": "inv_cask_04",
+            "itemId": "33927",
+            "name": "Brewfest Pony Keg"
+          },
+          {
+            "icon": "inv_holiday_beerfestsausage03",
+            "itemId": "138900",
+            "name": "Gravil Goldbraid's Famous Sausage Hat"
+          },
+          {
+            "icon": "archaeology_5_0_emptykegofbrewfatherxinwoyin",
+            "itemId": "90427",
+            "name": "Pandaren Brewpack"
+          },
+          {
+            "icon": "achievement_cooking_masterofthegrill",
+            "itemId": "116757",
+            "name": "Steamworks Sausage Grill"
+          },
+          {
+            "icon": "ability_mount_ridinghorse",
+            "itemId": "71137",
+            "name": "Brewfest Keg Pony"
+          }
+        ],
+        "name": "Brewfest"
+      },
+      {
+        "id": "be5810ca",
+        "items": [
+          {
+            "icon": "inv_misc_book_10",
+            "itemId": "138415",
+            "name": "Slightly-Chewed Insult Book"
+          },
+          {
+            "icon": "warrior_skullbanner",
+            "itemId": "150547",
+            "name": "Jolly Roger"
+          }
+        ],
+        "name": "Pirate's Day"
+      },
+      {
+        "id": "ca273c36",
+        "items": [
+          {
+            "icon": "inv_misc_bag_enchantedrunecloth",
+            "itemId": "128794",
+            "name": "Sack of Spectral Spiders"
+          },
+          {
+            "icon": "spell_burningsoul",
+            "itemId": "70722",
+            "name": "Little Wickerman"
+          },
+          {
+            "icon": "inv_misc_horsecostume_front",
+            "itemId": "151271",
+            "name": "Horse Head Costume"
+          },
+          {
+            "icon": "inv_misc_horsecostume_back",
+            "itemId": "151270",
+            "name": "Horse Tail Costume"
+          },
+          {
+            "icon": "inv_misc_coin_16",
+            "itemId": "128807",
+            "name": "Coin of Many Faces"
+          }
+        ],
+        "name": "Hallow's End"
+      },
+      {
+        "id": "65432d64",
+        "items": [
+          {
+            "icon": "ability_fixated_state_yellow",
+            "itemId": "116891",
+            "name": "\"Snowy Owl\" Contender's Costume"
+          },
+          {
+            "icon": "ability_fixated_state_orange",
+            "itemId": "116890",
+            "name": "\"Santo's Sun\" Contender's Costume"
+          },
+          {
+            "icon": "ability_fixated_state_purple",
+            "itemId": "116889",
+            "name": "\"Purple Phantom\" Contender's Costume"
+          },
+          {
+            "icon": "ability_fixated_state_blue",
+            "itemId": "116888",
+            "name": "\"Night Demon\" Contender's Costume"
+          },
+          {
+            "icon": "ability_fixated_state_red",
+            "itemId": "116856",
+            "name": "\"Blooming Rose\" Contender's Costume"
+          }
+        ],
+        "name": "Day of the Dead"
+      },
+      {
+        "id": "e60e12a8",
+        "items": [
+          {
+            "icon": "inv_weapon_rifle_01",
+            "itemId": "116400",
+            "name": "Silver-Plated Turkey Shooter"
+          }
+        ],
+        "name": "Pilgrim's Bounty"
+      },
+      {
+        "id": "816def3b",
+        "items": [
+          {
+            "icon": "inv_misc_bag_10_black",
+            "itemId": "116691",
+            "name": "Zhevra Lounge Cushion"
+          },
+          {
+            "icon": "inv_misc_football",
+            "itemId": "90883",
+            "name": "The Pigskin"
+          },
+          {
+            "icon": "inv_misc_football",
+            "itemId": "104323",
+            "name": "The Pigskin"
+          },
+          {
+            "icon": "inv_misc_bag_10",
+            "itemId": "116690",
+            "name": "Safari Lounge Cushion"
+          },
+          {
+            "icon": "inv_misc_bag_10_red",
+            "itemId": "116689",
+            "name": "Pineapple Lounge Cushion"
+          },
+          {
+            "icon": "inv_misc_bag_10_green",
+            "itemId": "116692",
+            "name": "Fuzzy Green Lounge Cushion"
+          },
+          {
+            "icon": "inv_misc_soccerball",
+            "itemId": "104324",
+            "name": "Foot Ball"
+          },
+          {
+            "icon": "inv_misc_soccerball",
+            "itemId": "90888",
+            "name": "Foot Ball"
+          },
+          {
+            "icon": "spell_frost_frostward",
+            "itemId": "17712",
+            "name": "Winter Veil Disguise Kit"
+          },
+          {
+            "icon": "inv_helm_cloth_holiday_christmas_a_03",
+            "itemId": "139337",
+            "name": "Disposable Winter Veil Suits"
+          },
+          {
+            "icon": "trade_archaeology_highborne_scroll",
+            "itemId": "116456",
+            "name": "Scroll of Storytelling"
+          },
+          {
+            "icon": "inv_misc_xmassled",
+            "itemId": "128776",
+            "name": "Red Wooden Sled"
+          },
+          {
+            "icon": "inv_gizmo_goblingtonkcontroller",
+            "itemId": "46709",
+            "name": "MiniZep Controller"
+          },
+          {
+            "icon": "inv_weapon_rifle_33",
+            "itemId": "128636",
+            "name": "Endothermic Blaster"
+          },
+          {
+            "icon": "ability_mount_shreddermount",
+            "itemId": "116763",
+            "name": "Crashin' Thrashin' Shredder Controller"
+          },
+          {
+            "icon": "achievement_boss_ironjuggernaut",
+            "itemId": "108635",
+            "name": "Crashin' Thrashin' Killdozer Controller"
+          },
+          {
+            "icon": "inv_misc_enggizmos_20",
+            "itemId": "104318",
+            "name": "Crashin' Thrashin' Flyer Controller"
+          },
+          {
+            "icon": "ability_ironmaidens_deployturret",
+            "itemId": "108632",
+            "name": "Crashin' Thrashin' Flamer Controller"
+          },
+          {
+            "icon": "inv_shield_1h_alliancetoy_a_01",
+            "itemId": "151349",
+            "name": "Toy Weapon Set",
+            "side": "A"
+          },
+          {
+            "icon": "inv_shield_1h_hordetoy_a_01",
+            "itemId": "151348",
+            "name": "Toy Weapon Set",
+            "side": "H"
+          },
+          {
+            "icon": "inv_misc_gobstationx",
+            "itemId": "151344",
+            "name": "Hearthstation",
+            "side": "H"
+          },
+          {
+            "icon": "inv_misc_gnomefundo86",
+            "itemId": "151343",
+            "name": "Hearthstation",
+            "side": "A"
+          },
+          {
+            "icon": "inv_gizmo_goblingtonkcontroller",
+            "itemId": "37710",
+            "name": "Crashin' Thrashin' Racer Controller"
+          }
+        ],
+        "name": "Winter Veil"
+      },
+      {
+        "id": "a5b95ce0",
+        "items": [],
+        "name": "Argent Tournament"
+      },
+      {
+        "id": "e17ba155",
+        "items": [
+          {
+            "icon": "inv_misc_balloon_01",
+            "itemId": "75042",
+            "name": "Flimsy Yellow Balloon"
+          },
+          {
+            "icon": "inv_misc_seesaw",
+            "itemId": "97994",
+            "name": "Darkmoon Seesaw"
+          },
+          {
+            "icon": "ability_hunter_beastcall",
+            "itemId": "90899",
+            "name": "Darkmoon Whistle"
+          },
+          {
+            "icon": "inv_zulgurubtrinket",
+            "itemId": "116139",
+            "name": "Haunting Memento"
+          },
+          {
+            "icon": "inv_misc_missilelarge_green",
+            "itemId": "138202",
+            "name": "Sparklepony XL"
+          },
+          {
+            "icon": "archaeology_5_0_spearofxuen",
+            "itemId": "126931",
+            "name": "Seafarer's Slidewhistle"
+          },
+          {
+            "icon": "inv_60dungeon_ring5b",
+            "itemId": "116067",
+            "name": "Ring of Broken Promises"
+          },
+          {
+            "icon": "inv_gauntlets_02",
+            "itemId": "105898",
+            "name": "Moonfang's Paw"
+          },
+          {
+            "icon": "ability_mount_whitedirewolf",
+            "itemId": "101571",
+            "name": "Moonfang Shroud"
+          },
+          {
+            "icon": "inv_gizmo_goblingtonkcontroller",
+            "itemId": "122122",
+            "name": "Darkmoon Tonk Controller"
+          },
+          {
+            "icon": "inv_jewelry_ring_03",
+            "itemId": "122123",
+            "name": "Darkmoon Ring-Flinger"
+          },
+          {
+            "icon": "inv_shoulder_leather_firelandsdruid_d_01",
+            "itemId": "116115",
+            "name": "Blazing Wings"
+          },
+          {
+            "icon": "inv_misc_flaskofvolatility",
+            "itemId": "122129",
+            "name": "Fire-Eater's Vial"
+          },
+          {
+            "icon": "inv_darkmoon_vengeance",
+            "itemId": "122120",
+            "name": "Gaze of the Darkmoon"
+          },
+          {
+            "icon": "inv_misc_missilelarge_purple",
+            "itemId": "122119",
+            "name": "Everlasting Darkmoon Firework"
+          },
+          {
+            "icon": "inv_darkmoon_eye",
+            "itemId": "122121",
+            "name": "Darkmoon Gazer"
+          },
+          {
+            "icon": "misc_arrowright",
+            "itemId": "122126",
+            "name": "Attraction Sign"
+          },
+          {
+            "icon": "inv_mace_122",
+            "itemId": "151265",
+            "name": "Blight Boar Microphone"
+          }
+        ],
+        "name": "Darkmoon Faire"
+      },
+      {
+        "id": "abab0c56",
+        "items": [
+          {
+            "icon": "inv_corgi2",
+            "itemId": "158149",
+            "name": "Overtuned Corgi Goggles"
+          }
+        ],
+        "name": "WoW's Anniversary"
+      }
+    ]
+  },
+  {
+    "id": "8b3b51e5",
+    "items": [],
+    "name": "Promotion",
+    "subcats": [
+      {
+        "id": "4218fec7",
+        "items": [
+          {
+            "icon": "ability_mount_ridinghorse",
+            "itemId": "69215",
+            "name": "War Party Hitching Post"
+          },
+          {
+            "icon": "inv_banner_03",
+            "itemId": "38578",
+            "name": "The Flag of Ownership"
+          },
+          {
+            "icon": "trade_archaeology_uldumcanopicjar",
+            "itemId": "72161",
+            "name": "Spurious Sarcophagus"
+          },
+          {
+            "icon": "inv_misc_bag_10",
+            "itemId": "71628",
+            "name": "Sack of Starfish"
+          },
+          {
+            "icon": "inv_box_01",
+            "itemId": "32566",
+            "name": "Picnic Basket"
+          },
+          {
+            "icon": "inv_misc_missilesmall_purple",
+            "itemId": "49703",
+            "name": "Perpetual Purple Firework"
+          },
+          {
+            "icon": "inv_misc_toy_06",
+            "itemId": "34499",
+            "name": "Paper Flying Machine Kit"
+          },
+          {
+            "icon": "inv_misc_ogrepinata",
+            "itemId": "46780",
+            "name": "Ogre Pinata"
+          },
+          {
+            "icon": "inv_misc_idol_01",
+            "itemId": "72159",
+            "name": "Magical Ogre Idol"
+          },
+          {
+            "icon": "inv_misc_statue_02",
+            "itemId": "54212",
+            "name": "Instant Statue Pedestal"
+          },
+          {
+            "icon": "inv_potion_27",
+            "itemId": "32542",
+            "name": "Imp in a Ball"
+          },
+          {
+            "icon": "spell_fire_twilightfire",
+            "itemId": "67097",
+            "name": "Grim Campfire"
+          },
+          {
+            "icon": "inv_misc_weathermachine_01",
+            "itemId": "35227",
+            "name": "Goblin Weather Machine - Prototype 01-B"
+          },
+          {
+            "icon": "inv_drink_17",
+            "itemId": "33219",
+            "name": "Goblin Gumbo Kettle"
+          },
+          {
+            "icon": "inv_misc_gem_goldendraenite_01",
+            "itemId": "69227",
+            "name": "Fool's Gold"
+          },
+          {
+            "icon": "ability_warrior_challange",
+            "itemId": "45063",
+            "name": "Foam Sword Rack"
+          },
+          {
+            "icon": "inv_fishingchair",
+            "itemId": "33223",
+            "name": "Fishing Chair"
+          },
+          {
+            "icon": "achievement_boss_illidan",
+            "itemId": "79769",
+            "name": "Demon Hunter's Aspect"
+          },
+          {
+            "icon": "inv_misc_discoball_01",
+            "itemId": "38301",
+            "name": "D.I.S.C.O."
+          },
+          {
+            "icon": "inv_misc_idol_01",
+            "itemId": "49704",
+            "name": "Carved Ogre Idol"
+          },
+          {
+            "icon": "achievement_dungeon_outland_dungeonmaster",
+            "itemId": "93672",
+            "name": "Dark Portal (TCG)"
+          },
+          {
+            "icon": "ability_mage_netherwindpresence",
+            "itemId": "54452",
+            "name": "Ethereal Portal"
+          }
+        ],
+        "name": "Trading Card Game"
+      },
+      {
+        "id": "c976edb6",
+        "items": [
+          {
+            "icon": "inv_misc_head_murloc_01",
+            "itemId": "33079",
+            "name": "Murloc Costume"
+          }
+        ],
+        "name": "Blizzcon"
+      },
+      {
+        "id": "0e8d6ca6",
+        "items": [
+          {
+            "icon": "inv_misc_steel_hitching_post2",
+            "itemId": "112324",
+            "name": "Nightmarish Hitching Post"
+          }
+        ],
+        "name": "Blizzard Store"
+      }
+    ]
+  }
+]

--- a/app/index.html
+++ b/app/index.html
@@ -78,6 +78,7 @@
     <script src="scripts/controllers/overview.controller.js"></script>
     <script src="scripts/controllers/reputation.controller.js"></script>
     <script src="scripts/controllers/settings.controller.js"></script>
+    <script src="scripts/controllers/toys.controller.js"></script>
 
     <script src="scripts/services/login.service.js"></script>
     <script src="scripts/services/admin.service.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -51,6 +51,10 @@
               templateUrl: 'views/mounts.html',
               controller: 'MountsCtrl'
             }).  
+            when('/:region/:realm/:character/collectable/toys', {
+              templateUrl: 'views/toys.html',
+              controller: 'ToysCtrl'
+            }).
             when('/:region/:realm/:character', {
               templateUrl: 'views/overview.html',
               controller: 'OverviewCtrl'

--- a/app/scripts/controllers/toys.controller.js
+++ b/app/scripts/controllers/toys.controller.js
@@ -1,0 +1,40 @@
+/*globals $WowheadPower */
+'use strict';
+
+(function() {
+
+    angular
+        .module('simpleArmoryApp')
+        .controller('ToysCtrl' , ToysCtrl);
+
+    function ToysCtrl($scope, MountsAndPetsService, PlannerService, $window, SettingsService) {
+
+        $scope.settings = SettingsService;
+
+    	// Analytics for page
+        $window.ga('send', 'pageview', 'Toys');
+
+        MountsAndPetsService.getItems('toys', 'toys', 'itemId').then(function(items){
+            $scope.items = items;
+        });
+    }
+
+  angular
+    .module('simpleArmoryApp')
+    .controller('ToysFormCtrl' , ToysFormCtrl);
+
+  function ToysFormCtrl($scope) {
+    $scope.formInfo = {};
+    $scope.saveData = function() {
+      try {
+        JSON.parse($scope.formInfo.toys);
+      } catch (e) {
+        // TODO: display json error, do more consistency checks
+        return;
+      }
+      localStorage.setItem('toys', $scope.formInfo.toys);
+      window.location.reload(true);
+    };
+  }
+
+})();

--- a/app/scripts/services/mountsAndPets.service.js
+++ b/app/scripts/services/mountsAndPets.service.js
@@ -21,10 +21,12 @@
         var parsedMounts;
         var parsedCompanions;
         var parsedPets;
+        var parsedToys;
         LoginService.onLogin(function() {
             parsedMounts = undefined;
             parsedCompanions = undefined;
             parsedPets = undefined;
+            parsedToys = undefined;
         });
 
         return {
@@ -36,6 +38,8 @@
                     return $q.when(parsedPets);
                 } else if (jsonFile === 'mounts' && parsedMounts) {
                     return $q.when(parsedMounts);
+                } else if (jsonFile === 'toys' && parsedToys) {
+                    return $q.when(parsedToys);
                 }
 
                 return LoginService.getCharacter(
@@ -57,6 +61,8 @@
                                     parsedPets = parsed; 
                                 } else if (jsonFile === 'mounts') {
                                     parsedMounts = parsed;
+                                } else if (jsonFile === 'toys') {
+                                    parsedToys = parsed;
                                 }
 
                                 return parsed;
@@ -71,6 +77,15 @@
             var totalCollected = 0;
             var totalPossible = 0;
             var found = {};
+
+            // Retrieve the toys from the localstorage
+            // Remove this if Blizzard ever implements this in the API.
+            var toys = JSON.parse(localStorage.getItem('toys'));
+            character.toys = {};
+            character.toys.collected = [];
+            angular.forEach(toys, function(item) {
+                character.toys.collected.push({'itemId': item});
+            });
 
             // Build up lookup for items that character has
             angular.forEach(character[characterProperty].collected, function(item) {

--- a/app/scripts/services/settings.service.js
+++ b/app/scripts/services/settings.service.js
@@ -20,6 +20,7 @@
                 'pets': 'data/pets.json',
                 'battlepets': 'data/battlepets.json',
                 'mounts': 'data/mounts.json',
+                'toys': 'data/toys.json',
                 'achievements': 'data/achievements.json'
             }
         };

--- a/app/views/header.html
+++ b/app/views/header.html
@@ -40,6 +40,7 @@
             <li ng-class="{ active: isActive('collectable/mounts') }"><a ng-click="isCollapsed = true" ng-href="{{getUrl('collectable/mounts')}}">Mounts</a></li>
             <li ng-class="{ active: isActive('collectable/companions') }"><a ng-click="isCollapsed = true" ng-href="{{getUrl('collectable/companions')}}">Companions</a></li>
             <li ng-class="{ active: isActive('collectable/battlepets') }"><a ng-click="isCollapsed = true" ng-href="{{getUrl('collectable/battlepets')}}">Battle Pets</a></li>
+            <li ng-class="{ active: isActive('collectable/toys') }"><a ng-click="isCollapsed = true" ng-href="{{getUrl('collectable/toys')}}">Toys</a></li>
           </ul>
         </li>
         <li ng-class="{ active: isActive('calendar') }"><a ng-click="isCollapsed = true" ng-href="{{getUrl('calendar')}}">Calendar</a></li>

--- a/app/views/toys.html
+++ b/app/views/toys.html
@@ -1,0 +1,40 @@
+<div class="container">
+  <div class="page-header">
+    <h2>
+      Toys
+    <div class="progress progressRight">
+            <progressbar max="100" type="success"
+      	  		value="percent(items.collected, items.possible)" >
+      	  		<span>{{ achFormater(items.collected, items.possible) }}</span>
+      	  	</progressbar>
+        </div>
+    </h2>
+  </div>
+  <div>
+    <p><strong>The Blizzard API doesn't allow yet fetching toys from your
+      character.</strong>
+    To see what toys you have earned, you have to paste a <strong>Toy export
+      string</strong> in the field below. You can get this string by downloading the
+    <a href="http://">Simple Armory Toy Exporter</a> addon, then typing
+    <code>/simplearmorytoyexporter</code> in your chat window.</p>
+    <p><small>(If you find this frustrating, you can do a post on the forums to ask for
+      the Toys to be exported in the API along with the mounts and pets.)</small></p>
+
+    <form role="form" ng-app="simpleArmoryApp" ng-controller="ToysFormCtrl">
+      <textarea name="toys" cols="80" ng-model="formInfo.toys"
+        placeholder="Copy your Simple Armory Toy Export string here..."></textarea>
+
+      <div><input type="submit" value="Save" ng-click="saveData()" /></div>
+    </form>
+  </div>
+  <div>
+    <h3 class="categoryHeader" ng-hide="category.name == 'Toys'" ng-repeat-start="category in items.categories">{{ category.name }}</h3>
+    <div class="sect" ng-repeat="subCategory in category.subCategories">
+  		<h5 class="subCatHeader">{{ subCategory.name }}</h5>
+  		<a target="{{settings.anchorTarget}}" ng-href="//{{settings.WowHeadUrl}}/{{ item.link }}" class="thumbnail" ng-repeat="item in subCategory.items" ng-class="{borderOn:!item.collected, borderOff:item.collected}">
+          	<img ng-src="{{getImageSrc(item)}}">
+        	</a>
+    </div>
+    <div class="clear" ng-repeat-end></div>
+  </div>
+</div>


### PR DESCRIPTION
I implemented a **Toys** section that relies on an import string instead of fetching the toys from the armory. The end result looks like this:

![Preview](http://koin.fr/upload/koin-2018-05-11-025502-3c5a72190a6c8711e8b6bc1e220627549b8ebea31bf48d0d2a4212fc20008829.png)

I sorted all the toys manually with help from wowhead and a few scripts (that I can give you or commit in the repository if you want). Some toys might be in the wrong place, but overall I feel pretty confident of the quality of the sorting.

To be able to get the import string, you need the Simple Armory Toy Exporter addon, which I made but I didn't release on Curse yet. It's available here: https://github.com/seirl/SimpleArmoryToyExporter

Once you paste the import string in the form, your data is put in your local storage, and the page uses this import string to know which toys you already have.

This was rushed in an afternoon/night so it might need some polishing, but it should be in a pretty good place already.