### PR TITLE
Fix the following mount icons :

### DIFF
--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -138,7 +138,7 @@
             "ID": 1504,
             "name": "Hand of Salaranga",
             "spellid": 354355,
-            "icon": "inv_mawguardhandmountblack",
+            "icon": "inv_bracer_leather_draenorcrafted_d_01_alliance",
             "itemId": 186654
           },
           {
@@ -166,7 +166,7 @@
             "ID": 1417,
             "name": "Hand of Hrestimorak",
             "spellid": 339957,
-            "icon": "inv_mawguardhandmountblue",
+            "icon": "inv_bracer_43",
             "itemId": 186653
           },
           {

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -225,7 +225,7 @@
             "ID": 1404,
             "name": "Silverwind Larion",
             "spellid": 334433,
-            "icon": "inv_wingedlion2mount",
+            "icon": "inv_wingedlion2mount_silver",
             "itemId": 180772
           }
         ]
@@ -251,7 +251,7 @@
             "ID": 1422,
             "name": "Warstitched Darkhound",
             "spellid": 341766,
-            "icon": "inv_darkhoundmount_draka",
+            "icon": "inv_darkhoundmount_draka_blue",
             "itemId": 183615
           },
           {
@@ -277,7 +277,7 @@
             "ID": 1503,
             "name": "Hand of Nilganihmaht",
             "spellid": 354354,
-            "icon": "inv_mawguardhandmountgold",
+            "icon": "inv_70_quest_ring7b",
             "itemId": 186713
           }
         ]
@@ -289,7 +289,7 @@
             "ID": 1475,
             "name": "Hand of Bahmethra",
             "spellid": 352309,
-            "icon": "inv_mawguardhandmountpurple",
+            "icon": "inv_belt_44c",
             "itemId": 185973
           }
         ]
@@ -422,7 +422,7 @@
             "ID": 1406,
             "name": "Marrowfang",
             "spellid": 336036,
-            "icon": "inv_maldraxxusflyermount",
+            "icon": "inv_maldraxxusflyermount_red",
             "itemId": 181819
           },
           {
@@ -466,7 +466,7 @@
             "ID": 1407,
             "name": "Callow Flayedwing",
             "spellid": 336038,
-            "icon": "inv_maldraxxusflyermount",
+            "icon": "inv_maldraxxusflyermount_green",
             "itemId": 181818
           }
         ]
@@ -675,7 +675,7 @@
             "ID": 1408,
             "name": "Gruesome Flayedwing",
             "spellid": 336039,
-            "icon": "inv_maldraxxusflyermount",
+            "icon": "inv_maldraxxusflyermount_blue",
             "itemId": 181300
           },
           {


### PR DESCRIPTION
#366 

- Silverwind Larion
- Warstitched Darkhound
- Hand of Nilganihmaht
- Hand of Bahmethra
- Marrowfang
- Callow Flayedwing
- Gruesome Flayedwing