### PR TITLE
Add new store mount 

### DIFF
--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -7684,6 +7684,12 @@
             "icon": "3160007",
             "name": "Gargantuan Grrloc",
             "spellid": 315132
+          },
+          {
+            "ID": 1594,
+            "icon": "4381911",
+            "name": "Jade, Bright Foreseer",
+            "spellid": 369451
           }
         ],
         "name": "Blizzard Store"


### PR DESCRIPTION
This PR adds the new store mount that is included with the 12- or 6-month subscription: https://www.wowhead.com/spell=369451/jade-bright-foreseer. 