### PR TITLE
fix: re-seed EU server names to include accents in slug.

### DIFF
--- a/app/data/servers.eu.json
+++ b/app/data/servers.eu.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "Aggra (Português)",
-      "slug": "aggra-portugues"
+      "slug": "aggra-português"
     },
     {
       "name": "Aggramar",
@@ -214,7 +214,7 @@
     },
     {
       "name": "Chants éternels",
-      "slug": "chants-eternels"
+      "slug": "chants-éternels"
     },
     {
       "name": "Cho'gall",
@@ -230,7 +230,7 @@
     },
     {
       "name": "Confrérie du Thorium",
-      "slug": "confrerie-du-thorium"
+      "slug": "confrérie-du-thorium"
     },
     {
       "name": "Conseil des Ombres",
@@ -434,7 +434,7 @@
     },
     {
       "name": "Festung der Stürme",
-      "slug": "festung-der-sturme"
+      "slug": "festung-der-stürme"
     },
     {
       "name": "Fordragon",
@@ -610,7 +610,7 @@
     },
     {
       "name": "La Croisade écarlate",
-      "slug": "la-croisade-ecarlate"
+      "slug": "la-croisade-écarlate"
     },
     {
       "name": "Laughing Skull",
@@ -678,7 +678,7 @@
     },
     {
       "name": "Marécage de Zangar",
-      "slug": "marecage-de-zangar"
+      "slug": "marécage-de-zangar"
     },
     {
       "name": "Mazrigos",
@@ -766,7 +766,7 @@
     },
     {
       "name": "Pozzo dell'Eternità",
-      "slug": "pozzo-delleternita"
+      "slug": "pozzo-delleternità"
     },
     {
       "name": "Proudmoore",


### PR DESCRIPTION
I've ran servers_fixer_bnet.py locally to update server slugs. I was able to find my character:

Current - No Bueno:
https://simplearmory.com/#/eu/aggra-portugues/advokate

Updated - Works:
https://simplearmory.com/#/eu/aggra-portugu%C3%AAs/advokate

Also tested for a few other characters on french realms

fixes #245 
