### PR TITLE
Add 10.0.5 achievements, mounts, companions, titles and toys

### DIFF
--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -181,6 +181,24 @@
               "name": "Items"
             },
             {
+              "id": "3e10604b",
+              "items": [
+                {
+                  "icon": "tradingpostcurrency",
+                  "id": 17305,
+                  "points": 10,
+                  "title": "Trading Post: Dragonflight"
+                },
+                {
+                  "icon": "tradingpostcurrency",
+                  "id": 17334,
+                  "points": 10,
+                  "title": "Trading Post Enthusiast"
+                }
+              ],
+              "name": "Trading Post"
+            },
+            {
               "id": "ea171fdd",
               "items": [
                 {
@@ -605,6 +623,24 @@
                 }
               ],
               "name": "Azure Span"
+            },
+            {
+              "id": "eae797d4",
+              "items": [
+                {
+                  "icon": "ability_evoker_timedilation",
+                  "id": 17342,
+                  "points": 5,
+                  "title": "The Future We Make"
+                },
+                {
+                  "icon": "inv_elemental_eternal_fire",
+                  "id": 17343,
+                  "points": 5,
+                  "title": "Drop It Like It's Hot"
+                }
+              ],
+              "name": "Primalist Future"
             },
             {
               "id": "3b0121a0",
@@ -9868,6 +9904,24 @@
                   "id": 16616,
                   "points": 10,
                   "title": "Prosperously Bloody"
+                },
+                {
+                  "icon": "ability_dragonriding_barrelroll01",
+                  "id": 17335,
+                  "points": 5,
+                  "title": "Airborne Tumbler"
+                },
+                {
+                  "icon": "ability_dragonriding_barrelroll01",
+                  "id": 17336,
+                  "points": 5,
+                  "title": "Airborne Tumbler"
+                },
+                {
+                  "icon": "ability_dragonriding_barrelroll01",
+                  "id": 17345,
+                  "points": 5,
+                  "title": "Airborne Tumbler"
                 }
               ],
               "name": "Dragonflight"
@@ -20292,6 +20346,12 @@
                   "id": 9547,
                   "points": 10,
                   "title": "Everything Is Awesome!"
+                },
+                {
+                  "icon": "ui_profession_fishing",
+                  "id": 17207,
+                  "points": 10,
+                  "title": "Discombobberlated"
                 }
               ],
               "name": "Other"
@@ -22639,6 +22699,12 @@
                   "id": 6006,
                   "points": 10,
                   "title": "Elders of Cataclysm"
+                },
+                {
+                  "icon": "spell_holy_symbolofhope",
+                  "id": 17321,
+                  "points": 10,
+                  "title": "Elders of the Dragon Isles"
                 }
               ],
               "name": "Elders"
@@ -26644,6 +26710,138 @@
               "name": "Count"
             }
           ]
+        },
+        {
+          "id": "0bfea8d6",
+          "name": "Dragon Isle Drake Cosmetics",
+          "subcats": [
+            {
+              "id": "6d222748",
+              "items": [
+                {
+                  "icon": "inv_companionprotodragon",
+                  "id": 16696,
+                  "points": 5,
+                  "title": "Renewed Proto-Drake Armor"
+                },
+                {
+                  "icon": "inv_companionprotodragon",
+                  "id": 16697,
+                  "points": 5,
+                  "title": "Renewed Proto-Drake Head Features"
+                },
+                {
+                  "icon": "inv_companionprotodragon",
+                  "id": 16698,
+                  "points": 5,
+                  "title": "Renewed Proto-Drake Tail Features"
+                },
+                {
+                  "icon": "inv_companionprotodragon",
+                  "id": 16699,
+                  "points": 5,
+                  "title": "Renewed Proto-Drake Scales and Patterns"
+                },
+                {
+                  "icon": "inv_companionprotodragon",
+                  "id": 16700,
+                  "points": 5,
+                  "title": "Renewed Proto-Drake Horns and Hair"
+                },
+                {
+                  "icon": "inv_companionpterrordaxdrake",
+                  "id": 16701,
+                  "points": 5,
+                  "title": "Windborne Velocidrake Scales and Patterns"
+                },
+                {
+                  "icon": "inv_companionpterrordaxdrake",
+                  "id": 16702,
+                  "points": 5,
+                  "title": "Windborne Velocidrake Armor"
+                },
+                {
+                  "icon": "inv_companionpterrordaxdrake",
+                  "id": 16704,
+                  "points": 5,
+                  "title": "Windborne Velocidrake Horns and Fur"
+                },
+                {
+                  "icon": "inv_companionpterrordaxdrake",
+                  "id": 16705,
+                  "points": 5,
+                  "title": "Windborne Velocidrake Head Features"
+                },
+                {
+                  "icon": "inv_companionpterrordaxdrake",
+                  "id": 16706,
+                  "points": 5,
+                  "title": "Windborne Velocidrake Back and Tail"
+                },
+                {
+                  "icon": "inv_companiondrake",
+                  "id": 16707,
+                  "points": 5,
+                  "title": "Highland Drake Scales and Patterns"
+                },
+                {
+                  "icon": "inv_companiondrake",
+                  "id": 16708,
+                  "points": 5,
+                  "title": "Highland Drake Armor"
+                },
+                {
+                  "icon": "inv_companiondrake",
+                  "id": 16710,
+                  "points": 5,
+                  "title": "Highland Drake Horns and Hair"
+                },
+                {
+                  "icon": "inv_companiondrake",
+                  "id": 16711,
+                  "points": 5,
+                  "title": "Highland Drake Back and Tail"
+                },
+                {
+                  "icon": "inv_companiondrake",
+                  "id": 16712,
+                  "points": 5,
+                  "title": "Highland Drake Head Features"
+                },
+                {
+                  "icon": "inv_companionwyvern",
+                  "id": 16723,
+                  "points": 5,
+                  "title": "Cliffside Wylderdrake Scales and Patterns"
+                },
+                {
+                  "icon": "inv_companionwyvern",
+                  "id": 16724,
+                  "points": 5,
+                  "title": "Cliffside Wylderdrake Armor"
+                },
+                {
+                  "icon": "inv_companionwyvern",
+                  "id": 16725,
+                  "points": 5,
+                  "title": "Cliffside Wylderdrake Horns and Manes"
+                },
+                {
+                  "icon": "inv_companionwyvern",
+                  "id": 16726,
+                  "points": 5,
+                  "title": "Cliffside Wylderdrake Back and Tail"
+                },
+                {
+                  "icon": "inv_companionwyvern",
+                  "id": 16727,
+                  "points": 5,
+                  "title": "Cliffside Wylderdrake Head Features"
+                }
+              ],
+              "name": "Cosmetics"
+            }
+          ]
         }
       ],
       "id": "8d854418",
@@ -26675,6 +26873,24 @@
                   "id": 15941,
                   "points": 20,
                   "title": "Dragon Racing Completionist: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 17330,
+                  "points": 10,
+                  "title": "Reverse Racer: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 17331,
+                  "points": 10,
+                  "title": "Reverse Racer: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 17332,
+                  "points": 10,
+                  "title": "Reverse Racer: Gold"
                 }
               ],
               "name": ""
@@ -26834,6 +27050,84 @@
                 }
               ],
               "name": "Advanced Races"
+            },
+            {
+              "id": "2da9bd1a",
+              "items": [
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 17195,
+                  "points": 10,
+                  "title": "Waking Shores Reverse: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 17198,
+                  "points": 10,
+                  "title": "Ohn'ahran Plains Reverse: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 17201,
+                  "points": 10,
+                  "title": "Azure Span Reverse: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 17204,
+                  "points": 10,
+                  "title": "Thaldraszus Reverse: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 17196,
+                  "points": 10,
+                  "title": "Waking Shores Reverse: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 17199,
+                  "points": 10,
+                  "title": "Ohn'ahran Plains Reverse: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 17202,
+                  "points": 10,
+                  "title": "Azure Span Reverse: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 17205,
+                  "points": 10,
+                  "title": "Thaldraszus Reverse: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 17197,
+                  "points": 10,
+                  "title": "Waking Shores Reverse: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 17200,
+                  "points": 10,
+                  "title": "Ohn'ahran Plains Reverse: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 17203,
+                  "points": 10,
+                  "title": "Azure Span Reverse: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 17206,
+                  "points": 10,
+                  "title": "Thaldraszus Reverse: Gold"
+                }
+              ],
+              "name": "Reverse Races"
             },
             {
               "id": "ce7230c2",
@@ -34209,7 +34503,7 @@
                   "icon": "achievement_featsofstrength_gladiator_07",
                   "id": 16734,
                   "points": 0,
-                  "title": "Crimson Soloist: Dragonflight Season 1"
+                  "title": "Crimson Legend: Dragonflight Season 1"
                 }
               ],
               "name": "Rated Arena"

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -375,6 +375,13 @@
             "itemId": 192791,
             "name": "Plainswalker Bearer",
             "spellid": 374196
+          },
+          {
+            "ID": 1478,
+            "icon": "inv_tallstriderprimalmount_blue",
+            "itemId": 192800,
+            "name": "Skyskin Hornstrider",
+            "spellid": 352926
           }
         ],
         "name": "Events"
@@ -8140,6 +8147,61 @@
           }
         ],
         "name": "Trading Card Game"
+      },
+      {
+        "id": "0738daf2",
+        "items": [
+          {
+            "ID": 1574,
+            "icon": "inv_crabmount_blue",
+            "itemId": 190168,
+            "name": "Crusty Crawler",
+            "spellid": 366789
+          },
+          {
+            "ID": 1575,
+            "icon": "inv_parrotmount_purple",
+            "itemId": 190169,
+            "name": "Quawks",
+            "spellid": 366790
+          },
+          {
+            "ID": 1577,
+            "icon": "4220140",
+            "itemId": 190231,
+            "name": "Ash'adar, Harbinger of Dawn",
+            "spellid": 366962
+          },
+          {
+            "ID": 1579,
+            "icon": "inv_sharkraymount_4",
+            "itemId": 190539,
+            "name": "Coral-Stalker Waveray",
+            "spellid": 367620
+          },
+          {
+            "ID": 1582,
+            "icon": "4329767",
+            "itemId": 190613,
+            "name": "Savage Green Battle Turtle",
+            "spellid": 367826
+          },
+          {
+            "ID": 1586,
+            "icon": "inv_pterrordax2mount_gold",
+            "itemId": 190767,
+            "name": "Armored Golden Pterrordax",
+            "spellid": 368126
+          },
+          {
+            "ID": 1595,
+            "icon": "ivn_toadloamount_blue",
+            "itemId": 191094,
+            "name": "Cerulean Marsh Hopper",
+            "spellid": 369480
+          }
+        ],
+        "name": "Trading Post"
       }
     ]
   },
@@ -8630,6 +8692,35 @@
           }
         ],
         "name": "Make-A-Wish"
+      },
+      {
+        "id": "482f61e7",
+        "items": [
+          {
+            "ID": 1573,
+            "icon": "inv_pandarenserpentmount_purple",
+            "itemId": 189978,
+            "name": "Magenta Cloud Serpent",
+            "notObtainable": true,
+            "spellid": 366647
+          },
+          {
+            "ID": 1583,
+            "icon": "4201986",
+            "itemId": 190636,
+            "name": "Armored Siege Kodo",
+            "notObtainable": true,
+            "spellid": 367875
+          },
+          {
+            "ID": 1690,
+            "icon": "inv_companionprotodragon",
+            "name": "Whelpling",
+            "notObtainable": true,
+            "spellid": 395095
+          }
+        ],
+        "name": "Unknown"
       }
     ]
   }

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -407,6 +407,14 @@
             "spellid": 388913
           },
           {
+            "ID": 3334,
+            "creatureId": 191298,
+            "icon": "inv_kirinbaby_bronze",
+            "itemId": 193855,
+            "name": "Time-Lost Vorquin Foal",
+            "spellid": 375567
+          },
+          {
             "ID": 3303,
             "creatureId": 189140,
             "icon": "inv_duckbaby_mallard",
@@ -9827,6 +9835,84 @@
           }
         ],
         "name": "Trading Card Game"
+      },
+      {
+        "id": "231e8d27",
+        "items": [
+          {
+            "ID": 3242,
+            "creatureId": 185322,
+            "icon": "inv_brontosaurusmount",
+            "itemId": 190173,
+            "name": "Lil' Maka'jin",
+            "spellid": 366833
+          },
+          {
+            "ID": 3243,
+            "creatureId": 183686,
+            "icon": "creatureportrait_robot_doberman",
+            "itemId": 190175,
+            "name": "Pippin",
+            "spellid": 366841
+          },
+          {
+            "ID": 3244,
+            "creatureId": 185324,
+            "icon": "inv_mummypet",
+            "itemId": 190176,
+            "name": "Drazka'zet the Wrathful",
+            "spellid": 366842
+          },
+          {
+            "ID": 3250,
+            "creatureId": 183708,
+            "icon": "inv_pet_egbert",
+            "itemId": 190603,
+            "name": "Egbob",
+            "spellid": 367732
+          },
+          {
+            "ID": 3251,
+            "creatureId": 185604,
+            "icon": "inv_bee_red",
+            "itemId": 190604,
+            "name": "Buzzworth",
+            "spellid": 367748
+          },
+          {
+            "ID": 3252,
+            "creatureId": 185606,
+            "icon": "4215254",
+            "itemId": 190607,
+            "name": "Garrlok",
+            "spellid": 367768
+          },
+          {
+            "ID": 3253,
+            "creatureId": 185611,
+            "icon": "4205812",
+            "itemId": 190608,
+            "name": "Crushhoof",
+            "spellid": 367778
+          },
+          {
+            "ID": 3254,
+            "creatureId": 185621,
+            "icon": "inv_jewelcrafting_jadeowl",
+            "itemId": 190609,
+            "name": "Watcher of the Huntress",
+            "spellid": 367800
+          },
+          {
+            "ID": 3255,
+            "creatureId": 185756,
+            "icon": "inv_pet_babymoose_white",
+            "itemId": 190925,
+            "name": "Buttercup",
+            "spellid": 368314
+          }
+        ],
+        "name": "Trading Post"
       },
       {
         "items": [

--- a/static/data/titles.json
+++ b/static/data/titles.json
@@ -225,20 +225,20 @@
     "subcats": [
       {
         "items": [
-            {
-              "icon": "achievement_raidprimalist_raszageth",
-              "id": 17116,
-              "name": "Famed Slayer of Raszageth",
-              "titleId": 487,
-              "type": "achievement"
-            },
-            {
-              "icon": "achievement_raidprimalist_raszageth",
-              "id": 16353,
-              "name": "The Storm-Eater",
-              "titleId": 488,
-              "type": "achievement"
-            }
+          {
+            "icon": "achievement_raidprimalist_raszageth",
+            "id": 17116,
+            "name": "Famed Slayer of Raszageth",
+            "titleId": 487,
+            "type": "achievement"
+          },
+          {
+            "icon": "achievement_raidprimalist_raszageth",
+            "id": 16353,
+            "name": "The Storm-Eater",
+            "titleId": 488,
+            "type": "achievement"
+          }
         ],
         "name": "Raids"
       },
@@ -326,9 +326,9 @@
             "icon": "inv_misc_questionmark",
             "id": 742,
             "name": "The Elite Evoker",
+            "notObtainable": true,
             "titleId": 481,
-            "type": "title",
-            "notObtainable": true
+            "type": "title"
           }
         ],
         "name": "Unknown"
@@ -354,6 +354,13 @@
             "id": 15941,
             "name": "Isles Racer",
             "titleId": 478,
+            "type": "achievement"
+          },
+          {
+            "icon": "achievement_challengemode_arakkoaspires_gold",
+            "id": 17332,
+            "name": "Reverse Racer",
+            "titleId": 490,
             "type": "achievement"
           }
         ],
@@ -1983,6 +1990,13 @@
             "name": "Malicious",
             "titleId": 479,
             "type": "achievement"
+          },
+          {
+            "icon": "ability_dragonriding_barrelroll01",
+            "id": 17345,
+            "name": "Skyscourge",
+            "titleId": 492,
+            "type": "achievement"
           }
         ],
         "name": "World PVP"
@@ -2407,9 +2421,16 @@
             "type": "achievement"
           },
           {
+            "icon": "achievement_featsofstrength_gladiator_04",
+            "id": 17339,
+            "name": "Legend",
+            "titleId": 491,
+            "type": "achievement"
+          },
+          {
             "icon": "achievement_featsofstrength_gladiator_07",
             "id": 16734,
-            "name": "Crimson Soloist",
+            "name": "Crimson Legend",
             "titleId": 482,
             "type": "achievement"
           }

--- a/static/data/toys.json
+++ b/static/data/toys.json
@@ -310,6 +310,11 @@
             "icon": "inv_eagle2wind",
             "itemId": 200630,
             "name": "Ohn'ir Windsage's Hearthstone"
+          },
+          {
+            "icon": "achievement_profession_fishing_outlandangler",
+            "itemId": 202207,
+            "name": "Reusable Oversized Bobber"
           }
         ],
         "name": "Achievement"
@@ -447,6 +452,11 @@
             "icon": "inv_box_01",
             "itemId": 200707,
             "name": "Armoire of Endless Cloaks"
+          },
+          {
+            "icon": "spell_lightning_lightningbolt01",
+            "itemId": 202020,
+            "name": "Chasing Storm"
           }
         ],
         "name": "Vendor"
@@ -1101,6 +1111,12 @@
             "icon": "inv_misc_mdi_banner04",
             "itemId": 187959,
             "name": "PH - Banner of the Opportune",
+            "notObtainable": true
+          },
+          {
+            "icon": "inv_mdi_awc_bannerreward_icons_purple",
+            "itemId": 203716,
+            "name": "Thundering Banner of the Aspects",
             "notObtainable": true
           }
         ],
@@ -3986,6 +4002,11 @@
             "icon": "inv_engineering_90_wormholegenerator",
             "itemId": 172924,
             "name": "Wormhole Generator: Shadowlands"
+          },
+          {
+            "icon": "inv_misc_bomb_04",
+            "itemId": 202309,
+            "name": "Defective Doomsday Device"
           }
         ],
         "name": "Engineering"


### PR DESCRIPTION
Title says it all.

Two remarks:
- I made a subcategory Trading Post (new 10.0.5 feature) under promotional, as it seemed the best fit, but I'm curious what category you guys would put it under.
- Some mounts do not have correct icons or are unknown at wowhead. I assume these are Trading Post mounts as well but just to be sure I made a new subcategory under "Other" and put them as `notObtainable`. Is this an ok solution or what would you do in this case?