### PR TITLE
Modified profile attributes to fix class checks

### DIFF
--- a/app/data/mounts.json
+++ b/app/data/mounts.json
@@ -6595,7 +6595,7 @@
             "allowableClasses": [
               12
             ],
-            "icon": "inv_dhmount",
+            "icon": "inv_dhmount_felsaber",
             "spellid": "200175"
           }
         ],

--- a/app/scripts/services/login.service.js
+++ b/app/scripts/services/login.service.js
@@ -63,9 +63,10 @@
 
                   profileCached = data.data;
 
-                  // add region and faction to character
+                  // add region, faction and class to character
                   profileCached.region = $routeParams.region;
                   profileCached.realm = $routeParams.realm;
+                  profileCached.class = data.data.character_class.id;
                   profileCached.faction = [
                     '',
                     'A',  // Human


### PR DESCRIPTION
When fetching the user's profile, the character's class is stored under the `character_class` attribute but was used as `profile.class` in `mountsAndPetsServices` for class checks resulting in undefined class and causing issues reported in #232.

The `character_class`'s id is now saved as a new profile attribute `class` to preserve the code in the mounts and pets service.