### PR TITLE
add new store mount: wen lo, river's edge

### DIFF
--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -6935,6 +6935,12 @@
             "icon": "3232104",
             "name": "Sunwarmed Furline",
             "spellid": 317177
+          },
+          {
+            "ID": 1531,
+            "icon": "4180079",
+            "name": "Wen Lo, the River's Edge",
+            "spellid": 359317
           }
         ],
         "name": "Blizzard Store"


### PR DESCRIPTION
This adds the new store mount with its details to the mounts json.

You might want to wait a bit with accepting this PR, as the icon and mount are not yet on Wowhead, I'm not sure if that would break anything.