### PR TITLE
fixed armory url

### DIFF
--- a/app/scripts/controllers/application.controller.js
+++ b/app/scripts/controllers/application.controller.js
@@ -33,6 +33,8 @@
                 LoginService.getCharacter({'region': rgr[1], 'realm':rgr[2], 'character':rgr[3]})
                     .then(function(character) {
                         $scope.character = character;
+                        $scope.region = rgr[1];
+                        $scope.realm = rgr[2];
                         $scope.isLoggedIn = true;
                 });
             }

--- a/app/scripts/controllers/header.controller.js
+++ b/app/scripts/controllers/header.controller.js
@@ -7,9 +7,9 @@
         .controller('HeaderCtrl' , HeaderCtrl);
 
     function HeaderCtrl($scope, $location) {
-     
+
         $scope.isCollapsed = true;
-        
+
         $scope.getUrl = function(subSite) {
             var url = '#' + getBaseUrl($scope.character);
             if (subSite !== '') {
@@ -22,7 +22,7 @@
         $scope.isActive = function (viewLocation, subMenu) {
 
             // if its a submenu search, then just look for the location in the url
-            // and call it good      
+            // and call it good
             if (subMenu) {
                 return $location.path().indexOf(viewLocation) > 0;
             }
@@ -31,7 +31,7 @@
             var combinedUrl = getBaseUrl($scope.character);
             if (viewLocation !== '') {
                 combinedUrl += '/' + viewLocation;
-            } 
+            }
 
             return $location.path() === combinedUrl;
         };
@@ -50,26 +50,26 @@
                 return window.location.protocol + '//render-' + c.region + '.worldofwarcraft.com/character/' + c.thumbnail;
             }
 
-            return '';   
+            return '';
         };
 
         $scope.armoryUrl = function() {
             if ($scope.character) {
                 var c = $scope.character;
-                return window.location.protocol + '//' + 
-                       c.region + '.battle.net/wow/en/character/' + c.realm + '/' + c.name.toLowerCase() + '/advanced';
+                return window.location.protocol + '//' +
+                    'worldofwarcraft.com/character/' + c.region + '/' + $scope.$parent.realm + '/' + c.name.toLowerCase();
             }
 
-            return '#';   
+            return '#';
         };
 
-        function getBaseUrl(character) {    
+        function getBaseUrl(character) {
             if (!character) {
                 return '';
             }
 
-            return '/' + character.region.toLowerCase() + '/' + 
-                   character.realm.toLowerCase()  + '/' + 
+            return '/' + character.region.toLowerCase() + '/' +
+                   character.realm.toLowerCase()  + '/' +
                    character.name.toLowerCase();
         }
     }


### PR DESCRIPTION
The armory url in the top right dropdown does not work (it is now worldofwarcraft.com not battle.net). There are also some edge cases that didn't work. Example:

https://simplearmory.com/#/eu/anubarak/Linero

The armory url from that character wouldn't work because of the realm name (`HeaderCtrl` used the display name). I added realm and region to the `$scope` of `ApplicationCtrl` and accessed it via `$scope.$parent` in `HeaderCtrl`.

Since worldofwarcraft.com defaults to my local language it needs some additional manual testing.