### PR TITLE
Closes #419, Closes #369, Adds 9.2.5 mounts

### DIFF
--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -1381,6 +1381,34 @@
           }
         ],
         "name": "Protoform Synthesis"
+      },
+      {
+        "id": "05a1417f",
+        "items": [
+          {
+            "ID": 1600,
+            "icon": "ability_mount_cockatricemount_green",
+            "itemId": 191566,
+            "name": "Elusive Emerald Hawkstrider",
+            "side": "H",
+            "spellid": 370620
+          }
+        ],
+        "name": "Blood Elf"
+      },
+      {
+        "id": "05a1418a",
+        "items": [
+          {
+            "ID": 1597,
+            "icon": "inv_darkhoundmount",
+            "itemId": 191123,
+            "name": "Grimhowl",
+            "side": "A",
+            "spellid": 369666
+          }
+        ],
+        "name": "Dark Iron Dwarf"
       }
     ]
   },

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -308,6 +308,24 @@
             "itemId": 188808,
             "name": "Patient Bufonid",
             "spellid": 363701
+          },
+          {
+            "ID": 1600,
+            "icon": "ability_mount_cockatricemount_green",
+            "itemId": 191566,
+            "name": "Elusive Emerald Hawkstrider",
+            "side": "H",
+            "spellid": 370620
+          },
+          {
+            "ID": 1597,
+            "allowableRaces": [
+              34
+            ],
+            "icon": "inv_darkhoundmount",
+            "itemId": 191123,
+            "name": "Grimhowl",
+            "spellid": 369666
           }
         ],
         "name": "Quest"
@@ -1381,34 +1399,6 @@
           }
         ],
         "name": "Protoform Synthesis"
-      },
-      {
-        "id": "05a1417f",
-        "items": [
-          {
-            "ID": 1600,
-            "icon": "ability_mount_cockatricemount_green",
-            "itemId": 191566,
-            "name": "Elusive Emerald Hawkstrider",
-            "side": "H",
-            "spellid": 370620
-          }
-        ],
-        "name": "Blood Elf"
-      },
-      {
-        "id": "05a1418a",
-        "items": [
-          {
-            "ID": 1597,
-            "icon": "inv_darkhoundmount",
-            "itemId": 191123,
-            "name": "Grimhowl",
-            "side": "A",
-            "spellid": 369666
-          }
-        ],
-        "name": "Dark Iron Dwarf"
       }
     ]
   },

--- a/static/data/planner.json
+++ b/static/data/planner.json
@@ -248,7 +248,7 @@
 						"itemId": 43986,
 						"mount": "Black Drake",
 						"name": "Sartharion",
-						"note": "10 man",
+						"note": "10 Man, All Purple Dragons Up",
 						"spellId": 59650
 					  },
 					  {
@@ -258,7 +258,7 @@
 						"itemId": 43954,
 						"mount": "Twilight Drake",
 						"name": "Sartharion",
-						"note": "25 man",
+						"note": "25 Man, All Purple Dragons Up",
 						"spellId": 59571
 					  }
 					],
@@ -845,7 +845,7 @@
 					"icon": "inv_infernalmountgreen",
 					"itemId": 137574,
 					"mount": "Living Infernal Core",
-					"note": "All 3 difficulties in same week",
+					"note": "Normal/Heroic/Mythic",
 					"name": "Gul'dan",
 					"spellId": 213134
 				  },
@@ -876,6 +876,7 @@
 					"icon": "inv_serpentmount_green",
 					"itemId": 143643,
 					"mount": "Abyss Worm",
+					"note": "LFR/Normal/Heroic/Mythic",
 					"name": "Mistress Sassz'ine",
 					"spellId": 232519
 				  }
@@ -898,7 +899,7 @@
 						"icon": "inv_felhound3_shadow_fire",
 						"itemId": 152816,
 						"mount": "Antoran Charhound",
-						"note": "All 3 difficulties in same week",
+						"note": "LFR/Normal/Heroic/Mythic",
 						"name": "Felhounds of Sargeras",
 						"spellId": 253088
 					  },
@@ -933,6 +934,7 @@
 					"itemId": 166518,
 					"mount": "G.M.O.D.",
 					"name": "High Tinker Mekkatorque",
+					"note": "Normal/Heroic/Mythic",
 					"spellId": 289083
 				  },
 				  {
@@ -1018,7 +1020,7 @@
 			"title": "Portal to Zandalar / Kul'Tiras"
 		  },
 		  {
-			"finalStep": "Hearthstone to Oribos",
+			"finalStep": "Portal to Oribos",
 			"steps": [
 			  {
 				"steps": [
@@ -1071,7 +1073,7 @@
 						  "itemId": 186656,
 						  "mount": "Sanctum Gloomcharger",
 						  "name": "The Nine",
-						  "note": "All 3 difficulties in same week",
+						  "note": "LFR/Normal/Heroic/Mythic",
 						  "spellId": 354351
 						},
 						{
@@ -1088,7 +1090,7 @@
 					"title": "Run Sanctum of Domination"
 				  }
 				],
-				"title": "Portal to Oribos, then The Maw"
+				"title": "Fly to Oribos, then Portal to The Maw"
 			  }
 			],
 			"title": "Hearthstone to Oribos"

--- a/static/data/planner.json
+++ b/static/data/planner.json
@@ -1020,7 +1020,7 @@
 			"title": "Portal to Zandalar / Kul'Tiras"
 		  },
 		  {
-			"finalStep": "Portal to Oribos",
+			"finalStep": "Hearthstone to Oribos",
 			"steps": [
 			  {
 				"steps": [

--- a/static/data/planner.json
+++ b/static/data/planner.json
@@ -612,7 +612,7 @@
 					"title": "Fly to Stranglethorn Vale"
 				  }
 				],
-				"title": "Portal to Blasted Lands"
+				"title": "Portal to Stormwind/Blimp to Stranglethorn Vale"
 			  }
 			],
 			"title": "Portal to "

--- a/static/data/planner.json
+++ b/static/data/planner.json
@@ -845,6 +845,7 @@
 					"icon": "inv_infernalmountgreen",
 					"itemId": 137574,
 					"mount": "Living Infernal Core",
+					"note": "All 3 difficulties in same week",
 					"name": "Gul'dan",
 					"spellId": 213134
 				  },
@@ -897,6 +898,7 @@
 						"icon": "inv_felhound3_shadow_fire",
 						"itemId": 152816,
 						"mount": "Antoran Charhound",
+						"note": "All 3 difficulties in same week",
 						"name": "Felhounds of Sargeras",
 						"spellId": 253088
 					  },
@@ -1014,6 +1016,82 @@
 			  }
 			],
 			"title": "Portal to Zandalar / Kul'Tiras"
+		  },
+		  {
+			"finalStep": "Hearthstone to Oribos",
+			"steps": [
+			  {
+				"steps": [
+				  {
+					"bosses": [
+					  {
+						"ID": "1406",
+						"epic": true,
+						"icon": "inv_maldraxxusflyermount_red",
+						"itemId": 181819,
+						"mount": "Marrowfang",
+						"name": "Nalthor the Rimebinder",
+						"note": "Mythic only",
+						"spellId": 336036
+					  }
+					],
+					"title": "Run Necrotic Wake"
+				  }
+				],
+				"title": "Fly to Bastion"
+			  },
+			  {
+				"steps": [
+				  {
+					"bosses": [
+					  {
+						"ID": "1481",
+						"epic": true,
+						"icon": "inv_brokermount_dark",
+						"itemId": 186638,
+						"mount": "Cartel Master's Gearglider",
+						"name": "So'leah",
+						"note": "Mythic only",
+						"spellId": 353263
+					  }
+					],
+					"title": "Run Tazavesh the Veiled Market"
+				  }
+				],
+				"title": "Fly to Tazavesh"
+			  },
+			  {
+				"steps": [
+				  {
+					"bosses": [
+						{
+						  "ID": "1500",
+						  "epic": true,
+						  "icon": "ability_mount_mawhorsespikes_purple",
+						  "itemId": 186656,
+						  "mount": "Sanctum Gloomcharger",
+						  "name": "The Nine",
+						  "note": "All 3 difficulties in same week",
+						  "spellId": 354351
+						},
+						{
+						  "ID": "1471",
+						  "epic": true,
+						  "icon": "inv_dragonhawkmountshadowlands",
+						  "itemId": 186642,
+						  "mount": "Vengeance",
+						  "name": "Lady Sylvanas Windrunner",
+						  "note": "Mythic only",
+						  "spellId": 351195
+						}
+					  ],
+					"title": "Run Sanctum of Domination"
+				  }
+				],
+				"title": "Portal to Oribos, then The Maw"
+			  }
+			],
+			"title": "Hearthstone to Oribos"
 		  }
 		],
 		"title": "Start off in "


### PR DESCRIPTION
Updates planner for shadowlands mounts, adds new notes for mounts that drop on all 3 difficulties, and removes the portal to Blasted Lands being an option.