### PR TITLE
Ulduar no longer has a 25 man - Addresses #298

### DIFF
--- a/app/data/planner.json
+++ b/app/data/planner.json
@@ -298,7 +298,7 @@
 						"itemId": 45693,
 						"mount": "Mimiron's Head",
 						"name": "Yogg-Saron",
-						"note": "Requires 25-man no watchers up",
+						"note": "Requires no watchers up",
 						"spellId": 63796
 					  }
 					],


### PR DESCRIPTION
Addresses issue #298 

As of patch 7.3.5, Ulduar 10 and 25 have been combined. https://www.wowhead.com/news=278262/more-details-on-ulduar-in-patch-7-3-5-loot-transmog-and-mounts