### PR TITLE
Swap Factions On Season 4 Mounts

### DIFF
--- a/app/data/mounts.json
+++ b/app/data/mounts.json
@@ -4201,14 +4201,14 @@
             "icon": "inv_skeletalwarhorse_01_purple",
             "itemId": 173713,
             "name": "Vicious White Bonesteed",
-            "side": "A",
+            "side": "H",
             "spellid": 281889
           },
           {
             "icon": "ability_mount_warnightsaber",
             "itemId": 173714,
             "name": "Vicious White Warsaber",
-            "side": "H",
+            "side": "A",
             "spellid": 281888
           }
         ]

--- a/app/data/mounts.json
+++ b/app/data/mounts.json
@@ -4174,6 +4174,7 @@
             "spellid": "272481",
             "icon": "inv_viciousalliancehippo",
             "name": "Vicious War Riverbeast",
+            "notObtainable": true,
             "side": "A"
           },
           {
@@ -4181,6 +4182,7 @@
             "spellid": "270560",
             "icon": "inv_vicioushordeclefthoof",
             "name": "Vicious War Clefthoof",
+            "notObtainable": true,
             "side": "H"
           },
           {
@@ -4188,6 +4190,7 @@
             "itemId": 165019,
             "name": "Vicious Black Warsaber",
             "side": "A",
+            "notObtainable": true,
             "spellid": 281887
           },
           {
@@ -4195,6 +4198,7 @@
             "itemId": 165020,
             "name": "Vicious Black Bonesteed",
             "side": "H",
+            "notObtainable": true,
             "spellid": 281890
           },
           {


### PR DESCRIPTION
Addresses issue #211. Also marks the BFA season 2 and 3 mounts as unobtainable as they cannot be purchased with a vicious saddle yet.