### PR TITLE
Added quality comparison when parsing pets

### DIFF
--- a/src/api/_collectables.js
+++ b/src/api/_collectables.js
@@ -1,3 +1,21 @@
+function getHigherQualityBattlePet(currentPet, newPet) {
+    function getPetsQuality(type) {
+        switch (type) {
+            case "RARE": return 5
+            case "UNCOMMON": return 4
+            case "COMMON": return 3
+            case "POOR": return 2
+            default: return 1
+        }
+    }
+
+    if (currentPet != undefined &&
+            getPetsQuality(currentPet.quality.type)
+            >= getPetsQuality(newPet.quality.type)) {
+        return currentPet
+    }
+    return newPet
+}
 
 export async function parseCollectablesObject(categories, profile, collected_data, collectedProperty, collectedId, isBattlePets) {
     var obj = { 'categories': [] };
@@ -7,7 +25,13 @@ export async function parseCollectablesObject(categories, profile, collected_dat
 
     // Build up lookup for items that character has
     collected_data[collectedProperty].forEach((item) => {
-        collected[item[collectedId].id] = item;
+        if (isBattlePets) {
+            collected[item[collectedId].id] = getHigherQualityBattlePet(
+                collected[item[collectedId].id], item
+            );
+        } else {
+            collected[item[collectedId].id] = item;
+        }
     });
 
     // Lets parse out all the categories and build out our structure


### PR DESCRIPTION
Fixed a small bug when parsing the "Unborn Val'kyr" battle pet.

Blizzard API was returning poor quality after the rare quality one.
That way we were replacing the better one with the lower one.

https://github.com/kevinclement/SimpleArmory/issues/480