### PR TITLE
Add Battle for Azeroth mounts

### DIFF
--- a/app/data/mounts.json
+++ b/app/data/mounts.json
@@ -50,64 +50,145 @@
             "icon": "inv_bluegodcloudserpent"
           },
           {
+            "itemId": "137614",
+            "name": "Biting Frostshard Core",
+            "icon": "inv_infernalmounice",
+            "spellid": "213350"
+          },
+          {
+            "itemId": "163981",
+            "name": "Frenzied Feltalon",
+            "icon": "ability_mount_fireravengodmountgreen",
+            "spellid": "280729"
+          },
+          {
             "spellid": "175700",
             "itemId": "118676",
             "icon": "ability_mount_drake_blue"
           }
         ],
         "id": "d0982483"
+      },
+      {
+        "name": "Reputations",
+        "id": "5f70e5b4",
+        "items": [
+          {
+            "itemId": "163982",
+            "name": "Pureheart Courser",
+            "icon": "inv_horse2white",
+            "spellid": "280730"
+          }
+        ]
+      },
+      {
+        "name": "Toys",
+        "id": "e2d7702d",
+        "items": [
+          {
+            "spellid": "223814",
+            "itemId": "140500",
+            "icon": "ability_mount_shreddermount"
+          }
+        ]
+      },
+      {
+        "name": "Heirlooms",
+        "id": "91888e4b",
+        "items": [
+          {
+            "spellid": "179245",
+            "itemId": "120968",
+            "icon": "inv_misc_key_06",
+            "side": "A"
+          },
+          {
+            "spellid": "179244",
+            "itemId": "122703",
+            "icon": "inv_misc_key_06",
+            "side": "H"
+          }
+        ]
       }
     ],
     "id": "40fa67ae"
   },
   {
-    "name": "Legion",
+    "name": "Battle for Azeroth",
     "subcats": [
       {
         "name": "Achievement",
+        "id": "d2878c68",
         "items": [
           {
-            "spellid": "193007",
-            "itemId": "141216",
-            "icon": "inv_moosemount2nightmare"
+            "itemId": "163577",
+            "name": "Conquerer's Scythemaw",
+            "icon": "inv_trilobitemount_green",
+            "spellid": "279454"
           },
           {
-            "spellid": "215558",
-            "itemId": "138387",
-            "icon": "inv_ratmount"
+            "itemId": "161215",
+            "name": "Reins of the Obsidian Krolusk",
+            "icon": "inv_trilobitemount_black",
+            "spellid": "239049"
           },
           {
-            "spellid": "225765",
-            "itemId": "141217",
-            "icon": "inv_mount_hippogryph_arcane"
+            "itemId": "163216",
+            "name": "Bloodgorged Crawg",
+            "icon": "inv_bloodtrollbeast_mount",
+            "spellid": "250735"
+          }
+        ]
+      },
+      {
+        "name": "Vendor",
+        "id": "062a5729",
+        "items": [
+          {
+            "itemId": "163589",
+            "name": "Reins of the Palehide Direhorn",
+            "icon": "ability_mount_triceratopsmount_yellow",
+            "spellid": "279474"
           },
           {
-            "spellid": "223814",
-            "itemId": "140500",
-            "icon": "ability_mount_shreddermount"
-          },
+            "itemId": "163042",
+            "name": "Reins of the Mighty Caravan Brutosaur",
+            "icon": "inv_brontosaurusmount",
+            "spellid": "264058"
+          }
+        ]
+      },
+      {
+        "name": "Quest",
+        "id": "c31da708",
+        "items": [
           {
-            "spellid": "193695",
-            "itemId": "129280",
-            "icon": "inv_alliancepvpmount",
+            "itemId": "163127",
+            "spellid": "274610",
+            "icon": "inv_hippogryphmountnightelf",
+            "name": "Smoldering Reins of the Teldrassil Hippogryph",
             "side": "A"
           },
           {
-            "spellid": "204166",
-            "itemId": "143864",
-            "icon": "ability_mount_hordepvpmount",
+            "itemId": "163128",
+            "spellid": "272472",
+            "icon": "inv_felbatmountforsaken",
+            "name": "War-Torn Reins of the Undercity Plaguebat",
             "side": "H"
           },
           {
-            "spellid": 253087,
-            "itemId": 152815,
-            "icon": "inv_felhound3_shadow_mount"
-          },
-          {
-            "spellid": 254260,
-            "itemId": 153041,
-            "icon": "inv_argustalbukmount_felred"
-          },
+            "itemId": "159146",
+            "spellid": "267270",
+            "icon": "inv_pterrordax2mount_yellow",
+            "side": "H",
+            "name": "Kua'fon's Harness"
+          }
+        ]
+      },
+      {
+        "name": "Allied Races",
+        "id": "fda11c9c",
+        "items": [
           {
             "icon": "inv_hmmoosemount",
             "spellid": 258060,
@@ -131,6 +212,318 @@
             "spellid": 258022,
             "itemId": 155656,
             "side": "A"
+          },
+          {
+            "itemId": "161330",
+            "name": "Mag'har Direwolf",
+            "icon": "inv_orcclanworg",
+            "spellid": "267274",
+            "side": "H"
+          },
+          {
+            "itemId": "161331",
+            "name": "Dark Iron Core Hound",
+            "icon": "inv_darkirondwarfcorehound",
+            "spellid": "271646",
+            "side": "A"
+          },
+          {
+            "itemId": "157870",
+            "name": "Zandalari Direhorn",
+            "icon": "inv_triceratopszandalari",
+            "spellid": "263707",
+            "side": "H"
+          }
+        ]
+      },
+      {
+        "name": "Dungeon",
+        "id": "8e8e5c12",
+        "items": [
+          {
+            "itemId": "159921",
+            "name": "Mummified Raptor Skull",
+            "icon": "inv_armoredraptorundead",
+            "spellid": "266058"
+          },
+          {
+            "itemId": "160829",
+            "name": "Underrot Crawg Harness",
+            "icon": "inv_archaeology_ogres_chimera_riding_harness",
+            "spellid": "273541"
+          },
+          {
+            "itemId": "159842",
+            "name": "Sharkbait's Favorite Crackers",
+            "icon": "inv_misc_food_wheat_02",
+            "spellid": "254813"
+          }
+        ]
+      },
+      {
+        "name": "Pre-Patch Event",
+        "id": "d9a261ed",
+        "items": []
+      },
+      {
+        "name": "Warfront",
+        "id": "1caadcd7",
+        "items": [
+          {
+            "itemId": "163579",
+            "name": "Highland Mustang",
+            "icon": "ability_mount_ridinghorse",
+            "spellid": "279456",
+            "side": "A"
+          },
+          {
+            "itemId": "163578",
+            "name": "Broken Highland Mustang",
+            "icon": "ability_mount_ridinghorse",
+            "spellid": "279457",
+            "side": "H"
+          },
+          {
+            "itemId": "163644",
+            "name": "Swift Albino Raptor",
+            "icon": "ability_mount_raptor_white",
+            "spellid": "279569"
+          },
+          {
+            "itemId": "163645",
+            "name": "Skullripper",
+            "icon": "ability_hunter_pet_raptor",
+            "spellid": "279611"
+          },
+          {
+            "itemId": "163706",
+            "name": "Witherbark Direwing",
+            "icon": "ability_hunter_pet_bat",
+            "spellid": "279868"
+          },
+          {
+            "itemId": "163646",
+            "name": "Lil' Donkey",
+            "icon": "ability_mount_ridinghorse",
+            "spellid": "279608"
+          }
+        ]
+      },
+      {
+        "name": "Island Expedition",
+        "id": "da655cc0",
+        "items": [
+          {
+            "itemId": "163584",
+            "name": "Twilight Avenger",
+            "icon": "ability_mount_drake_twilight",
+            "spellid": "279466"
+          },
+          {
+            "itemId": "163585",
+            "name": "Surf Jelly",
+            "icon": "inv_misc_fish_70",
+            "spellid": "278979"
+          },
+          {
+            "itemId": "163583",
+            "name": "Craghorn Chasm-Leaper",
+            "icon": "inv_misc_pet_pandaren_yeti",
+            "spellid": "279467"
+          },
+          {
+            "itemId": "163586",
+            "name": "Squawks",
+            "icon": "inv_parrotmount_green",
+            "spellid": "254811"
+          }
+        ]
+      },
+      {
+        "name": "Zone",
+        "id": "6f5b737b",
+        "items": [
+          {
+            "itemId": "163576",
+            "name": "Captured Dune Scavenger",
+            "icon": "inv_hyena2mount_tan",
+            "spellid": "237286"
+          },
+          {
+            "itemId": "163574",
+            "name": "Chewed-On Reins of the Terrified Pack Mule",
+            "icon": "ability_mount_ridinghorse",
+            "spellid": "260174"
+          },
+          {
+            "itemId": "163575",
+            "name": "Reins of a Tamed Bloodfeaster",
+            "icon": "ability_mount_bloodtick_red",
+            "spellid": "243795"
+          },
+          {
+            "itemId": "161479",
+            "name": "Nazjatar Blood Serpent",
+            "icon": "inv_serpentmount_red",
+            "spellid": "275623"
+          },
+          {
+            "itemId": "163573",
+            "name": "Goldenmane's Reins",
+            "icon": "ability_mount_ridinghorse",
+            "spellid": "260175"
+          }
+        ]
+      },
+      {
+        "name": "Reputation",
+        "id": "b219cdc7",
+        "items": [
+          {
+            "itemId": "161911",
+            "name": "Reins of the Admiralty Stallion",
+            "icon": "ability_mount_ridinghorse",
+            "spellid": "259213"
+          },
+          {
+            "itemId": "161912",
+            "name": "Reins of the Dapple Gray",
+            "icon": "ability_mount_ridinghorse",
+            "spellid": "260172"
+          },
+          {
+            "itemId": "161910",
+            "name": "Reins of the Smoky Charger",
+            "icon": "ability_mount_ridinghorse",
+            "spellid": "260173"
+          },
+          {
+            "itemId": "161773",
+            "name": "Reins of the Alabaster Hyena",
+            "icon": "inv_hyena2mount_light",
+            "spellid": "237287"
+          },
+          {
+            "itemId": "161879",
+            "name": "Reins of the Proudmoore Sea Scout",
+            "icon": "inv_misc_elitegryphonarmored",
+            "spellid": "275868"
+          },
+          {
+            "itemId": "161909",
+            "name": "Reins of the Stormsong Coastwatcher",
+            "icon": "inv_misc_elitegryphonarmored",
+            "spellid": "275866"
+          },
+          {
+            "itemId": "161908",
+            "name": "Reins of the Dusky Waycrest Gryphon",
+            "icon": "inv_misc_elitegryphonarmored",
+            "spellid": "275859"
+          },
+          {
+            "itemId": "161774",
+            "name": "Reins of the Expedition Bloodswarmer",
+            "icon": "inv_bloodtrollbeast_mount",
+            "spellid": "275841"
+          },
+          {
+            "itemId": "161666",
+            "name": "Reins of the Armored Orange Pterrordax",
+            "icon": "inv_pterrordax2mount_orange",
+            "spellid": "275838"
+          },
+          {
+            "itemId": "161667",
+            "name": "Reins of the Armored Albino Pterrordax",
+            "icon": "inv_pterrordax2mount_white",
+            "spellid": "275840"
+          },
+          {
+            "itemId": "161665",
+            "name": "Reins of the Cobalt Pterrordax",
+            "icon": "inv_pterrordax2mount_blue",
+            "spellid": "275837"
+          },
+          {
+            "itemId": "161664",
+            "name": "Reins of the Armored Ebony Pterrordax",
+            "icon": "inv_pterrordax2mount_black",
+            "spellid": "244712"
+          }
+        ]
+      },
+      {
+        "name": "Unknown",
+        "id": "eba1d3de",
+        "items": [
+          {
+            "itemId": "156798",
+            "name": "The Hivemind",
+            "icon": "spell_shadow_brainwash",
+            "spellid": "261395",
+            "notObtainable": true
+          },
+          {
+            "itemId": "153594",
+            "spellid": "256123",
+            "icon": "inv_hovercraftmount",
+            "name": "Xiwyllag ATV",
+            "notObtainable": true
+          },
+          {
+            "itemId": "163183",
+            "spellid": "259740",
+            "icon": "ivn_toadloamount",
+            "name": "Spawn of Krag'wa",
+            "notObtainable": true
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Legion",
+    "subcats": [
+      {
+        "name": "Achievement",
+        "items": [
+          {
+            "spellid": "193007",
+            "itemId": "141216",
+            "icon": "inv_moosemount2nightmare"
+          },
+          {
+            "spellid": "215558",
+            "itemId": "138387",
+            "icon": "inv_ratmount"
+          },
+          {
+            "spellid": "225765",
+            "itemId": "141217",
+            "icon": "inv_mount_hippogryph_arcane"
+          },
+          {
+            "spellid": "193695",
+            "itemId": "129280",
+            "icon": "inv_alliancepvpmount",
+            "side": "A"
+          },
+          {
+            "spellid": "204166",
+            "itemId": "143864",
+            "icon": "ability_mount_hordepvpmount",
+            "side": "H"
+          },
+          {
+            "spellid": 253087,
+            "itemId": 152815,
+            "icon": "inv_felhound3_shadow_mount"
+          },
+          {
+            "spellid": 254260,
+            "itemId": 153041,
+            "icon": "inv_argustalbukmount_felred"
           }
         ],
         "id": "13a5b522"
@@ -152,36 +545,6 @@
             "spellid": "213115",
             "itemId": "137570",
             "icon": "inv_spidermount"
-          },
-          {
-            "spellid": 253007,
-            "itemId": 152797,
-            "icon": "inv_argustalbukmount_blue"
-          },
-          {
-            "spellid": 253006,
-            "itemId": 152793,
-            "icon": "inv_argustalbukmount_red"
-          },
-          {
-            "spellid": 253005,
-            "itemId": 152795,
-            "icon": "inv_argustalbukmount_green"
-          },
-          {
-            "spellid": 253004,
-            "itemId": 152794,
-            "icon": "inv_argustalbukmount_purple"
-          },
-          {
-            "spellid": 253008,
-            "itemId": 152796,
-            "icon": "inv_argustalbukmount_brown"
-          },
-          {
-            "spellid": 242305,
-            "itemId": 152791,
-            "icon": "inv_argustalbukmount_black"
           },
           {
             "spellid": 239013,
@@ -241,6 +604,42 @@
           }
         ],
         "id": "bc380747"
+      },
+      {
+        "name": "Reputation",
+        "id": "82bf985b",
+        "items": [
+          {
+            "spellid": 253007,
+            "itemId": 152797,
+            "icon": "inv_argustalbukmount_blue"
+          },
+          {
+            "spellid": 253006,
+            "itemId": 152793,
+            "icon": "inv_argustalbukmount_red"
+          },
+          {
+            "spellid": 253005,
+            "itemId": 152795,
+            "icon": "inv_argustalbukmount_green"
+          },
+          {
+            "spellid": 253004,
+            "itemId": 152794,
+            "icon": "inv_argustalbukmount_purple"
+          },
+          {
+            "spellid": 253008,
+            "itemId": 152796,
+            "icon": "inv_argustalbukmount_brown"
+          },
+          {
+            "spellid": 242305,
+            "itemId": 152791,
+            "icon": "inv_argustalbukmount_black"
+          }
+        ]
       },
       {
         "name": "Rare Spawn",
@@ -587,13 +986,6 @@
             "notObtainable": true
           },
           {
-            "spellid": "171845",
-            "itemId": "116788",
-            "icon": "inv_chopper_horde",
-            "notObtainable": true,
-            "side": "H"
-          },
-          {
             "spellid": "171632",
             "itemId": "116670",
             "icon": "inv_giantboarmount_brown"
@@ -608,18 +1000,6 @@
             "itemId": "116791",
             "icon": "inv_misc_pet_pandaren_yeti",
             "notObtainable": true
-          },
-          {
-            "spellid": "179245",
-            "itemId": "120968",
-            "icon": "inv_misc_key_06",
-            "side": "A"
-          },
-          {
-            "spellid": "179244",
-            "itemId": "122703",
-            "icon": "inv_misc_key_06",
-            "side": "H"
           },
           {
             "spellid": "186305",
@@ -648,12 +1028,6 @@
             "itemId": "116775",
             "icon": "ability_mount_talbukdraenormount",
             "side": "H"
-          },
-          {
-            "spellid": "171846",
-            "itemId": "116789",
-            "icon": "inv_chopper_alliance",
-            "side": "A"
           },
           {
             "spellid": "171625",
@@ -946,32 +1320,6 @@
           }
         ],
         "id": "bf2baf59"
-      },
-      {
-        "name": "Timewalking",
-        "items": [
-          {
-            "spellid": "142910",
-            "itemId": "129922",
-            "icon": "ability_mount_steelwarhorse"
-          },
-          {
-            "spellid": "194464",
-            "itemId": "129923",
-            "icon": "ability_hunter_pet_dragonhawk"
-          },
-          {
-            "spellid": "201098",
-            "itemId": "133543",
-            "icon": "achievement_boss_infinitecorruptor"
-          },
-          {
-            "spellid": 127165,
-            "itemId": 87775,
-            "icon": "ability_monk_summonserpentstatue"
-          }
-        ],
-        "id": "544f6a72"
       }
     ],
     "id": "7e3a5bf1"
@@ -2880,6 +3228,12 @@
             "spellid": "134359",
             "itemId": "95416",
             "icon": "ability_mount_shreddermount"
+          },
+          {
+            "itemId": "161134",
+            "name": "Mecha-Mogul Mk2",
+            "icon": "achievement_dungeon_mogulrazdunk",
+            "spellid": "261437"
           }
         ],
         "id": "5a9bbbf6"
@@ -2898,9 +3252,15 @@
             "icon": "ability_hunter_pet_turtle"
           },
           {
-            "spellid": 253711,
-            "itemId": 152912,
+            "spellid": "253711",
+            "itemId": "152912",
             "icon": "inv_ammo_bullet_07"
+          },
+          {
+            "itemId": "163131",
+            "name": "Great Sea Ray",
+            "icon": "inv_stingray2mount",
+            "spellid": "278803"
           }
         ],
         "id": "0583d5aa"
@@ -3134,6 +3494,34 @@
             "itemId": 152869,
             "icon": "inv_viciouswarfoxhorde",
             "side": "H"
+          },
+          {
+            "itemId": "163122",
+            "spellid": "261433",
+            "icon": "inv_viciouswarbasiliskalliance",
+            "name": "Vicious War Basilisk",
+            "side": "A"
+          },
+          {
+            "itemId": "163121",
+            "spellid": "261434",
+            "icon": "inv_viciouswarbasiliskhorde",
+            "name": "Vicious War Basilisk",
+            "side": "H"
+          },
+          {
+            "itemId": "163123",
+            "spellid": "272481",
+            "icon": "inv_viciousalliancehippo",
+            "name": "Vicious War Riverbeast",
+            "side": "A"
+          },
+          {
+            "itemId": "163124",
+            "spellid": "270560",
+            "icon": "inv_vicioushordeclefthoof",
+            "name": "Vicious War Clefthoof",
+            "side": "H"
           }
         ],
         "id": "2255b4f2"
@@ -3290,6 +3678,55 @@
             "spellid": 243201,
             "itemId": 153493,
             "notObtainable": true
+          },
+          {
+            "itemId": "156885",
+            "name": "Gold Gladiator's Proto-Drake",
+            "icon": "ability_mount_protodrakegladiatormount",
+            "spellid": "262028",
+            "notObtainable": true
+          },
+          {
+            "itemId": "156884",
+            "name": "Black Gladiator's Proto-Drake",
+            "icon": "ability_mount_protodrakegladiatormount",
+            "spellid": "262027",
+            "notObtainable": true
+          },
+          {
+            "itemId": "156883",
+            "name": "Green Gladiator's Proto-Drake",
+            "icon": "ability_mount_protodrakegladiatormount",
+            "spellid": "262026",
+            "notObtainable": true
+          },
+          {
+            "itemId": "156882",
+            "name": "Pale Gladiator's Proto-Drake",
+            "icon": "ability_mount_protodrakegladiatormount",
+            "spellid": "262025",
+            "notObtainable": true
+          },
+          {
+            "itemId": "156881",
+            "name": "Purple Gladiator's Proto-Drake",
+            "icon": "ability_mount_protodrakegladiatormount",
+            "spellid": "262024",
+            "notObtainable": true
+          },
+          {
+            "itemId": "156880",
+            "name": "Blue Gladiator's Proto-Drake",
+            "icon": "ability_mount_protodrakegladiatormount",
+            "spellid": "262023",
+            "notObtainable": true
+          },
+          {
+            "itemId": "156879",
+            "name": "Dread Gladiator's Proto-Drake",
+            "icon": "ability_mount_protodrakegladiatormount",
+            "spellid": "262022",
+            "notObtainable": true
           }
         ],
         "id": "deeb6401"
@@ -3311,7 +3748,7 @@
         "id": "5a77a53d"
       },
       {
-        "name": "Honor",
+        "name": "Mark of Honor",
         "items": [
           {
             "spellid": "23510",
@@ -3423,7 +3860,7 @@
         "id": "b5e5edfb"
       },
       {
-        "name": "Prestige",
+        "name": "Honor",
         "items": [
           {
             "spellid": "222202",
@@ -3438,26 +3875,28 @@
           {
             "spellid": "222240",
             "itemId": "140408",
-            "icon": "inv_horse2mountyellow",
-            "notObtainable": true
+            "icon": "inv_horse2mountyellow"
           },
           {
             "spellid": "222237",
             "itemId": "140232",
-            "icon": "inv_horse2mountgreen",
-            "notObtainable": true
+            "icon": "inv_horse2mountgreen"
           },
           {
             "spellid": "222241",
             "itemId": "140407",
-            "icon": "inv_horse2mountblack",
-            "notObtainable": true
+            "icon": "inv_horse2mountblack"
           },
           {
             "spellid": "222236",
             "itemId": "140230",
-            "icon": "inv_horse2mountpurple",
-            "notObtainable": true
+            "icon": "inv_horse2mountpurple"
+          },
+          {
+            "itemId": "164250",
+            "name": "Prestigious Bloodforged Courser",
+            "icon": "inv_horse2mountelite",
+            "spellid": "281044"
           }
         ],
         "id": "2dc780cd"
@@ -3500,32 +3939,6 @@
           }
         ],
         "id": "0b1cc64a"
-      },
-      {
-        "name": "Darkmoon Faire",
-        "items": [
-          {
-            "spellid": "102346",
-            "itemId": "72140",
-            "icon": "ability_hunter_pet_tallstrider"
-          },
-          {
-            "spellid": "103081",
-            "itemId": "73766",
-            "icon": "ability_hunter_pet_bear"
-          },
-          {
-            "spellid": "228919",
-            "itemId": "142398",
-            "icon": "inv_stingray2mount"
-          },
-          {
-            "spellid": 247448,
-            "itemId": 153485,
-            "icon": "inv_zeppelinmount"
-          }
-        ],
-        "id": "5c49f96a"
       },
       {
         "name": "Hallow's End",
@@ -3577,7 +3990,7 @@
         "id": "96c4a446"
       },
       {
-        "name": "Brawlers Guild",
+        "name": "Brawler's Guild",
         "items": [
           {
             "spellid": "142641",
@@ -3588,10 +4001,63 @@
           {
             "spellid": 230844,
             "itemId": 142403,
-            "icon": "inv_basaliskmount"
+            "icon": "inv_basaliskmount",
+            "notObtainable": true
           }
         ],
         "id": "6359899a"
+      },
+      {
+        "name": "Darkmoon Faire",
+        "items": [
+          {
+            "spellid": "102346",
+            "itemId": "72140",
+            "icon": "ability_hunter_pet_tallstrider"
+          },
+          {
+            "spellid": "103081",
+            "itemId": "73766",
+            "icon": "ability_hunter_pet_bear"
+          },
+          {
+            "spellid": "228919",
+            "itemId": "142398",
+            "icon": "inv_stingray2mount"
+          },
+          {
+            "spellid": 247448,
+            "itemId": 153485,
+            "icon": "inv_zeppelinmount"
+          }
+        ],
+        "id": "5c49f96a"
+      },
+      {
+        "name": "Timewalking",
+        "items": [
+          {
+            "spellid": "194464",
+            "itemId": "129923",
+            "icon": "ability_hunter_pet_dragonhawk"
+          },
+          {
+            "spellid": "142910",
+            "itemId": "129922",
+            "icon": "ability_mount_steelwarhorse"
+          },
+          {
+            "spellid": 127165,
+            "itemId": 87775,
+            "icon": "ability_monk_summonserpentstatue"
+          },
+          {
+            "spellid": "201098",
+            "itemId": "133543",
+            "icon": "achievement_boss_infinitecorruptor"
+          }
+        ],
+        "id": "544f6a72"
       }
     ],
     "id": "c405b7f1"
@@ -3670,8 +4136,9 @@
             "icon": "inv_shadowstalkerpanthermount"
           },
           {
-            "icon": "1795322",
-            "spellid": 259395
+            "icon": "inv_dogmount",
+            "spellid": 259395,
+            "itemId": 156564
           }
         ],
         "id": "a90a3293"
@@ -3732,7 +4199,8 @@
           {
             "spellid": "232405",
             "itemId": "143631",
-            "icon": "inv_firecatmount"
+            "icon": "inv_firecatmount",
+            "notObtainable": true
           }
         ],
         "id": "fcd49279"
@@ -3798,6 +4266,25 @@
           }
         ],
         "id": "3c7b97bc"
+      },
+      {
+        "name": "Azeroth Choppers",
+        "items": [
+          {
+            "spellid": "171846",
+            "itemId": "116789",
+            "icon": "inv_chopper_alliance",
+            "side": "A"
+          },
+          {
+            "spellid": "171845",
+            "itemId": "116788",
+            "icon": "inv_chopper_horde",
+            "notObtainable": true,
+            "side": "H"
+          }
+        ],
+        "id": "460fa3d3"
       },
       {
         "name": "Trading Card Game",


### PR DESCRIPTION
## Import method

This time it was a bit more complicated:

- I went on http://www.wowhead.com/news=281120/battle-for-azeroth-mount-models which has a nicely sorted list of mounts that is dynamically loaded in javascript
- I used the developer tools to inspect the DOM after the news article was loaded to get its HTML, pretty-printed it and saved it locally
- I adapted the script I used for the toys to get the initial list:

```bash
xmllint --html --xpath '(//a[starts-with(@href, '/item')] | //a[starts-with(@href, '/spell')] | //h2)' mountsbfa.html  |
  sed 's/\/\(a\|h2\)>/\/\1>\n/g' |
  grep 'item=\|h2\|spell= ' |
  grep -B1000 Removed |
  head -n-1 |
  sed 's#<a href="//bfa\.wowhead\.com/item=\([0-9]\+\)"[^>]\+><img src="//wow\.zamimg\.com/images/wow/icons/tiny/\([^.]\+\).gif"[^>]\+>&nbsp;<span class="tinyicontxt">\([^<]\+\).\+#\1 \2 \3#' |
  tr '\n' '\0' |
  xargs -0 -L1 -I {} zsh -c 'if echo "{}" | grep "^<h2" >/dev/null;
      then echo "{}" |
        sed "s#.\+>\([^<]\+\)<.\+#\1#" |
        read catg; echo "]}, {\"name\": \"$catg\", \"id\": \"$( echo $RANDOM | sha1sum | head -c8 )\", \"items\": [";
      else echo "{}" | read iid icon iname;
        echo "{\"itemId\": \"$iid\", \"name\": \"$iname\", \"icon\": \"$icon\", \"spellid\": \"$( curl -L -s http://www.wowhead.com/item=$iid |
          grep -o "Use: <a href=\"/spell=[0-9]\+" |
          head -n1 | cut -d= -f3 )\"},"; fi' |
  tail -c +5 |
  head -c -2 |
  python3 -c 'import sys; import json; print(json.dumps(eval("[" + sys.stdin.read() + "]}]"), indent=2))' > mountsbfa.json
```

- Once I had the initial list, I realized some mounts weren't there, so I used the WoWhead search with the filter "Added in patch 8.0.1": http://www.wowhead.com/mount-items?filter=82;2;80001
- I manually noted the IDs of the mounts that weren't in my initial list
- I wrote the following script that takes a list of IDs and generates the JSON list by doing requests to wowhead to get the spell ids, icons and names:

```bash
#!/bin/bash

set -e

echo '['
first=1
for iid in $*; do
    if [ "$first" -eq 1 ]; then
        first=0
    else
        echo ,
    fi
    tf=$( mktemp )
    curl -L -s "http://www.wowhead.com/item=$iid" > "$tf"
    spellid=$( grep -o "Use: <a href=\"/spell=[0-9]\+" "$tf" | head -n1 | cut -d= -f3 )
    icon=$( grep 'og:image' "$tf" | sed "s#.\+large/\([^.]\+\).jpg\".\+#\1#" )
    name=$( grep '<title>' "$tf" | sed "s#.\+title>\(.\+\) - Item.\+#\1#" )
    printf '  {"itemId": "%s", "spellid": "%s", "icon": "%s", "name": "%s"}' "$iid" "$spellid" "$icon" "$name"
    rm $tf
done
echo
echo ']'
```
- Some mounts like http://www.wowhead.com/item=163981/frenzied-feltalon don't have a SpellID set, so I had to search for the matching spell IDs in the wowhead DB and add them manually.

## Sorting details and main changes

- I added an "Unknown" category in the BFA section containing only items set to `notObtainable` for the mounts that we don't yet know how to get. It will therefore remain hidden for everyone while we figure out how to get them.
- I moved the "Collect 300 toys" mount to a new top-level subsection next to "Collect"
- I moved the "Collect 35 heirlooms" mount to another top-level subsection
- I added the "100 exalted reputations" mount to another top-level subsection
- I moved the allied races mounts from Legion/Achievements to a new subsection BFA/Allied Races. If Blizzard adds more allied races in the future, this subsection could be moved to the "Racial" section.
- I renamed the "Honor" subsection to "Mark of Honor"
- I renamed the "Prestige" subsection to "Honor"
- I removed the nonObtainable attribute of the prestige mounts
- I moved the Legion reputation mounts (tabulks) to their own category for better consistency
- I moved Timewalking in its own section in World Events
- I moved  both choppers in a new Promotions/Azeroth Choppers section
- I added the notObtainable property to the HotS promotion mount