### PR TITLE
mounts: properly sort PvP honor mounts

### DIFF
--- a/app/data/mounts.json
+++ b/app/data/mounts.json
@@ -3883,14 +3883,14 @@
             "icon": "inv_horse2mountgreen"
           },
           {
-            "spellid": "222241",
-            "itemId": "140407",
-            "icon": "inv_horse2mountblack"
-          },
-          {
             "spellid": "222236",
             "itemId": "140230",
             "icon": "inv_horse2mountpurple"
+          },
+          {
+            "spellid": "222241",
+            "itemId": "140407",
+            "icon": "inv_horse2mountblack"
           },
           {
             "itemId": "164250",


### PR DESCRIPTION
Currently the level 250 achievement is in between 125 and 150. Swap the
150 and 250 ones to have the proper ascending order.