### PR TITLE
Legion Pets - Issue

### DIFF
--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -3828,6 +3828,22 @@
             "itemId": 147542,
             "name": "Ban-Fu, Cub of Ban-Lu",
             "spellid": 240794
+          },
+          {
+            "ID": 1928,
+            "creatureId": 112132,
+            "icon": "inv_batpet",
+            "itemId": 140316,
+            "name": "Firebat Pup",
+            "spellid": 223339
+          },
+          {
+            "ID": 1929,
+            "creatureId": 112144,
+            "icon": "inv_corgi2",
+            "itemId": 140320,
+            "name": "Corgnelius",
+            "spellid": 223359
           }
         ],
         "name": "Order Hall"
@@ -4363,22 +4379,6 @@
             "itemId": 127748,
             "name": "Cinder Pup",
             "spellid": 184482
-          },
-          {
-            "ID": 1928,
-            "creatureId": 112132,
-            "icon": "inv_batpet",
-            "itemId": 140316,
-            "name": "Firebat Pup",
-            "spellid": 223339
-          },
-          {
-            "ID": 1929,
-            "creatureId": 112144,
-            "icon": "inv_corgi2",
-            "itemId": 140320,
-            "name": "Corgnelius",
-            "spellid": 223359
           }
         ],
         "name": "Table Missions"


### PR DESCRIPTION
The following pets were moved from "Warlords of Draenor / Table Missions" to "Legion / Order Hall" (https://github.com/kevinclement/SimpleArmory/issues/462):
- https://www.wowhead.com/item=140320/corgnelius
- https://www.wowhead.com/item=140316/firebat-pup