### PR TITLE
Fix : Fixed icon name for one achiev and two toys

### DIFF
--- a/app/data/achievements.json
+++ b/app/data/achievements.json
@@ -41407,7 +41407,7 @@
                   "points": 0
                 },
                 {
-                  "icon": "inv_aetherserpentmount",
+                  "icon": "3040844",
                   "id": 14283,
                   "points": 0,
                   "title": "Heroic Edition: Ensorcelled Everwyrm"

--- a/app/data/toys.json
+++ b/app/data/toys.json
@@ -120,7 +120,7 @@
             "name": "Muckpool Cookpot"
           },
           {
-            "icon": "achievement_guildperk_everyonesahero",
+            "icon": "achievement_guildperk_everyones-a-hero",
             "itemId": 179393,
             "name": "Mirror of Envious Dreams"
           },
@@ -261,7 +261,7 @@
             "name": "Regenerating Slime Vial"
           },
           {
-            "icon": "trade_archaeology_carvedharpofexoticwood",
+            "icon": "trade_archaeology_carved-harp-of-exotic-wood",
             "itemId": 181794,
             "name": "Orophea's Lyre"
           },


### PR DESCRIPTION
Hello,

Fixed toys icon name for toys `Mirror of Envious Dreams` and `Orophea's Lyre`.

It was :
`achievement_guildperk_everyonesahero`
`trade_archaeology_carvedharpofexoticwood`

and should be :
`achievement_guildperk_everyones-a-hero`
`trade_archaeology_carved-harp-of-exotic-wood`

(https://wow.zamimg.com/images/wow/icons/medium/achievement_guildperk_everyones-a-hero.jpg
https://wow.zamimg.com/images/wow/icons/medium/trade_archaeology_carved-harp-of-exotic-wood.jpg)

as issued in [issue#321](https://github.com/kevinclement/SimpleArmory/issues/321)

Also, the icon for the feat of strength `Heroic Edition: Ensorcelled Everwyrm` was also returning 404 and the correct icon name seems to be an id and not a name somehow
(Wowhead uses https://wow.zamimg.com/images/wow/icons/medium/3040844.jpg as icon for [the achievement](https://www.wowhead.com/achievement=14283/heroic-edition-ensorcelled-everwyrm))

