### PR TITLE
prepatch mount fixes

### DIFF
--- a/app/data/mounts.json
+++ b/app/data/mounts.json
@@ -5615,31 +5615,36 @@
             "ID": "224",
             "icon": "ability_mount_charger",
             "itemId": "37719",
-            "spellid": "49322"
+            "spellid": "49322",
+            "notObtainable": true
           },
           {
             "ID": "382",
             "icon": "ability_mount_rocketmount2",
             "itemId": "54860",
-            "spellid": "75973"
+            "spellid": "75973",
+            "notObtainable": true
           },
           {
             "ID": "455",
             "icon": "inv_misc_reforgedarchstone_01",
             "itemId": "83086",
-            "spellid": "121820"
+            "spellid": "121820",
+            "notObtainable": true
           },
           {
             "ID": "568",
             "icon": "inv_misc_elitehippogryph",
             "itemId": "106246",
-            "spellid": "149801"
+            "spellid": "149801",
+            "notObtainable": true
           },
           {
             "ID": "454",
             "icon": "inv_lavahorse",
             "itemId": "118515",
-            "spellid": "171847"
+            "spellid": "171847",
+            "notObtainable": true
           },
           {
             "ID": "1288",

--- a/app/data/mounts.json
+++ b/app/data/mounts.json
@@ -262,13 +262,6 @@
             "spellid": "279474"
           },
           {
-            "ID": "1039",
-            "icon": "inv_brontosaurusmount",
-            "itemId": "163042",
-            "name": "Reins of the Mighty Caravan Brutosaur",
-            "spellid": "264058"
-          },
-          {
             "ID": "1262",
             "icon": "ability_mount_seahorse",
             "itemId": 169203,
@@ -6047,6 +6040,13 @@
             "icon": "ability_mount_drake_proto",
             "itemId": "44175",
             "spellid": "60021"
+          },
+          {
+            "ID": "1039",
+            "icon": "inv_brontosaurusmount",
+            "itemId": "163042",
+            "name": "Reins of the Mighty Caravan Brutosaur",
+            "spellid": "264058"
           }
         ],
         "name": "BMAH"


### PR DESCRIPTION
This PR fixes two open issues:

* #289: I moved the brutosaur mount to BMAH and upgraded it to a section instead of a subsection, because I also added mounts from these lists:
  * https://www.warcraftmounts.com/bmah.php
  * https://www.wowhead.com/news=318099/black-market-auction-house-location-in-shadowlands
* #285: I marked the old RAF mounts as unobtainable

I've done this by hand for now.