### PR TITLE
inherit quality background color from theme

### DIFF
--- a/src/pages/BattlePets.svelte
+++ b/src/pages/BattlePets.svelte
@@ -24,7 +24,7 @@
     }
 
     function qualityToBackground(item) {
-        var bgColor = '#fff';
+        var bgColor = 'inherit';
 
         switch(item.quality) {
             case 'poor':

--- a/src/pages/BattlePets.svelte
+++ b/src/pages/BattlePets.svelte
@@ -24,7 +24,7 @@
     }
 
     function qualityToBackground(item) {
-        var bgColor = 'inherit';
+        var bgColor = 'transparent';
 
         switch(item.quality) {
             case 'poor':


### PR DESCRIPTION
Instead of hard-coding the background color for the quality bar to white, use inherit so it will pull the background color from the theme.

fixes #415