### PR TITLE
mounts: added feature to toggle unobtainable mounts

### DIFF
--- a/app/data/mounts.json
+++ b/app/data/mounts.json
@@ -276,7 +276,7 @@
             "name": "Zandalari Direhorn",
             "icon": "inv_triceratopszandalari",
             "spellid": "263707",
-            "notObtainable": true,
+            "notIngame": true,
             "side": "H"
           }
         ]
@@ -373,42 +373,42 @@
             "itemId": "161879",
             "name": "Reins of the Proudmoore Sea Scout",
             "icon": "inv_misc_elitegryphonarmored",
-            "notObtainable": true,
+            "notIngame": true,
             "spellid": "275868"
           },
           {
             "itemId": "161909",
             "name": "Reins of the Stormsong Coastwatcher",
             "icon": "inv_misc_elitegryphonarmored",
-            "notObtainable": true,
+            "notIngame": true,
             "spellid": "275866"
           },
           {
             "itemId": "161908",
             "name": "Reins of the Dusky Waycrest Gryphon",
             "icon": "inv_misc_elitegryphonarmored",
-            "notObtainable": true,
+            "notIngame": true,
             "spellid": "275859"
           },
           {
             "itemId": "161666",
             "name": "Reins of the Armored Orange Pterrordax",
             "icon": "inv_pterrordax2mount_orange",
-            "notObtainable": true,
+            "notIngame": true,
             "spellid": "275838"
           },
           {
             "itemId": "161667",
             "name": "Reins of the Armored Albino Pterrordax",
             "icon": "inv_pterrordax2mount_white",
-            "notObtainable": true,
+            "notIngame": true,
             "spellid": "275840"
           },
           {
             "itemId": "161664",
             "name": "Reins of the Armored Ebony Pterrordax",
             "icon": "inv_pterrordax2mount_black",
-            "notObtainable": true,
+            "notIngame": true,
             "spellid": "244712"
           }
         ]
@@ -544,7 +544,7 @@
             "itemId": 166436,
             "name": "Sandy Nightsaber",
             "spellid": 288506,
-            "notObtainable": true
+            "notIngame": true
           },
           {
             "icon": "inv_chimera3",
@@ -663,14 +663,14 @@
             "spellid": "256123",
             "icon": "inv_hovercraftmount",
             "name": "Xiwyllag ATV",
-            "notObtainable": true
+            "notIngame": true
           },
           {
             "icon": "inv_hyena2mount_dark",
             "itemId": 166417,
             "name": "Onyx War Hyena",
             "spellid": 237288,
-            "notObtainable": true
+            "notIngame": true
           }
         ]
       }
@@ -3831,14 +3831,16 @@
             "spellid": "261433",
             "icon": "inv_viciouswarbasiliskalliance",
             "name": "Vicious War Basilisk",
-            "side": "A"
+            "side": "A",
+            "notIngame": true
           },
           {
             "itemId": "163121",
             "spellid": "261434",
             "icon": "inv_viciouswarbasiliskhorde",
             "name": "Vicious War Basilisk",
-            "side": "H"
+            "side": "H",
+            "notIngame": true
           },
           {
             "itemId": "163123",
@@ -3982,9 +3984,9 @@
             "notObtainable": true
           },
           {
-            "spellid": "227989",
-            "itemId": "141845",
-            "icon": "inv_stormdragonmount2dark",
+            "spellid": "227986",
+            "itemId": "141843",
+            "icon": "inv_stormdragonmount2",
             "notObtainable": true
           },
           {
@@ -3994,21 +3996,15 @@
             "notObtainable": true
           },
           {
+            "spellid": "227989",
+            "itemId": "141845",
+            "icon": "inv_stormdragonmount2dark",
+            "notObtainable": true
+          },
+          {
             "spellid": "227991",
             "itemId": "141846",
             "icon": "inv_stormdragonmount2green",
-            "notObtainable": true
-          },
-          {
-            "spellid": "227986",
-            "itemId": "141843",
-            "icon": "inv_stormdragonmount2",
-            "notObtainable": true
-          },
-          {
-            "spellid": "227995",
-            "itemId": "141848",
-            "icon": "inv_stormdragonmount2yellow",
             "notObtainable": true
           },
           {
@@ -4018,9 +4014,9 @@
             "notObtainable": true
           },
           {
-            "icon": "inv_stormdragonmount2_fel",
-            "spellid": 243201,
-            "itemId": 153493,
+            "spellid": "227995",
+            "itemId": "141848",
+            "icon": "inv_stormdragonmount2yellow",
             "notObtainable": true
           },
           {
@@ -4028,42 +4024,35 @@
             "name": "Gold Gladiator's Proto-Drake",
             "icon": "ability_mount_protodrakegladiatormount",
             "spellid": "262028",
-            "notObtainable": true
+            "notIngame": true
           },
           {
             "itemId": "156884",
             "name": "Black Gladiator's Proto-Drake",
             "icon": "ability_mount_protodrakegladiatormount",
             "spellid": "262027",
-            "notObtainable": true
+            "notIngame": true
           },
           {
             "itemId": "156883",
             "name": "Green Gladiator's Proto-Drake",
             "icon": "ability_mount_protodrakegladiatormount",
             "spellid": "262026",
-            "notObtainable": true
+            "notIngame": true
           },
           {
             "itemId": "156882",
             "name": "Pale Gladiator's Proto-Drake",
             "icon": "ability_mount_protodrakegladiatormount",
             "spellid": "262025",
-            "notObtainable": true
+            "notIngame": true
           },
           {
             "itemId": "156881",
             "name": "Purple Gladiator's Proto-Drake",
             "icon": "ability_mount_protodrakegladiatormount",
             "spellid": "262024",
-            "notObtainable": true
-          },
-          {
-            "itemId": "156880",
-            "name": "Blue Gladiator's Proto-Drake",
-            "icon": "ability_mount_protodrakegladiatormount",
-            "spellid": "262023",
-            "notObtainable": true
+            "notIngame": true
           },
           {
             "itemId": "156879",
@@ -4071,6 +4060,12 @@
             "icon": "ability_mount_protodrakegladiatormount",
             "spellid": "262022",
             "notObtainable": true
+          },
+          {
+            "itemId": "156880",
+            "name": "Sinister Gladiator's Proto-Drake",
+            "icon": "ability_mount_protodrakegladiatormount",
+            "spellid": "262023"
           }
         ],
         "id": "deeb6401"
@@ -4831,16 +4826,6 @@
             "spellid": "26656",
             "itemId": "21176",
             "icon": "inv_misc_qirajicrystal_05",
-            "notObtainable": true
-          },
-          {
-            "icon": "inv_misc_qirajicrystal_05",
-            "spellid": 25863,
-            "notObtainable": true
-          },
-          {
-            "icon": "inv_misc_qirajicrystal_05",
-            "spellid": 26655,
             "notObtainable": true
           },
           {

--- a/app/data/mounts.json
+++ b/app/data/mounts.json
@@ -623,6 +623,12 @@
             "itemId": 166471,
             "name": "Saltwater Seahorse",
             "spellid": 288711
+          },
+          {
+            "icon": "inv_vulturemount_alabatrosswhite",
+            "itemId": 166745,
+            "name": "Siltwing Albatross",
+            "spellid": 266925
           }
         ]
       },

--- a/app/data/planner.json
+++ b/app/data/planner.json
@@ -944,6 +944,36 @@
 					"steps": 
 					[
 						{
+							"title": "Run Battle of Dazar'alor",
+							"bosses":
+							[
+								{
+									"name":"High Tinker Mekkatorque",
+									"spellId":289083,
+									"itemId":166518,
+									"mount": "G.M.O.D.",
+									"epic": true,
+									"icon":"achievement_dungeon_coinoperatedcrowdpummeler"
+								},
+								{
+									"name":"Jaina Proudmoore",
+									"spellId":289555,
+									"itemId":166705,
+									"mount": "Glacial Tidestorm",
+									"epic": true,
+									"icon":"spell_frost_summonwaterelemental_2",
+									"note":"Mythic only"
+								}
+							]
+						}
+					]
+				},
+				{
+					"title":"Portal to Zandalar / Kul'Tiras",
+					"finalStep": "Hearthstone to Zandalar / Kul'Tiras",
+					"steps": 
+					[
+						{
 							"title": "Walk to Tiragarde Sound",
 							"steps": 
 							[

--- a/app/scripts/filters/filters.js
+++ b/app/scripts/filters/filters.js
@@ -1,3 +1,36 @@
 'use strict';
 
-/* Filters */
+(function() {
+    angular
+    	.module('simpleArmoryApp')
+        .filter('filterUnobtainables', filterUnobtainables);
+
+	/* Filters */
+	function filterUnobtainables() {
+
+		return function (category, unobtainable) {
+			var filteredCatergory = [];
+
+		    for(var i = 0; i < category.length; i++) {
+		    	if(!unobtainable) {
+					unobtainable = undefined;
+				}
+
+				// Proceed if some mounts in the sub-category are obtainable OR
+				// if every sub-category mount is unobtainable and the 'show unobtainables' option is enabled
+		    	if(
+		    		category[i].items.some(function(subCategory) { return subCategory.notObtainable === unobtainable || subCategory.collected; }) || 
+		    		category[i].items.every(function(subCategory) { return subCategory.notObtainable !== unobtainable; }) && 
+		    		unobtainable
+		    	) {	
+		    		// Proceed if all the mounts are currently in-game
+		    		if(category[i].items.some(function(subCategory) { return !subCategory.notIngame; })) {
+		    			filteredCatergory.push(category[i]);	
+		    		}	
+		    	}
+		    }
+
+		    return filteredCatergory;
+		};
+	}
+})();

--- a/app/scripts/services/mountsAndPets.service.js
+++ b/app/scripts/services/mountsAndPets.service.js
@@ -75,6 +75,8 @@
             var obj = { 'categories': [] };
             var collected = {};
             var totalCollected = 0;
+            var totalNotObtainableCollected = 0;
+            var totalNotObtainable = 0;
             var totalPossible = 0;
             var found = {};
 
@@ -223,11 +225,12 @@
 
                         // What would cause it to show up in the UI:
                         //    1) You have the item
-                        //    2) Its still obtainable 
+                        //    2) Its either obtainable or unobtainable 
                         //    3) You meet the class restriction
                         //    4) You meet the race restriction
+                        //    5) The item is currently in-game
                         var hasthis = itm.collected;
-                        var showthis = (hasthis || !item.notObtainable);
+                        var showthis = (hasthis || !item.notObtainable || item.notObtainable);
 
                         if (item.side && item.side !== character.faction) {
                             showthis = false;
@@ -261,10 +264,21 @@
                             }
                         }
 
+                        if (item.notIngame) {
+                            showthis = false;
+                        }
+
                         if (showthis) {
                             subCat.items.push(itm);
                             if (hasthis) {
                                 totalCollected++;
+                            }
+                            if(item.notObtainable) {
+                                if (hasthis) {
+                                    totalNotObtainableCollected++;
+                                }
+
+                                totalNotObtainable++;
                             }
 
                             totalPossible++;
@@ -289,6 +303,8 @@
 
             // Add totals
             obj.collected = totalCollected;
+            obj.notObtainable = totalNotObtainable;
+            obj.notObtainableCollected = totalNotObtainableCollected;
             obj.possible = totalPossible;
             obj.lookup = collected;
 

--- a/app/views/mounts.html
+++ b/app/views/mounts.html
@@ -2,19 +2,20 @@
   <div class="page-header">
     <h2>
         Mounts <small class="pbSmall"><input type="checkbox" id="planner" ng-model="showPlanner" ng-change="plannerChanged()"><label for="planner">Show Planner</label></small>
+		    <small class="pbSmall" ng-hide="showPlanner"><input type="checkbox" id="show-unobtainable" ng-model="unobtainable"><label for="show-unobtainable">Show Unobtainables</label></small>
     <div class="progress progressRight">
             <progressbar max="100" type="success"
-      	  		value="percent(items.collected, items.possible)" >
-      	  		<span>{{ achFormater(items.collected, items.possible) }}</span>
+      	  		value="percent((items.collected), unobtainable ? items.possible : items.possible - items.notObtainable)" >
+      	  		<span>{{ achFormater((items.collected), unobtainable ? items.possible : (items.possible - items.notObtainable) + items.notObtainableCollected) }}</span>
       	  	</progressbar>  	
         </div>
     </h2>
   </div>
   <div ng-hide="showPlanner">
     <h3 class="categoryHeader" ng-hide="category.name == 'Mounts'" ng-repeat-start="category in items.categories">{{ category.name }}</h3>
-    <div class="sect" ng-repeat="subCategory in category.subCategories">
+    <div class="sect" ng-repeat="subCategory in category.subCategories | filterUnobtainables:unobtainable">
   		<h5 class="subCatHeader">{{ subCategory.name }}</h5>
-  		<a target="{{settings.anchorTarget}}" ng-href="//{{settings.WowHeadUrl}}/{{ item.link }}" class="thumbnail" ng-repeat="item in subCategory.items" ng-class="{borderOn:!item.collected, borderOff:item.collected}">
+  		<a target="{{settings.anchorTarget}}" ng-href="//{{settings.WowHeadUrl}}/{{ item.link }}" class="thumbnail" ng-if="!item.notObtainable || item.notObtainable == unobtainable || item.collected" ng-repeat="item in subCategory.items" ng-class="{borderOn:!item.collected, borderOff:item.collected}">
           	<img ng-src="{{getImageSrc(item)}}">
         	</a>
     </div>


### PR DESCRIPTION
Added an option (checkbox) to show/hide unobtainable mounts. By default, every unobtainable mount that you own will be shown and any unobtainable mount that you don't own will be hidden.

I also added a `notIngame` property to the mounts in mounts.json to prevent them from being shown as they are not in-game.

I reordered some of the Gladiator mounts as they were not in chronological order.

Closes #100 