### PR TITLE
Fixing a few promotional pets

### DIFF
--- a/app/data/pets.json
+++ b/app/data/pets.json
@@ -5808,6 +5808,7 @@
           {
             "creatureId": 34930,
             "icon": "inv_misc_gem_stone_01",
+            "itemId": "46894",
             "spellid": "66520"
           },
           {
@@ -5819,13 +5820,14 @@
           {
             "creatureId": 36910,
             "icon": "inv_jewelcrafting_gem_06",
+            "itemId": "49664",
             "spellid": "69539"
           },
           {
             "creatureId": 157524,
-            "icon": "inv_marmosetpet",
-            "name": "Rikki",
-            "spellid": 307264
+            "icon": "2991181",
+            "itemId": "173296",
+            "spellid": "307264"
           }
         ],
         "name": "Recruit-A-Friend"
@@ -6081,7 +6083,7 @@
           {
             "creatureId": 91226,
             "icon": "inv_gravegolempet",
-            "itemId": "122477",
+            "itemId": "118518",
             "spellid": "181086"
           }
         ],

--- a/app/data/pets.json
+++ b/app/data/pets.json
@@ -5803,25 +5803,29 @@
             "creatureId": 25146,
             "icon": "inv_misc_coin_01",
             "itemId": "34518",
-            "spellid": "45174"
+            "spellid": "45174",
+            "notObtainable": true
           },
           {
             "creatureId": 34930,
             "icon": "inv_misc_gem_stone_01",
             "itemId": "46894",
-            "spellid": "66520"
+            "spellid": "66520",
+            "notObtainable": true
           },
           {
             "creatureId": 25147,
             "icon": "inv_misc_coin_03",
             "itemId": "34519",
-            "spellid": "45175"
+            "spellid": "45175",
+            "notObtainable": true
           },
           {
             "creatureId": 36910,
             "icon": "inv_jewelcrafting_gem_06",
             "itemId": "49664",
-            "spellid": "69539"
+            "spellid": "69539",
+            "notObtainable": true
           },
           {
             "creatureId": 157524,


### PR DESCRIPTION
Switches the HotS pet item from My Special Pet to Graves (blizzard switched this at some point and wowhead incorrectly has Graves as unobtainable).
Added item ids for the following Recruit-A-Friend pets: Rikki, Jade Tiger, Zipao Tiger
Marks the old Recruit-A-Friend pets as unobtainable since they're no longer obtainable as of 8.2.5