### PR TITLE
reputations: fixed exalted reputation row

### DIFF
--- a/app/scripts/services/factions.service.js
+++ b/app/scripts/services/factions.service.js
@@ -46,7 +46,7 @@
             angular.forEach(character.reputation, function(rep, index) {
                 standing[rep.id] = {
                     level: rep.standing,
-                    perc: (rep.value / rep.max) * 100,
+                    perc: (rep.standing == 7 ? 100 : (rep.value / rep.max) * 100),
                     value: rep.value,
                     max: rep.max
                 };

--- a/app/scripts/services/factions.service.js
+++ b/app/scripts/services/factions.service.js
@@ -44,9 +44,11 @@
 
             // Build up lookup for factions
             angular.forEach(character.reputation, function(rep, index) {
+                var calculatedPerc = (rep.value / rep.max) * 100;
+
                 standing[rep.id] = {
                     level: rep.standing,
-                    perc: (isNaN((rep.value / rep.max) * 100) ? 100 : (rep.value / rep.max) * 100),
+                    perc: (isNaN(calculatedPerc) ? 100 : calculatedPerc),
                     value: rep.value,
                     max: rep.max
                 };

--- a/app/scripts/services/factions.service.js
+++ b/app/scripts/services/factions.service.js
@@ -46,7 +46,7 @@
             angular.forEach(character.reputation, function(rep, index) {
                 standing[rep.id] = {
                     level: rep.standing,
-                    perc: (rep.standing == 7 ? 100 : (rep.value / rep.max) * 100),
+                    perc: (isNaN((rep.value / rep.max) * 100) ? 100 : (rep.value / rep.max) * 100),
                     value: rep.value,
                     max: rep.max
                 };


### PR DESCRIPTION
Apparently if a reputation is marked as 'Exalted' we do not show the exalted row, because the [perc](https://github.com/kevinclement/SimpleArmory/blob/1d9aee7664ef7e327076ac1ace2747c4de56130e/app/scripts/services/factions.service.js#L49) property would return `NaN`, as `0 / 0 = NaN`.

For reference, it should look like this:
![exalted-row](https://user-images.githubusercontent.com/27146982/52313819-4b8c9c80-29b0-11e9-96d2-264383257332.PNG)
