### PR TITLE
Mounts: reformat / reorder / remove duplicate glad mount

### DIFF
--- a/app/data/mounts.json
+++ b/app/data/mounts.json
@@ -5652,20 +5652,12 @@
             "spellid": 243201
           },
           {
-            "ID": "1035",
+            "ID": "1030",
             "icon": "ability_mount_protodrakegladiatormount",
-            "itemId": "156884",
-            "name": "Black Gladiator's Proto-Drake",
+            "itemId": "156879",
+            "name": "Dread Gladiator's Proto-Drake",
             "notObtainable": true,
-            "spellid": "262027"
-          },
-          {
-            "ID": "1032",
-            "icon": "ability_mount_protodrakegladiatormount",
-            "itemId": "156881",
-            "name": "Purple Gladiator's Proto-Drake",
-            "notObtainable": true,
-            "spellid": "262024"
+            "spellid": "262022"
           },
           {
             "ID": "1031",
@@ -5676,27 +5668,27 @@
             "spellid": "262023"
           },
           {
-            "ID": "1030",
+            "ID": "1032",
             "icon": "ability_mount_protodrakegladiatormount",
-            "itemId": "156879",
-            "name": "Dread Gladiator's Proto-Drake",
+            "itemId": "156881",
+            "name": "Purple Gladiator's Proto-Drake",
             "notObtainable": true,
-            "spellid": "262022"
+            "spellid": "262024"
           },
           {
             "ID": "1035",
             "icon": "inv_protodrakegladiatormount_black",
-            "itemId": 156884,
+            "itemId": "156884",
             "name": "Corrupted Gladiator's Proto-Drake",
             "notObtainable": true,
-            "spellid": 262027
+            "spellid": "262027"
           },
           {
-              "ID": 1363,
-              "name": "Sinful Gladiator's Soul Eater",
-              "spellid": 332400,
-              "icon": "inv_shadebeastmount",
-              "itemId": 183937
+            "ID": "1363",
+            "name": "Sinful Gladiator's Soul Eater",
+            "spellid": "332400",
+            "icon": "inv_shadebeastmount",
+            "itemId": "183937"
           }
         ],
         "name": "Gladiator"


### PR DESCRIPTION
Fixed duplicate glad mount as reported in #312.

- BFA S4 Glad mount was present two times in the data with one entry having the wrong name
- Reordered mounts by chronological order of the seasons
- Reformated shadowlands S1 mount entry to be compliant with the others (two space indent / stringified id)