### PR TITLE
Mounts: Creates Torghast tab and fixes #436

### DIFF
--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -216,13 +216,6 @@
             "spellid": 363297
           },
           {
-            "ID": 1565,
-            "icon": "inv_mawratmount_03",
-            "itemId": 188700,
-            "name": "Colossal Umbrahide Mawrat",
-            "spellid": 363178
-          },
-          {
             "ID": 1566,
             "icon": "inv_mawratmount_05",
             "itemId": 188696,
@@ -254,6 +247,18 @@
           }
         ],
         "name": "Achievement"
+      },
+      {
+        "items": [
+          {
+            "ID": 1565,
+            "icon": "inv_mawratmount_03",
+            "itemId": 188700,
+            "name": "Colossal Umbrahide Mawrat",
+            "spellid": 363178
+          }
+        ],
+        "name": "Torghast"
       },
       {
         "items": [


### PR DESCRIPTION
Moves Colossal Umbrahide Mawrat from achievements to Torghast since its a drop