### PR TITLE
fix broken character avatar image because of 9.0.1 API changes

### DIFF
--- a/app/scripts/controllers/application.controller.js
+++ b/app/scripts/controllers/application.controller.js
@@ -40,7 +40,12 @@
 
                     // fetch the profile image for the header as a seperate call as to not block initial render
                     LoginService.getProfileMedia({'region': rgr[1], 'realm':rgr[2], 'character':rgr[3]}).then(function(pMedia) {
-                        $scope.characterMedia = pMedia.data.avatar_url;
+                        var avatarFallback = '?alt=/shadow/avatar/1-1.jpg';
+                        if(pMedia.data.avatar_url) {
+                            $scope.characterMedia = pMedia.data.avatar_url + avatarFallback
+                        } else {
+                            $scope.characterMedia = pMedia.data.assets[0].value + avatarFallback;
+                        }
                     });
                 });
             }


### PR DESCRIPTION
The battle.net API changed how character media is handled. This change either returns the old `avatar_url` (existing on chars that have not logged into wow since the patch) or the avatar from the new `assets` array. If neither of these images exist the battle.net API will always return a shadow fallback image (set by the query parameter).

More details: 
* [Shadowlands API Changes](https://us.forums.blizzard.com/en/blizzard/t/api-changes-wow-shadowlands-pre-patch/11826) 
* [Character Renders Documentation](https://develop.battle.net/documentation/world-of-warcraft/guides/character-renders)