### PR TITLE
Removed pets that never made it to Legion.

### DIFF
--- a/app/data/pets.json
+++ b/app/data/pets.json
@@ -1548,24 +1548,9 @@
             "icon": "ability_mount_blackpanther"
           },
           {
-            "spellid": "193279",
-            "itemId": "129108",
-            "icon": "inv_weapon_shortblade_70"
-          },
-          {
             "spellid": "193514",
             "itemId": "129208",
             "icon": "inv_misc_head_dragon_01"
-          },
-          {
-            "spellid": "210680",
-            "itemId": "136907",
-            "icon": "inv_giantboarmount_brown"
-          },
-          {
-            "spellid": "210679",
-            "itemId": "136906",
-            "icon": "inv_giantboarmount_brown"
           },
           {
             "spellid": "210675",


### PR DESCRIPTION
These three pets were present in the Legion Beta, but never made it live, and are thus unobtainable by players, creating unfillable gaps in our simple armory page.

For reference:
http://www.wowhead.com/item=129108/son-of-goredome
http://www.wowhead.com/item=136907/black-piglet
http://www.wowhead.com/item=136906/brown-piglet