### PR TITLE
Update pets and achievements according to latest data import

### DIFF
--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -9449,6 +9449,24 @@
                 }
               ],
               "name": "Solo Shuffle"
+            },
+            {
+              "id": "28ad8a15",
+              "items": [
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 15957,
+                  "points": 0,
+                  "title": "Gladiator: Dragonflight Season 1"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_04",
+                  "id": 17339,
+                  "points": 0,
+                  "title": "Legend: Dragonflight Season 1"
+                }
+              ],
+              "name": "Rated Arena"
             }
           ]
         },
@@ -24605,12 +24623,6 @@
                   "id": 15643,
                   "points": 10,
                   "title": "What Can I Say? They Love Me."
-                },
-                {
-                  "icon": "inv_box_petcarrier_01",
-                  "id": 15644,
-                  "points": 10,
-                  "title": "Good Things Come in Small Packages"
                 }
               ],
               "name": "Count"
@@ -24815,12 +24827,6 @@
                   "id": 15004,
                   "points": 5,
                   "title": "A Sly Fox"
-                },
-                {
-                  "icon": "inv_icon_feather02d",
-                  "id": 16731,
-                  "points": 10,
-                  "title": "Court is Now in Session"
                 }
               ],
               "name": "Other"
@@ -34189,12 +34195,6 @@
                 },
                 {
                   "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 15957,
-                  "points": 0,
-                  "title": "Gladiator: Dragonflight Season 1"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_09",
                   "id": 15984,
                   "points": 0,
                   "title": "Elite: Dragonflight Season 1"
@@ -35555,6 +35555,12 @@
                   "id": 15323,
                   "points": 0,
                   "title": "Sarge's Tale"
+                },
+                {
+                  "icon": "4396090",
+                  "id": 15640,
+                  "points": 0,
+                  "title": "Return to Darkness"
                 }
               ],
               "name": "Mounts"

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -662,7 +662,6 @@
             "icon": "inv_eagle2windmount_white",
             "itemId": 200276,
             "name": "Ohuna Companion",
-            "notObtainable": true,
             "spellid": 389429
           },
           {
@@ -671,11 +670,10 @@
             "icon": "spell_hunter_lonewolf",
             "itemId": 200290,
             "name": "Bakar Companion",
-            "notObtainable": true,
             "spellid": 389503
           }
         ],
-        "name": "Unknown"
+        "name": "Grand Hunt"
       }
     ]
   },

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -421,14 +421,6 @@
             "itemId": 199326,
             "name": "Chip",
             "spellid": 386985
-          },
-          {
-            "ID": 3414,
-            "creatureId": 198316,
-            "icon": "inv_dragonwhelpproto_dark",
-            "itemId": 200930,
-            "name": "Obsidian Proto-Whelp",
-            "spellid": 393330
           }
         ],
         "name": "Vendor"
@@ -621,13 +613,7 @@
             "itemId": 199757,
             "name": "Magic Nibbler",
             "spellid": 388085
-          }
-        ],
-        "name": "Renown"
-      },
-      {
-        "id": "09ae7946",
-        "items": [
+          },
           {
             "ID": 3379,
             "creatureId": 196305,
@@ -637,21 +623,7 @@
             "spellid": 388086
           }
         ],
-        "name": "Obsidian Citadel"
-      },
-      {
-        "id": "ccca067e",
-        "items": [
-          {
-            "ID": 3348,
-            "creatureId": 191387,
-            "icon": "inv_10_elementalspiritfoozles_air",
-            "itemId": 199109,
-            "name": "Primal Stormling",
-            "spellid": 375713
-          }
-        ],
-        "name": "Pre-launch Event"
+        "name": "Renown"
       },
       {
         "id": "2aeb5179",
@@ -674,6 +646,48 @@
           }
         ],
         "name": "Grand Hunt"
+      },
+      {
+        "id": "e79f528b",
+        "items": [
+          {
+            "ID": 3360,
+            "creatureId": 192350,
+            "icon": "inv_babyturtle2_teal",
+            "itemId": 202085,
+            "name": "Bugbiter Tortoise",
+            "spellid": 377392
+          }
+        ],
+        "name": "Riddle"
+      },
+      {
+        "id": "09ae7946",
+        "items": [
+          {
+            "ID": 3414,
+            "creatureId": 198316,
+            "icon": "inv_dragonwhelpproto_dark",
+            "itemId": 200930,
+            "name": "Obsidian Proto-Whelp",
+            "spellid": 393330
+          }
+        ],
+        "name": "Obsidian Citadel"
+      },
+      {
+        "id": "ccca067e",
+        "items": [
+          {
+            "ID": 3348,
+            "creatureId": 191387,
+            "icon": "inv_10_elementalspiritfoozles_air",
+            "itemId": 199109,
+            "name": "Primal Stormling",
+            "spellid": 375713
+          }
+        ],
+        "name": "Pre-launch Event"
       }
     ]
   },


### PR DESCRIPTION
# Pets
- Added one new pet
- Removed `notObtainable` from two previously-unknown pets and change category name to Grand Hunt
- Swap category of two pets that were wrong before

# Achievements
- Added promotional Diablo IV mount achievement
- Removed two achievements that were removed with the latest build
- Changed gladiator and elite achievements to PvP section instead of Feats of Strength, according to db2 structure