### PR TITLE
Move Murglasses

### DIFF
--- a/static/data/toys.json
+++ b/static/data/toys.json
@@ -11,6 +11,11 @@
             "icon": "ability_siege_engineer_magnetic_crush",
             "itemId": 119215,
             "name": "Robo-Gnomebulator"
+          },
+          {
+            "icon": "inv_pet_babymurlocs_pink",
+            "itemId": 197986,
+            "name": "Murglasses"
           }
         ],
         "name": "Collect"
@@ -296,11 +301,6 @@
       {
         "id": "7dd60e6c",
         "items": [
-          {
-            "icon": "inv_pet_babymurlocs_pink",
-            "itemId": 197986,
-            "name": "Murglasses"
-          },
           {
             "icon": "inv_10_dungeonjewelry_primitive_trinket_tuskarrplushie_color1",
             "itemId": 200631,


### PR DESCRIPTION
Move Murglasses TO Collect FROM Dragonflight Achievement.

As Murglasses come from the 500 toy collection achievement, I wanted to move it to the overall Collection tab :)