### PR TITLE
Change crow battle pet to correct zone and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # [SimpleArmory](http://simplearmory.com) <img src="https://github.com/kevinclement/SimpleArmory/raw/master/static/images/shield.png?raw=true" align="left" height="32" width="32" style="max-width:100%;align-vertical: center;vertical-align: center;line-height: 20px;margin-top: 15px;margin-right: 5px;">
-World of Warcraft armory site that presents your armory in a simple manor.
+World of Warcraft armory site that presents your armory in a simple manner.
 
 ======================
 
-This is the code used to build out [simplearmory.com](http://simplearmory.com) website.  Contributions welcome.
+This is the code used to build out [simplearmory.com](http://simplearmory.com) website. Contributions welcome.
 
 [![Example armory for Marko@Proudmoore][2]][1]
 

--- a/static/data/battlepets.json
+++ b/static/data/battlepets.json
@@ -2372,12 +2372,6 @@
             "name": "Crimson Shale Hatchling"
           },
           {
-            "ID": 1068,
-            "creatureId": 67443,
-            "icon": "ability_hunter_murderofcrows",
-            "name": "Crow"
-          },
-          {
             "ID": 556,
             "creatureId": 62925,
             "icon": "inv_inscription_pigment_bug04",
@@ -3150,6 +3144,12 @@
             "creatureId": 67329,
             "icon": "inv_dragonflypet_blue",
             "name": "Darkmoon Glowfly"
+          },
+          {
+            "ID": 1068,
+            "creatureId": 67443,
+            "icon": "ability_hunter_murderofcrows",
+            "name": "Crow"
           }
         ],
         "name": ""


### PR DESCRIPTION
Big fan of the website, happy to see it's open source and welcoming contributions.

I stumbled upon the Crow battle pet in the wrong area last night. Even though there is no special "Darkmoon Island" (sub)category, now it's at least consistent with the Darkmoon Glowfly.