### PR TITLE
Fix for planner logic where horde mounts are added for alliance

### DIFF
--- a/app/scripts/services/planner.service.js
+++ b/app/scripts/services/planner.service.js
@@ -66,18 +66,41 @@
             // check to see if we've finished all the bosses
             if (step.bosses) {
                 angular.forEach(step.bosses, function(boss) {
-                    if (boss.isAlliance && items.isAlliance && items.lookup[boss.ID] === undefined) {
-                        neededBosses.push(boss);
-                        completed = false;
+
+                    var bossIsNeutral = !boss.isAlliance && !boss.isHorde,
+                        character = items, // aliasing for clarity
+                        characterNeedsBoss = function(id){ return !character.lookup[id]; },
+                        addBoss = function(boss) {
+                            neededBosses.push(boss);
+                            completed = false;
+                        };
+
+                    if (showAll) { addBoss(boss); return; }
+                    if (boss.ID === undefined) { return; } // continue the loop, bad boss data
+
+                    if (bossIsNeutral && characterNeedsBoss(boss.ID)) {
+                        addBoss(boss);
+                        return;
                     }
-                    else if (boss.isHorde && !items.isAlliance && items.lookup[boss.ID] === undefined) {
-                        neededBosses.push(boss);
-                        completed = false;
+
+                    if (boss.isAlliance && character.isAlliance) {
+                        if (characterNeedsBoss(boss.ID)) {
+                            addBoss(boss);
+                            return;
+                        } else {
+                            return; // already has boss
+                        }
                     }
-                    else if ((boss.ID !== undefined && items.lookup[boss.ID] === undefined) || showAll) {
-                        neededBosses.push(boss);
-                        completed = false;
+
+                    if (boss.isHorde && character.isHorde) {
+                        if (characterNeedsBoss(boss.ID)) {
+                            addBoss(boss);
+                            return;
+                        } else {
+                            return; // already has boss
+                        }
                     }
+
                 });
             }
 

--- a/app/scripts/services/planner.service.js
+++ b/app/scripts/services/planner.service.js
@@ -67,10 +67,10 @@
             if (step.bosses) {
                 angular.forEach(step.bosses, function(boss) {
 
-                    var bossIsNeutral = !boss.isAlliance && !boss.isHorde,
-                        character = items, // aliasing for clarity
-                        characterNeedsBoss = function(id){ return !character.lookup[id]; },
-                        addBoss = function(boss) {
+                    var bossIsNeutral = !boss.isAlliance && !boss.isHorde;
+                    var character = items; // aliasing for clarity
+                    var characterNeedsBoss = function(id){ return !character.lookup[id]; };
+                    var addBoss = function(boss) {
                             neededBosses.push(boss);
                             completed = false;
                         };

--- a/app/scripts/services/planner.service.js
+++ b/app/scripts/services/planner.service.js
@@ -77,28 +77,21 @@
 
                     if (showAll) { addBoss(boss); return; }
                     if (boss.ID === undefined) { return; } // continue the loop, bad boss data
+                    if (!characterNeedsBoss(boss.ID)) { return; }
 
-                    if (bossIsNeutral && characterNeedsBoss(boss.ID)) {
+                    if (bossIsNeutral) {
                         addBoss(boss);
                         return;
                     }
 
                     if (boss.isAlliance && character.isAlliance) {
-                        if (characterNeedsBoss(boss.ID)) {
-                            addBoss(boss);
-                            return;
-                        } else {
-                            return; // already has boss
-                        }
+                        addBoss(boss);
+                        return;
                     }
 
                     if (boss.isHorde && character.isHorde) {
-                        if (characterNeedsBoss(boss.ID)) {
-                            addBoss(boss);
-                            return;
-                        } else {
-                            return; // already has boss
-                        }
+                        addBoss(boss);
+                        return;
                     }
 
                 });

--- a/app/scripts/services/planner.service.js
+++ b/app/scripts/services/planner.service.js
@@ -79,17 +79,7 @@
                     if (boss.ID === undefined) { return; } // continue the loop, bad boss data
                     if (!characterNeedsBoss(boss.ID)) { return; }
 
-                    if (bossIsNeutral) {
-                        addBoss(boss);
-                        return;
-                    }
-
-                    if (boss.isAlliance && character.isAlliance) {
-                        addBoss(boss);
-                        return;
-                    }
-
-                    if (boss.isHorde && character.isHorde) {
+                    if ( bossIsNeutral || (boss.isAlliance && character.isAlliance) || (boss.isHorde && character.isHorde)) {
                         addBoss(boss);
                         return;
                     }


### PR DESCRIPTION
This PR should address: https://github.com/kevinclement/SimpleArmory/issues/282

There was a flaw in the planner logic for when to add a needed boss for cross faction mounts. In this case the `planner.json` has 8 mounts for VoA "Grand Black War Mammoth." 4 are Alliance, 4 are Horde. I am an alliance character that has already collected the alliance "Grand Black War Mammoth."

```js
if (boss.isAlliance && items.isAlliance && items.lookup[boss.ID] === undefined) {
    neededBosses.push(boss);
    completed = false;
}
else if (boss.isHorde && !items.isAlliance && items.lookup[boss.ID] === undefined) {
    neededBosses.push(boss);
    completed = false;
}
else if ((boss.ID !== undefined && items.lookup[boss.ID] === undefined) || showAll) {
    neededBosses.push(boss);
    completed = false;
}
```

The first 4 times it goes through this loop for the alliance "Grand Black War Mammoth" 
- clause 1 is `false`, because the character has the mount
- clause 2 is `false`, because the boss is Alliance
- clause 3 is `false`, because the character has the mount

The next 4 times it goes through the loop for the horde "Grand Black War Mammoth"
- clause 1 is `false`, because the boss is Horde
- clause 2 is `false`, because the character is Alliance
- clause 3 is `true`, because the Alliance character does not have the Horde mount

In this PR, I cleaned up the logic branches, and added some `return` statements to short circuit the rest of the conditionals.