### PR TITLE
Add Dragonflight factions

### DIFF
--- a/dataimporter/factions.py
+++ b/dataimporter/factions.py
@@ -8,6 +8,7 @@ from .fixer import WowToolsFixer
 
 IGNORE_FACTION_ID = [
     949,   # Test Faction 1
+    1072,  # [DNT] AC Major Faction Child Renown Test
 
     # Never implemented
     1351,  # The Brewmasters

--- a/src/api/reputations.js
+++ b/src/api/reputations.js
@@ -44,7 +44,8 @@ function parseFactions(all_factions, my_reputations) {
         var calculatedPerc = (rep.standing.value / rep.standing.max) * 100;
 
         standing[rep.faction.id] = {
-            level: rep.standing.tier,
+            // tier is called renown_level for renown factions such as those in dragonflight
+            level: rep.standing.tier != undefined ? rep.standing.tier : rep.standing.renown_level,
             perc: (isNaN(calculatedPerc) ? 100 : calculatedPerc),
             value: rep.standing.value,
             max: rep.standing.max
@@ -69,6 +70,11 @@ function parseFactions(all_factions, my_reputations) {
                 name: faction.name,
                 levels: levelsAsList(faction.levels ? faction.levels : defaultLevels),
             };
+
+            // If it's a faction with renown such as Dragonflight factions
+            if (faction.maxRenown) {
+                f.levels = maxRenownToLevels(faction.maxRenown);
+            }
 
             var stand = standing[faction.id];
             if (stand)
@@ -99,6 +105,14 @@ function levelsAsList(levelsDict) {
     });
     for (i = 0; i < items.length; i++) {
         items[i][0] = parseInt(items[i][0]);
+    }
+    return items;
+}
+
+function maxRenownToLevels(maxRenown, step = 2500) {
+    var items = [];
+    for (i = 0; i <= maxRenown; i++) {
+        items.push([i * step, "Renown 0" + i])
     }
     return items;
 }

--- a/src/api/reputations.js
+++ b/src/api/reputations.js
@@ -112,7 +112,7 @@ function levelsAsList(levelsDict) {
 function maxRenownToLevels(maxRenown, step = 2500) {
     var items = [];
     for (i = 0; i <= maxRenown; i++) {
-        items.push([i * step, "Renown 0" + i])
+        items.push([i * step, "Renown " + i])
     }
     return items;
 }

--- a/src/api/reputations.js
+++ b/src/api/reputations.js
@@ -72,8 +72,9 @@ function parseFactions(all_factions, my_reputations) {
             };
 
             // If it's a faction with renown such as Dragonflight factions
-            if (faction.maxRenown) {
-                f.levels = maxRenownToLevels(faction.maxRenown);
+            if (faction.renown) {
+                const step = faction.renown.step || 2500;
+                f.levels = renownToLevels(faction.renown.max, step);
                 f.renown = true;
             }
 
@@ -110,9 +111,9 @@ function levelsAsList(levelsDict) {
     return items;
 }
 
-function maxRenownToLevels(maxRenown, step = 2500) {
+function renownToLevels(max, step) {
     var items = [];
-    for (i = 0; i <= maxRenown; i++) {
+    for (i = 0; i <= max; i++) {
         items.push([i * step, "Renown " + i])
     }
     return items;

--- a/src/api/reputations.js
+++ b/src/api/reputations.js
@@ -74,6 +74,7 @@ function parseFactions(all_factions, my_reputations) {
             // If it's a faction with renown such as Dragonflight factions
             if (faction.maxRenown) {
                 f.levels = maxRenownToLevels(faction.maxRenown);
+                f.renown = true;
             }
 
             var stand = standing[faction.id];

--- a/src/components/ReputationRow.svelte
+++ b/src/components/ReputationRow.svelte
@@ -17,7 +17,9 @@
         return levelColors[
             Math.max(
                 0,
-                levelColors.length - (faction.levels.length - level)
+                faction.renown ?
+                    Math.floor((level / faction.levels.length) * (levelColors.length - 1)) :
+                    levelColors.length - (faction.levels.length - level)
             )
         ];
     }

--- a/static/data/factions.json
+++ b/static/data/factions.json
@@ -12,13 +12,23 @@
     "factions": [
       {
         "id": 2507,
-        "name": "Dragonscale Expedition",
-        "maxRenown": 25
+        "maxRenown": 25,
+        "name": "Dragonscale Expedition"
+      },
+      {
+        "id": 2503,
+        "maxRenown": 25,
+        "name": "Maruuk Centaur"
       },
       {
         "id": 2511,
-        "name": "Iskaara Tuskarr",
-        "maxRenown": 30
+        "maxRenown": 30,
+        "name": "Iskaara Tuskarr"
+      },
+      {
+        "id": 2510,
+        "maxRenown": 30,
+        "name": "Valdrakken Accord"
       },
       {
         "id": 2523,

--- a/static/data/factions.json
+++ b/static/data/factions.json
@@ -12,11 +12,13 @@
     "factions": [
       {
         "id": 2507,
-        "name": "Dragonscale Expedition"
+        "name": "Dragonscale Expedition",
+        "maxRenown": 25
       },
       {
         "id": 2511,
-        "name": "Iskaara Tuskarr"
+        "name": "Iskaara Tuskarr",
+        "maxRenown": 30
       },
       {
         "id": 2523,

--- a/static/data/factions.json
+++ b/static/data/factions.json
@@ -12,23 +12,35 @@
     "factions": [
       {
         "id": 2507,
-        "maxRenown": 25,
-        "name": "Dragonscale Expedition"
+        "name": "Dragonscale Expedition",
+        "renown": {
+          "max": 25,
+          "step": 2500
+        }
       },
       {
         "id": 2503,
-        "maxRenown": 25,
-        "name": "Maruuk Centaur"
+        "name": "Maruuk Centaur",
+        "renown": {
+          "max": 25,
+          "step": 2500
+        }
       },
       {
         "id": 2511,
-        "maxRenown": 30,
-        "name": "Iskaara Tuskarr"
+        "name": "Iskaara Tuskarr",
+        "renown": {
+          "max": 30,
+          "step": 2500
+        }
       },
       {
         "id": 2510,
-        "maxRenown": 30,
-        "name": "Valdrakken Accord"
+        "name": "Valdrakken Accord",
+        "renown": {
+          "max": 30,
+          "step": 2500
+        }
       },
       {
         "id": 2523,

--- a/static/data/factions.json
+++ b/static/data/factions.json
@@ -11,6 +11,89 @@
   {
     "factions": [
       {
+        "id": 2507,
+        "name": "Dragonscale Expedition"
+      },
+      {
+        "id": 2511,
+        "name": "Iskaara Tuskarr"
+      },
+      {
+        "id": 2523,
+        "name": "Dark Talons"
+      },
+      {
+        "id": 2524,
+        "name": "Obsidian Warders"
+      },
+      {
+        "id": 2517,
+        "levels": {
+          "0": "Acquaintance",
+          "8400": "Cohort",
+          "16800": "Ally",
+          "25200": "Fang",
+          "33600": "Friend",
+          "42000": "True Friend"
+        },
+        "name": "Wrathion"
+      },
+      {
+        "id": 2518,
+        "levels": {
+          "0": "Acquaintance",
+          "8400": "Cohort",
+          "16800": "Ally",
+          "25200": "Fang",
+          "33600": "Friend",
+          "42000": "True Friend"
+        },
+        "name": "Sabellian"
+      },
+      {
+        "id": 2544,
+        "levels": {
+          "0": "Neutral",
+          "500": "Preferred",
+          "2500": "Respected",
+          "5500": "Valued",
+          "12500": "Esteemed"
+        },
+        "name": "Artisan's Consortium - Dragon Isles Branch"
+      },
+      {
+        "id": 2550,
+        "levels": {
+          "0": "Empty",
+          "300": "Low",
+          "1200": "Medium",
+          "3600": "High",
+          "10000": "Maximum"
+        },
+        "name": "Cobalt Assembly"
+      },
+      {
+        "id": 2520,
+        "name": "Clan Nokhud"
+      },
+      {
+        "id": 2526,
+        "name": "Winterpelt Furbolg"
+      },
+      {
+        "id": 2542,
+        "name": "Clan Ukhel"
+      },
+      {
+        "id": 2555,
+        "name": "Clan Kaighan"
+      }
+    ],
+    "name": "Dragonflight"
+  },
+  {
+    "factions": [
+      {
         "id": 2465,
         "name": "The Wild Hunt"
       },


### PR DESCRIPTION
This one is not as easy as I'd hoped.

TODO Back-end:
- [x] Run data import for factions
- [x] Figure out why data import is not importing all factions (Centaurs, Valdrakken accord, etc.)
- [x] Change DataImporter to automatically import `maxRenown`.

TODO Front-end:
- [x] Make renown 25 and 30 fit into the default line width for reputations
- [x] Change "Renown 0x" to "Renown x"
- [x] Fix color with sliding scale for renown factions

Development Notes:
Puzzling with the CSV build files gave me the following information
- The dragonflight factions with renown have property `flag` set to `2`
- Main dragonflight factions are also covenants
- Reputation upgrades are visible under renown rewards csv (possibility for figuring out max-renown!)
