### PR TITLE
Lowercase character name when loading data from blizzard API

### DIFF
--- a/app/scripts/controllers/login.controller.js
+++ b/app/scripts/controllers/login.controller.js
@@ -60,7 +60,7 @@
             $modalInstance.close({
                 'region': $scope.selectedRealm.selected.region,
                 'realm': $scope.selectedRealm.selected.slug,
-                'character': $scope.characterName
+                'character': $scope.characterName.toLowerCase() // Blizzard API doesn't place nice with chars like Ä at start of names
             });
         };
     }


### PR DESCRIPTION
Came across this bug trying to load data for my character, Ägiel. From doing a little digging it looks like Blizzard's API 404s for Ägiel but is fine with ägiel. Allowing users to put in a capital first letter while still giving them their results would improve UX, as names are autocapitalized in WoW generally. Let me know if there's a better place in the code to make the change, and thank you for making the site!