### PR TITLE
fix alignment of achievement overview

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -75,13 +75,6 @@ body {
     }
 }
 
-.achGrid {
-    float:left;
-    display: block;
-    width: 220px;
-    margin-right:20px;
-}
-
 /* ## Header ############################### */
 .navbar {
     min-height:0px !important;

--- a/app/views/overview.html
+++ b/app/views/overview.html
@@ -1,142 +1,159 @@
 <div class="container">
-  <!-- Progress Overview -->
-  <div class="page-header">
-    <h2>Progress Overview</h2>
-  </div>
-  <strong class="desc">Total Complete</strong>
-  <div class="progress">
-  	<progressbar max="100" value="percent(achievements.completed, achievements.possible)" type="success"><span>{{ achFormater(achievements.completed, achievements.possible) }}</span></progressbar>  		
-  </div>
-
-
-
-  <div class="achGrid">
-    <strong class="desc">Character</strong>
-    <div class="progress">
-      <a ng-href="{{baseUrl}}/achievements/character">
-        <progressbar max="100" type="success"
-        	  value="percent(achievements['Character'].completed, achievements['Character'].possible)" ><span>{{ achFormater(achievements['Character'].completed, achievements['Character'].possible) }}</span></progressbar>  		
-      </a>
+    <!-- Progress Overview -->
+    <div class="page-header">
+        <h2>Progress Overview</h2>
     </div>
-  </div>
-
-  <div class="achGrid">
-    <strong class="desc">Quests</strong>
+    <strong class="desc">Total Complete</strong>
     <div class="progress">
-      <a ng-href="{{baseUrl}}/achievements/quests">
-        <progressbar max="100" type="success"
-        	  value="percent(achievements['Quests'].completed, achievements['Quests'].possible)" ><span>{{ achFormater(achievements['Quests'].completed, achievements['Quests'].possible) }}</span></progressbar>
-      </a>
+        <progressbar max="100" value="percent(achievements.completed, achievements.possible)" type="success">
+            <span>
+                {{ achFormater(achievements.completed, achievements.possible) }}
+            </span>
+        </progressbar>
     </div>
-  </div>
 
- <div class="achGrid">
-    <strong class="desc">Exploration</strong>
-    <div class="progress">
-      <a ng-href="{{baseUrl}}/achievements/exploration">
-	      <progressbar max="100" type="success"
-      	  value="percent(achievements['Exploration'].completed, achievements['Exploration'].possible)" ><span>{{ achFormater(achievements['Exploration'].completed, achievements['Exploration'].possible) }}</span></progressbar>  	
-      </a>
+    <div class="row">
+        <div class="col-xs-12 col-sm-4">
+            <strong class="desc">Character</strong>
+            <div class="progress">
+                <a ng-href="{{baseUrl}}/achievements/character">
+                    <progressbar max="100" type="success" value="percent(achievements['Character'].completed, achievements['Character'].possible)">
+                        <span>{{ achFormater(achievements['Character'].completed, achievements['Character'].possible) }}</span>
+                    </progressbar>
+                </a>
+            </div>
+        </div>
+        <div class="col-xs-12 col-sm-4">
+            <strong class="desc">Quests</strong>
+            <div class="progress">
+                <a ng-href="{{baseUrl}}/achievements/quests">
+                    <progressbar max="100" type="success" value="percent(achievements['Quests'].completed, achievements['Quests'].possible)">
+                        <span>{{ achFormater(achievements['Quests'].completed, achievements['Quests'].possible) }}</span>
+                    </progressbar>
+                </a>
+            </div>
+        </div>
+        <div class="col-xs-12 col-sm-4">
+            <strong class="desc">Exploration</strong>
+            <div class="progress">
+                <a ng-href="{{baseUrl}}/achievements/exploration">
+                    <progressbar max="100" type="success" value="percent(achievements['Exploration'].completed, achievements['Exploration'].possible)">
+                        <span>{{ achFormater(achievements['Exploration'].completed, achievements['Exploration'].possible) }}</span>
+                    </progressbar>
+                </a>
+            </div>
+        </div>
     </div>
-  </div>
 
- <div class="achGrid">
-    <strong class="desc">Player vs. Player</strong>
-    <div class="progress">
-      <a ng-href="{{baseUrl}}/achievements/pvp">
-	     <progressbar max="100" type="success"
-      	  value="percent(achievements['Player vs. Player'].completed, achievements['Player vs. Player'].possible)" ><span>{{ achFormater(achievements['Player vs. Player'].completed, achievements['Player vs. Player'].possible) }}</span></progressbar>
-      </a>
+    <div class="row">
+        <div class="col-xs-12 col-sm-4">
+            <strong class="desc">Player vs. Player</strong>
+            <div class="progress">
+                <a ng-href="{{baseUrl}}/achievements/pvp">
+                    <progressbar max="100" type="success" value="percent(achievements['Player vs. Player'].completed, achievements['Player vs. Player'].possible)">
+                        <span>{{ achFormater(achievements['Player vs. Player'].completed, achievements['Player vs. Player'].possible) }}</span>
+                    </progressbar>
+                </a>
+            </div>
+        </div>
+        <div class="col-xs-12 col-sm-4">
+            <strong class="desc">Dungeons & Raids</strong>
+            <div class="progress">
+                <a ng-href="{{baseUrl}}/achievements/dungeons">
+                    <progressbar max="100" type="success" value="percent(achievements['Dungeons & Raids'].completed, achievements['Dungeons & Raids'].possible)">
+                        <span>{{ achFormater(achievements['Dungeons & Raids'].completed, achievements['Dungeons & Raids'].possible) }}</span>
+                    </progressbar>
+                </a>
+            </div>
+        </div>
+        <div class="col-xs-12 col-sm-4">
+            <strong class="desc">Professions</strong>
+            <div class="progress">
+                <a ng-href="{{baseUrl}}/achievements/professions">
+                    <progressbar max="100" type="success" value="percent(achievements['Professions'].completed, achievements['Professions'].possible)">
+                        <span>{{ achFormater(achievements['Professions'].completed, achievements['Professions'].possible) }}</span>
+                    </progressbar>
+                </a>
+            </div>
+        </div>
     </div>
-  </div>
 
-  <div class="achGrid">
-    <strong class="desc">Dungeons & Raids</strong>
-    <div class="progress">
-      <a ng-href="{{baseUrl}}/achievements/dungeons">    
-	      <progressbar max="100" type="success"
-      	  value="percent(achievements['Dungeons & Raids'].completed, achievements['Dungeons & Raids'].possible)" ><span>{{ achFormater(achievements['Dungeons & Raids'].completed, achievements['Dungeons & Raids'].possible) }}</span></progressbar>  	
-      </a>          
+    <div class="row">
+        <div class="col-xs-12 col-sm-4">
+            <strong class="desc">Reputation</strong>
+            <div class="progress">
+                <a ng-href="{{baseUrl}}/achievements/reputation">
+                    <progressbar max="100" type="success" value="percent(achievements['Reputation'].completed, achievements['Reputation'].possible)">
+                        <span>{{ achFormater(achievements['Reputation'].completed, achievements['Reputation'].possible) }}</span>
+                    </progressbar>
+                </a>
+            </div>
+        </div>
+        <div class="col-xs-12 col-sm-4">
+            <strong class="desc">World Events</strong>
+            <div class="progress">
+                <a ng-href="{{baseUrl}}/achievements/events">
+                    <progressbar max="100" type="success" value="percent(achievements['World Events'].completed, achievements['World Events'].possible)">
+                        <span>{{ achFormater(achievements['World Events'].completed, achievements['World Events'].possible) }}</span>
+                    </progressbar>
+                </a>
+            </div>
+        </div>
+        <div class="col-xs-12 col-sm-4">
+            <strong class="desc">Pet Battles</strong>
+            <div class="progress">
+                <a ng-href="{{baseUrl}}/achievements/pets">
+                    <progressbar max="100" type="success" value="percent(achievements['Pet Battles'].completed, achievements['Pet Battles'].possible)">
+                        <span>{{ achFormater(achievements['Pet Battles'].completed, achievements['Pet Battles'].possible) }}</span>
+                    </progressbar>
+                </a>
+            </div>
+        </div>
     </div>
-  </div>
 
-  <div class="achGrid">
-    <strong class="desc">Professions</strong>
-    <div class="progress">
-      <a ng-href="{{baseUrl}}/achievements/professions">    
-	      <progressbar max="100" type="success"
-      	  value="percent(achievements['Professions'].completed, achievements['Professions'].possible)" ><span>{{ achFormater(achievements['Professions'].completed, achievements['Professions'].possible) }}</span></progressbar>  	
-      </a>          
+    <div class="row">
+        <div class="col-xs-12 col-sm-4">
+            <strong class="desc">Collections</strong>
+            <div class="progress">
+                <a ng-href="{{baseUrl}}/achievements/collections">
+                    <progressbar max="100" type="success" value="percent(achievements['Collections'].completed, achievements['Collections'].possible)">
+                        <span>{{ achFormater(achievements['Collections'].completed, achievements['Collections'].possible) }}</span>
+                    </progressbar>
+                </a>
+            </div>
+        </div>
+        <div class="col-xs-12 col-sm-4">
+            <strong class="desc">Expansion Features</strong>
+            <div class="progress">
+                <a ng-href="{{baseUrl}}/achievements/expansions">
+                    <progressbar max="100" type="success" value="percent(achievements['Expansion Features'].completed, achievements['Expansion Features'].possible)">
+                        <span>{{ achFormater(achievements['Expansion Features'].completed, achievements['Expansion Features'].possible) }}</span>
+                    </progressbar>
+                </a>
+            </div>
+        </div>
+        <div class="col-xs-12 col-sm-4">
+            <strong class="desc">Legacy</strong>
+            <div class="progress">
+                <a ng-href="{{baseUrl}}/achievements/legacy">
+                    <progressbar max="100" type="success" value="100">
+                        <span>{{achievements['Legacy'].legacyTotal}}</span>
+                    </progressbar>
+                </a>
+            </div>
+        </div>
     </div>
-  </div>
 
-  <div class="achGrid">
-    <strong class="desc">Reputation</strong>
-    <div class="progress">
-      <a ng-href="{{baseUrl}}/achievements/reputation">    
-	      <progressbar max="100" type="success"
-      	  value="percent(achievements['Reputation'].completed, achievements['Reputation'].possible)" ><span>{{ achFormater(achievements['Reputation'].completed, achievements['Reputation'].possible) }}</span></progressbar>  	
-      </a>          
+    <div class="row">
+        <div class="col-xs-12 col-sm-4">
+            <strong class="desc">Feats of Strength</strong>
+            <div class="progress">
+                <a ng-href="{{baseUrl}}/achievements/feats">
+                    <progressbar max="100" type="success" value="100">
+                        <span>{{achievements['Feats of Strength'].foSTotal}}</span>
+                    </progressbar>
+                </a>
+            </div>
+        </div>
     </div>
-  </div>
-
-  <div class="achGrid">
-    <strong class="desc">World Events</strong>
-    <div class="progress">
-      <a ng-href="{{baseUrl}}/achievements/events">    
-	      <progressbar max="100" type="success"
-      	  value="percent(achievements['World Events'].completed, achievements['World Events'].possible)" ><span>{{ achFormater(achievements['World Events'].completed, achievements['World Events'].possible) }}</span></progressbar> 
-      </a>          
-    </div>
-  </div>
-
-  <div class="achGrid">
-    <strong class="desc">Pet Battles</strong>
-    <div class="progress">
-      <a ng-href="{{baseUrl}}/achievements/pets">    
-	      <progressbar max="100" type="success"
-      	  value="percent(achievements['Pet Battles'].completed, achievements['Pet Battles'].possible)" ><span>{{ achFormater(achievements['Pet Battles'].completed, achievements['Pet Battles'].possible) }}</span></progressbar> 
-      </a>          
-    </div>
-  </div>
-
-  <div class="achGrid">
-    <strong class="desc">Collections</strong>
-    <div class="progress">
-      <a ng-href="{{baseUrl}}/achievements/collections">    
-        <progressbar max="100" type="success"
-          value="percent(achievements['Collections'].completed, achievements['Collections'].possible)" ><span>{{ achFormater(achievements['Collections'].completed, achievements['Collections'].possible) }}</span></progressbar> 
-      </a>          
-    </div>
-  </div>
-
-  <div class="achGrid">
-    <strong class="desc">Expansion Features</strong>
-    <div class="progress">
-      <a ng-href="{{baseUrl}}/achievements/expansions">    
-        <progressbar max="100" type="success"
-          value="percent(achievements['Expansion Features'].completed, achievements['Expansion Features'].possible)" ><span>{{ achFormater(achievements['Expansion Features'].completed, achievements['Expansion Features'].possible) }}</span></progressbar> 
-      </a>          
-    </div>
-  </div>
-
-  <div class="achGrid">
-    <strong class="desc">Legacy</strong>
-    <div class="progress">
-      <a ng-href="{{baseUrl}}/achievements/legacy">    
-        <progressbar max="100" type="success"
-          value="100" ><span>{{achievements['Legacy'].legacyTotal}}</span></progressbar> 
-      </a>          
-    </div>
-  </div>
-
-  <div class="achGrid">
-    <strong class="desc">Feats of Strength</strong>
-    <div class="progress">
-      <a ng-href="{{baseUrl}}/achievements/feats">    
-	      <progressbar max="100" type="success"
-      	  value="100" ><span>{{achievements['Feats of Strength'].foSTotal}}</span></progressbar> 
-      </a>          
-    </div>
-  </div>
-</div> 
+</div>


### PR DESCRIPTION
Looking at the overview, I noticed that the alignment of the achievement rows and "total completed row" is off. You can see a lot of space on the right ([Example](https://simplearmory.com/#/eu/anubarak/linero) - next to "Player vs. Player", "World Events", ...). This change removes the old grid class and uses the responsive grid already provided by bootstrap to fix this.

Note: I only changed the classes and fixed the indentation. Thats why it looks all red in the changes.

Edit:
* new version: https://deploy-preview-295--simplearmory.netlify.app/#/eu/anubarak/linero
* old version: https://simplearmory.com/#/eu/anubarak/linero