### PR TITLE
Fix mount_fixer.py

### DIFF
--- a/data_scripts/bnet.py
+++ b/data_scripts/bnet.py
@@ -2,14 +2,14 @@ import asyncio
 import aiohttp
 from aiohttp.helpers import BasicAuth
 from urllib.parse import urljoin
-from settings import OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, OAUTH_REGION
+from settings import OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, OAUTH_REGION, NAMESPACE, LOCALE
 
 
 class BnetClient:
     def __init__(self):
         self.access_token = None
         self.session = aiohttp.ClientSession()
-        self.bliz_url = 'https://{}.battle.net/'.format(OAUTH_REGION)
+        self.battle_net_url = 'https://{}.battle.net/'.format(OAUTH_REGION)
         self.api_url = 'https://{}.api.blizzard.com/'
 
     async def __aenter__(self):
@@ -21,69 +21,102 @@ class BnetClient:
         await self.session.__aexit__(exc_type, exc_value, tb)
 
     async def get_access_token(self):
-        r = await self.session.post(self.bliz_url + 'oauth/token',
-                                    auth=BasicAuth(OAUTH_CLIENT_ID,
-                                                   OAUTH_CLIENT_SECRET),
-                                    data={'grant_type': 'client_credentials'})
-        return (await r.json())['access_token']
+        """Returns a new access token for the battle.net API"""
+        response = await self.session.post(
+            self.battle_net_url + 'oauth/token',
+            auth=BasicAuth(OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET),
+            data={'grant_type': 'client_credentials'}
+        )
+        return (await response.json())['access_token']
 
     async def login(self):
+        """Tries to get a new access token"""
         if self.access_token is None:
             self.access_token = await self.get_access_token()
 
-    async def query(self, path, region='us', **kwargs):
+    async def query(self, path, region='eu', **kwargs):
+        """Queries the battle.net API"""
         url = urljoin(self.api_url, path).format(region)
         headers = {
-            'Authorization': 'Bearer ' + self.access_token,
-            'Battlenet-Namespace': 'static-us',
+            'Authorization': 'Bearer ' + self.access_token
         }
-        r = await self.session.get(url, headers=headers, **kwargs)
-        res = await r.json(content_type=None)
-        if 'status' in res and res['status'] == 'nok':
-            raise RuntimeError("Request failed: " + res['reason']
-                               + "\nURL: " + url)
-        return res
+        client_response = await self.session.get(url, headers=headers, **kwargs)
+        json_response = await client_response.json(content_type=None)
+        if 'status' in json_response and json_response['status'] == 'nok':
+            raise RuntimeError("Request failed: " + json_response['reason'] + "\nURL: " + url)
+        return json_response
 
-    async def achievement_category(self, cat_id=None):
-        category = 'index' if cat_id is None else str(cat_id)
-        return (await self.query(
-            'data/wow/achievement-category/{}'.format(category),
-            params={'locale': 'en_US'},
-        ))
+    async def achievement_category(self, category_id=None):
+        """Queries the battle.net API for a list of all achievement categories"""
+        category = 'index' if category_id is None else str(category_id)
+        url = 'data/wow/achievement-category/{}'.format(category)
+        params = {
+            'locale': LOCALE,
+            'namespace': get_namespace('static')
+        }
+        return await self.query(url, params=params)
 
-    async def achievement(self, ach_id):
-        return (await self.query(
-            'data/wow/achievement/{}'.format(ach_id),
-            params={'locale': 'en_US'},
-        ))
+    async def achievement(self, achievement_id):
+        """Queries the battle.net API for a list of all achievements"""
+        url = 'data/wow/achievement/{}'.format(achievement_id)
+        params = {
+            'locale': LOCALE,
+            'namespace': get_namespace('static')
+        }
+        return await self.query(url, params=params)
 
-    async def achievement_media(self, ach_id):
-        return (await self.query(
-            'data/wow/media/achievement/{}'.format(ach_id),
-            params={'locale': 'en_US'},
-        ))
+    async def achievement_media(self, achievement_id):
+        """Queries the battle.net API for image data of a specific achievement"""
+        url = 'data/wow/media/achievement/{}'.format(achievement_id)
+        params = {
+            'locale': LOCALE,
+            'namespace': get_namespace('static')
+        }
+        return await self.query(url, params=params)
 
     async def mounts(self):
-        return (await self.query('wow/mount/'))
-
-    async def pets(self):
-        return (await self.query('wow/pet/'))
+        """Queries the battle.net API for a list of all mounts"""
+        params = {
+            'locale': LOCALE,
+            'namespace': get_namespace('static')
+        }
+        return await self.query('data/wow/mount/index', params=params)
 
     async def realms(self, region):
-        params = {'namespace': 'dynamic-' + region,
-                  'locale': 'en_US'}
-        return (await self.query('data/wow/realm/', region=region,
-                                 params=params))
-
-    async def pets_species(self, species_id):
-        return (await self.query('wow/pet/species/{}'.format(species_id)))
+        """Queries the battle.net API for a list of all realms for the given region"""
+        params = {
+            'locale': LOCALE,
+            'namespace': get_namespace('dynamic'),
+        }
+        return await self.query('data/wow/realm/', region=region, params=params)
 
     async def item(self, item_id):
-        return (await self.query('wow/item/{}'.format(item_id)))
+        """Queries the battle.net API for the data of a given item"""
+        url = 'data/wow/item/{}'.format(item_id)
+        params = {
+            'locale': LOCALE,
+            'namespace': get_namespace('static')
+        }
+        return await self.query(url, params=params)
+
+    async def pets(self):
+        """Queries the battle.net API for a list of all pets"""
+        params = {
+            'locale': LOCALE,
+            'namespace': get_namespace('static')
+        }
+        return await self.query('data/wow/pet/index', params=params)
+
+    async def pets_species(self, species_id):
+        return await self.query('wow/pet/species/{}'.format(species_id))
 
     async def pet_source(self, species_id):
         species = await self.pets_species(species_id)
         return species['source'].split(':')[0].strip()
+
+
+def get_namespace(namespace):
+    return namespace + '-{}'.format(OAUTH_REGION.lower())
 
 
 def get_master_list(name, *args, **kwargs):
@@ -91,5 +124,5 @@ def get_master_list(name, *args, **kwargs):
 
     async def get():
         async with BnetClient() as client:
-            return (await getattr(client, name)(*args, **kwargs))
-    return asyncio.run(get())
+            return await getattr(client, name)(*args, **kwargs)
+    return asyncio.get_event_loop().run_until_complete(get())

--- a/data_scripts/mounts_fixer_bnet.py
+++ b/data_scripts/mounts_fixer_bnet.py
@@ -5,56 +5,44 @@ import json
 import logging
 import sys
 
-
-IGNORE_MOUNT_SPELLIDS = [
+IGNORE_MOUNT_IDS = [
     # Never actually added
-    10788,   # Leopard https://www.wowhead.com/item=8633
-    10790,   # Tiger https://www.wowhead.com/item=8630
-    61289,   # Borrowed Broom https://www.wowhead.com/item=44604
-    123160,  # Crimson Riding Crane https://www.wowhead.com/item=84728
-    123182,  # White Riding Yak https://www.wowhead.com/item=84753
-    127178,  # Jungle Riding Crane https://www.wowhead.com/item=87784
-    127180,  # Albino Riding Crane https://www.wowhead.com/item=87785
-    127209,  # Black Riding Yak https://www.wowhead.com/item=87786
-    127213,  # Brown Riding Yak https://www.wowhead.com/item=87787
-    127272,  # Orange Water Strider https://www.wowhead.com/item=87792
-    127274,  # Jade Water Strider https://www.wowhead.com/item=87793
-    127278,  # Golden Water Strider https://www.wowhead.com/item=87794
-    147595,  # Stormcrow https://www.wowhead.com/item=104011
-    171618,  # Ancient Leatherhide https://www.wowhead.com/item=116657
-    176762,  # Iron Star Roller https://www.wowhead.com/item=119179
-    278656,  # Spectral Phoenix https://www.wowhead.com/item=163063
-    278966,  # Tempestuous Skystallion https://www.wowhead.com/item=163186
-
-    # Mounts that cannot be learned in the journal
-    47977,   # Magic Broom https://www.wowhead.com/item=37011
-    145133,  # Moonfang https://www.wowhead.com/item=101675
-    239766,  # Blue Qiraji War Tank https://www.wowhead.com/item=151626
-    239767,  # Red Qiraji War Tank https://www.wowhead.com/item=151625
-
-    # Consumable mounts
-    68768,   # Little White Stallion https://www.wowhead.com/item=49289
-    68769,   # Little Ivory Raptor https://www.wowhead.com/item=49288
-    130678,  # Unruly Behemoth https://www.wowhead.com/item=89682
-    130730,  # Kafa-Crazed Goat https://www.wowhead.com/item=89697
-    130895,  # Rampaging Yak https://www.wowhead.com/item=89770
-    304696,  # Wild Snapdragon https://www.wowhead.com/item=170178
-
-    # Toy mounts
-    254545,  # Baarut the Brisk https://www.wowhead.com/item=153193
-    176759,  # Goren "Log" Roller https://www.wowhead.com/item=119180
-    148626,  # Furious Ashhide Mushan https://www.wowhead.com/item=104329
-    174004,  # Spirit of Shinri https://www.wowhead.com/item=113543
-
-    # "GM mistake" mounts
-    17458,   # Fluorescent Green Mechanostrider
-             # https://www.wowhead.com/item=13325
-
-    # Mounts in armor/weapons
-    101641,  # Tarecgosa's Visage https://www.wowhead.com/item=71086
-
-    # Replaced mounts marked as [OLD]
-    48954,   # Swift Zhevra https://www.wowhead.com/item=37598
+    7,  # Gray Wolf https://www.wowhead.com/mount/7
+    8,  # White Stallion https://www.wowhead.com/mount/8
+    12,  # Black Wolf https://www.wowhead.com/mount/12
+    13,  # Red Wolf https://www.wowhead.com/mount/13
+    15,  # Winter Wolf https://www.wowhead.com/mount/15
+    22,  # Black Ram https://www.wowhead.com/mount/22
+    28,  # Skeletal Horse https://www.wowhead.com/mount/28
+    32,  # Tiger https://www.wowhead.com/mount/32
+    35,  # Ivory Raptor https://www.wowhead.com/mount/35
+    43,  # Green Mechanostrider https://www.wowhead.com/mount/43
+    70,  # Riding Kodo https://www.wowhead.com/mount/70
+    123,  # Nether Drake https://www.wowhead.com/mount/123
+    145,  # Blue Mechanostrider https://www.wowhead.com/mount/145
+    206,  # Merciless Nether Drake https://www.wowhead.com/mount/206
+    222,  # Swift Zhevra https://www.wowhead.com/mount/222
+    225,  # Brewfest Riding Kodo https://www.wowhead.com/mount/225
+    238,  # Swift Spectral Gryphon https://www.wowhead.com/mount/238
+    251,  # Black Polar Bear https://www.wowhead.com/mount/251
+    273,  # Grand Caravan Mammoth https://www.wowhead.com/mount/273
+    274,  # Grand Caravan Mammoth https://www.wowhead.com/mount/274
+    293,  # Black Dragonhawk Mount https://www.wowhead.com/mount/293
+    308,  # Blue Skeletal Warhorse https://www.wowhead.com/mount/308
+    333,  # Magic Rooster https://www.wowhead.com/mount/333
+    334,  # Magic Rooster https://www.wowhead.com/mount/334
+    335,  # Magic Rooster https://www.wowhead.com/mount/335
+    462,  # White Riding Yak https://www.wowhead.com/mount/462
+    484,  # Black Riding Yak https://www.wowhead.com/mount/484
+    485,  # Brown Riding Yak https://www.wowhead.com/mount/485
+    776,  # Swift Spectral Rylak https://www.wowhead.com/mount/776
+    934,  # Swift Spectral Hippogryph https://www.wowhead.com/mount/934
+    935,  # Blue Qiraji War Tank https://www.wowhead.com/mount/935
+    936,  # Red Qiraji War Tank https://www.wowhead.com/mount/936
+    1269,  # Swift Spectral Fathom Ray https://www.wowhead.com/mount/1269
+    1270,  # Swift Spectral Magnetocraft https://www.wowhead.com/mount/1270
+    1271,  # Swift Spectral Armored Gryphon https://www.wowhead.com/mount/1271
+    1272,  # Swift Spectral Pterrordax https://www.wowhead.com/mount/1272
 ]
 
 
@@ -63,36 +51,31 @@ def changelog(*args, **kwargs):
 
 
 class MountFixer:
-    def __init__(self, bnet_mounts, mounts):
-        self.bnet_mounts = bnet_mounts
+    def __init__(self, battle_net_mounts, mounts):
+        self.battle_net_mounts = battle_net_mounts['mounts']
         self.mounts = mounts
-        self.id_to_old_mount = {}
+        self.known_mount_ids = {}
 
         self.register_old_mounts()
 
     def register_old_mounts(self):
-        for cat in self.mounts:
-            for subcat in cat['subcats']:
-                for item in subcat['items']:
-                    self.id_to_old_mount[int(item['spellid'])] = item
+        """Reads the mounts from the mounts.json and adds them to a list of already added mounts"""
+        for category in self.mounts:
+            for sub_category in category['subcats']:
+                for item in sub_category['items']:
+                    self.known_mount_ids[int(item['ID'])] = item
 
     def fix_missing(self):
+        """Matches the already added mounts against the mounts from the battle.net API and outputs the missing mounts"""
         mounts_to_add = []
-        for mount in self.bnet_mounts['mounts']:
-            if not mount['itemId']:
-                # Not a real obtainable mount
-                continue
-            spellid = int(mount['spellId'])
-            if ((spellid not in self.id_to_old_mount
-                 and spellid not in IGNORE_MOUNT_SPELLIDS)):
-                changelog('Mount {} missing: {} '
-                          'https://www.wowhead.com/item={}'
-                          .format(spellid, mount['name'], mount['itemId']))
+        for mount in self.battle_net_mounts:
+            mount_id = int(mount['id'])
+
+            if mount_id not in self.known_mount_ids and mount_id not in IGNORE_MOUNT_IDS:
+                changelog('Mount {} missing: {} https://www.wowhead.com/mount/{}'.format(mount_id, mount['name'], mount['id']))
                 mounts_to_add.append({
                     'name': mount['name'],
-                    'spellid': mount['spellId'],
-                    'itemId': mount['itemId'],
-                    'icon': mount['icon'],
+                    'ID': mount['id']
                 })
         json.dump(mounts_to_add, sys.stdout, indent=2, sort_keys=True)
 
@@ -106,8 +89,8 @@ if __name__ == '__main__':
     if len(sys.argv) < 2:
         sys.exit("Usage: {} mounts.json")
 
-    bnet_mounts = bnet.get_master_list('mounts')
+    battle_net_mounts = bnet.get_master_list('mounts')
     mounts = json.load(open(sys.argv[1]))
 
-    fixer = MountFixer(bnet_mounts, mounts)
+    fixer = MountFixer(battle_net_mounts, mounts)
     fixer.run()


### PR DESCRIPTION
This PR adds shadowlands mounts from the battle.net API. Here some notes:

* I grouped the mounts by covenants and zone, because most of them have very different sources, which would result in many small categories
* It is not always clear if you need a specific covenant for a mount/rare mob/... which is another reason for the zone grouping
* Some of the wowhead (tooltip) data is incorrect
* I updated the mount fixer, but didn't add the fix to `bnet.py`, because earlier commits use the us api everywhere and I use the eu api. I will add another PR later which moves the region to the `settings.py` and adds the correct mount api endpoint

We probably need to move some mounts once shadowlands launches, because currently the data is incomplete/conflicting/incorrect, but the main work for the mounts is done.