### PR TITLE
Add all Dragonflight mounts

### DIFF
--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -3886,7 +3886,7 @@
                   "title": "Treasures of Zereth Mortis"
                 }
               ],
-              "name": "Treasures"
+              "name": "Treasure"
             },
             {
               "id": "1b78a6ec",

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -155,6 +155,20 @@
         "id": "da78f1d2",
         "items": [
           {
+            "ID": 1626,
+            "icon": "inv_snailmount_red",
+            "itemId": 192784,
+            "name": "Shellack",
+            "spellid": 374155
+          },
+          {
+            "ID": 1644,
+            "icon": "inv_mammoth2lavamount_red",
+            "itemId": 192806,
+            "name": "Raging Magmammoth",
+            "spellid": 374275
+          },
+          {
             "ID": 1681,
             "icon": "inv_rhinoprimalmountice",
             "itemId": 199412,
@@ -267,6 +281,27 @@
             "itemId": 198872,
             "name": "Brown Scouting Ottuk",
             "spellid": 376875
+          },
+          {
+            "ID": 1659,
+            "icon": "inv_riverotterlargemount01_yellow",
+            "itemId": 200118,
+            "name": "Yellow Scouting Ottuk",
+            "spellid": 376880
+          },
+          {
+            "ID": 1653,
+            "icon": "inv_riverotterlargemount02_brown",
+            "itemId": 201426,
+            "name": "Brown War Ottuk",
+            "spellid": 376910
+          },
+          {
+            "ID": 1655,
+            "icon": "inv_riverotterlargemount02_yellow",
+            "itemId": 201425,
+            "name": "Yellow War Ottuk",
+            "spellid": 376913
           }
         ],
         "name": "Renown"

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -201,13 +201,6 @@
         "id": "e504fa83",
         "items": [
           {
-            "ID": 1469,
-            "icon": "inv_snailmount_orange",
-            "itemId": 192777,
-            "name": "Magmashell",
-            "spellid": 350219
-          },
-          {
             "ID": 1553,
             "icon": "inv_foxwyvernmountblack",
             "itemId": 201440,
@@ -222,16 +215,17 @@
             "spellid": 385266
           }
         ],
-        "name": "Drop"
+        "name": "Rare Spawn"
       },
       {
         "id": "8dc7b48a",
         "items": [
           {
-            "ID": 1545,
-            "icon": "inv_eagle2windmount_white",
-            "name": "Divine Kiss of Ohn'ahra",
-            "spellid": 395644
+            "ID": 1612,
+            "icon": "inv_mammoth2lavamount_orange",
+            "itemId": 192601,
+            "name": "Loyal Magmammoth",
+            "spellid": 373859
           },
           {
             "ID": 1639,
@@ -241,45 +235,17 @@
             "spellid": 374247
           },
           {
-            "ID": 1656,
-            "icon": "inv_riverotterlargemount01_blue",
-            "itemId": 198870,
-            "name": "Otto",
-            "spellid": 376873
+            "ID": 1545,
+            "icon": "inv_eagle2windmount_white",
+            "name": "Divine Kiss of Ohn'ahra",
+            "spellid": 395644
           }
         ],
-        "name": "Quest"
+        "name": "Puzzle"
       },
       {
         "id": "ccc05f3b",
         "items": [
-          {
-            "ID": 1617,
-            "icon": "inv_primaldragonflymount_green",
-            "itemId": 192764,
-            "name": "Verdant Skitterfly",
-            "spellid": 374048
-          }
-        ],
-        "name": "Renown"
-      },
-      {
-        "id": "8de51dfe",
-        "items": [
-          {
-            "ID": 1546,
-            "icon": "inv_riverotterlargemount01_black",
-            "itemId": 198871,
-            "name": "Iskaara Trader's Ottuk",
-            "spellid": 359409
-          },
-          {
-            "ID": 1612,
-            "icon": "inv_mammoth2lavamount_orange",
-            "itemId": 192601,
-            "name": "Loyal Magmammoth",
-            "spellid": 373859
-          },
           {
             "ID": 1615,
             "icon": "inv_primaldragonflymount_black",
@@ -295,32 +261,37 @@
             "spellid": 374034
           },
           {
+            "ID": 1657,
+            "icon": "inv_riverotterlargemount01_brown",
+            "itemId": 198872,
+            "name": "Brown Scouting Ottuk",
+            "spellid": 376875
+          }
+        ],
+        "name": "Renown"
+      },
+      {
+        "items": [
+          {
+            "ID": 1617,
+            "icon": "inv_primaldragonflymount_green",
+            "itemId": 192764,
+            "name": "Verdant Skitterfly",
+            "spellid": 374048
+          }
+        ],
+        "name": "Treasure"
+      },
+      {
+        "id": "9bd50489",
+        "items": [
+          {
             "ID": 1622,
             "icon": "inv_salamanderwatermount_purple",
             "itemId": 192775,
             "name": "Stormhide Salamanther",
             "spellid": 374098
           },
-          {
-            "ID": 1657,
-            "icon": "inv_riverotterlargemount01_brown",
-            "itemId": 198872,
-            "name": "Brown Scouting Ottuk",
-            "spellid": 376875
-          },
-          {
-            "ID": 1658,
-            "icon": "inv_riverotterlargemount01_white",
-            "itemId": 198873,
-            "name": "Ivory Trader's Ottuk",
-            "spellid": 376879
-          }
-        ],
-        "name": "Vendor"
-      },
-      {
-        "id": "9bd50489",
-        "items": [
           {
             "ID": 1635,
             "icon": "inv_mammoth2mount_orange",
@@ -329,10 +300,50 @@
             "spellid": 374196
           }
         ],
-        "name": "Grand Hunt"
+        "name": "Events"
       },
       {
         "items": [
+          {
+            "ID": 1658,
+            "icon": "inv_riverotterlargemount01_white",
+            "itemId": 198873,
+            "name": "Ivory Trader's Ottuk",
+            "spellid": 376879
+          }
+        ],
+        "name": "Dungeon Drop"
+      },
+      {
+        "items": [
+          {
+            "ID": 1546,
+            "icon": "inv_riverotterlargemount01_black",
+            "itemId": 198871,
+            "name": "Iskaara Trader's Ottuk",
+            "spellid": 359409
+          }
+        ],
+        "name": "Raid Drop"
+      },
+      {
+        "items": [
+          {
+            "ID": 1469,
+            "icon": "inv_snailmount_orange",
+            "itemId": 192777,
+            "name": "Magmashell",
+            "notObtainable": true,
+            "spellid": 350219
+          },
+          {
+            "ID": 1656,
+            "icon": "inv_riverotterlargemount01_blue",
+            "itemId": 198870,
+            "name": "Otto",
+            "notObtainable": true,
+            "spellid": 376873
+          },
           {
             "ID": 1607,
             "icon": "inv_pterrordax2mount_white",

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -517,7 +517,7 @@
             "spellid": 368128
           }
         ],
-        "name": "Treasures"
+        "name": "Treasure"
       },
       {
         "id": "8bd8a835",

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -152,6 +152,7 @@
     "name": "Dragonflight",
     "subcats": [
       {
+        "id": "da78f1d2",
         "items": [
           {
             "ID": 1681,
@@ -271,6 +272,7 @@
         "name": "Renown"
       },
       {
+        "id": "4d7efe56",
         "items": [
           {
             "ID": 1617,
@@ -303,6 +305,7 @@
         "name": "Events"
       },
       {
+        "id": "691957c8",
         "items": [
           {
             "ID": 1658,
@@ -315,6 +318,7 @@
         "name": "Dungeon Drop"
       },
       {
+        "id": "dbb2d43d",
         "items": [
           {
             "ID": 1546,
@@ -327,6 +331,7 @@
         "name": "Raid Drop"
       },
       {
+        "id": "5ca491d5",
         "items": [
           {
             "ID": 1469,

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -152,15 +152,20 @@
     "name": "Dragonflight",
     "subcats": [
       {
-        "id": "c0bf4e7b",
         "items": [
           {
-            "ID": 1563,
-            "icon": "inv_companiondrake",
-            "itemId": 194705,
-            "name": "Highland Drake",
-            "spellid": 360954
-          },
+            "ID": 1681,
+            "icon": "inv_rhinoprimalmountice",
+            "itemId": 199412,
+            "name": "Hailstorm Armoredon",
+            "spellid": 387231
+          }
+        ],
+        "name": "Achievement"
+      },
+      {
+        "id": "c0bf4e7b",
+        "items": [
           {
             "ID": 1589,
             "icon": "inv_companionprotodragon",
@@ -176,6 +181,13 @@
             "spellid": 368899
           },
           {
+            "ID": 1563,
+            "icon": "inv_companiondrake",
+            "itemId": 194705,
+            "name": "Highland Drake",
+            "spellid": 360954
+          },
+          {
             "ID": 1591,
             "icon": "inv_companionwyvern",
             "itemId": 194521,
@@ -183,7 +195,7 @@
             "spellid": 368901
           }
         ],
-        "name": "Achievement"
+        "name": "Campaign"
       },
       {
         "id": "e504fa83",
@@ -239,7 +251,6 @@
         "name": "Quest"
       },
       {
-        "name": "Renown",
         "id": "ccc05f3b",
         "items": [
           {
@@ -249,7 +260,8 @@
             "name": "Verdant Skitterfly",
             "spellid": 374048
           }
-        ]
+        ],
+        "name": "Renown"
       },
       {
         "id": "8de51dfe",
@@ -320,17 +332,7 @@
         "name": "Grand Hunt"
       },
       {
-        "name": "Unknown",
-        "id": "7d999dce",
         "items": [
-          {
-            "ID": 1681,
-            "icon": "inv_rhinoprimalmountice",
-            "itemId": 199412,
-            "name": "Hailstorm Armoredon",
-            "notObtainable": true,
-            "spellid": 387231
-          },
           {
             "ID": 1607,
             "icon": "inv_pterrordax2mount_white",
@@ -338,7 +340,8 @@
             "notObtainable": true,
             "spellid": 372995
           }
-        ]
+        ],
+        "name": "Unknown"
       }
     ]
   },
@@ -5700,7 +5703,6 @@
         "name": "Pandaren"
       },
       {
-        "name": "Dracthyr",
         "id": "d8c1c078",
         "items": [
           {
@@ -5751,8 +5753,16 @@
             "itemId": 198810,
             "name": "Majestic Armored Vorquin",
             "spellid": 385115
+          },
+          {
+            "ID": 1664,
+            "icon": "inv_kirinmount_dark",
+            "itemId": 198808,
+            "name": "Guardian Vorquin",
+            "spellid": 384963
           }
-        ]
+        ],
+        "name": "Dracthyr"
       },
       {
         "id": "238a21a8",
@@ -7708,7 +7718,7 @@
           },
           {
             "ID": 1602,
-            "icon": "4500249",
+            "icon": "inv_tuskarrglider",
             "name": "Tuskarr Shoreglider",
             "spellid": 370770
           },


### PR DESCRIPTION
This PR adds all Dragonflight mounts, even the ones missing from the game files CSV, organized into categories after researching their origin.