### PR TITLE
Cartel Master's Gearglider - Note

### DIFF
--- a/static/data/planner.json
+++ b/static/data/planner.json
@@ -1053,7 +1053,7 @@
 						"itemId": 186638,
 						"mount": "Cartel Master's Gearglider",
 						"name": "So'leah",
-						"note": "Mythic only",
+						"note": "Heroic/Mythic",
 						"spellId": 353263
 					  }
 					],


### PR DESCRIPTION
Fixing "Cartel Master's Gearglider in Mount Planner marked as mythic only"(https://github.com/kevinclement/SimpleArmory/issues/450) issue 