### PR TITLE
reorganize Dragonflight toys

### DIFF
--- a/static/data/toys.json
+++ b/static/data/toys.json
@@ -120,36 +120,6 @@
             "name": "Personal Shell"
           },
           {
-            "ID": 1102,
-            "icon": "inv_item_dragonegg_black01",
-            "itemId": 200640,
-            "name": "Obsidian Egg Clutch"
-          },
-          {
-            "ID": 1200,
-            "icon": "ability_creature_poison_02",
-            "itemId": 198090,
-            "name": "Jar of Excess Slime"
-          },
-          {
-            "ID": 1203,
-            "icon": "achievement_profession_fishing_northrendangler",
-            "itemId": 198428,
-            "name": "Tuskarr Dinghy"
-          },
-          {
-            "ID": 1205,
-            "icon": "inv_inscription_certificate",
-            "itemId": 198474,
-            "name": "Artist's Easel"
-          },
-          {
-            "ID": 1209,
-            "icon": "inv_misc_xmassled",
-            "itemId": 198827,
-            "name": "Magical Snow Sled"
-          },
-          {
             "ID": 1225,
             "icon": "ability_mage_massinvisibility",
             "itemId": 200148,
@@ -160,42 +130,6 @@
             "icon": "inv_misc_food_vendor_yakcheesecurds",
             "itemId": 200160,
             "name": "Notfar's Favorite Food"
-          },
-          {
-            "ID": 1244,
-            "icon": "inv_babyturtle2",
-            "itemId": 200999,
-            "name": "The Super Shellkhan Gang"
-          },
-          {
-            "ID": 1253,
-            "icon": "inv_misc_xmassled",
-            "itemId": 199899,
-            "name": "Iskaara Tug Sled"
-          },
-          {
-            "ID": 1269,
-            "icon": "inv_polearm_2h_dragon_b_01",
-            "itemId": 201933,
-            "name": "Black Dragon's Challenge Dummy"
-          },
-          {
-            "ID": 1274,
-            "icon": "inv_helm_glasses_b_01_black_teal",
-            "itemId": 202042,
-            "name": "Aquatic Shades"
-          },
-          {
-            "ID": 1275,
-            "icon": "inv_misc_book_03",
-            "itemId": 200926,
-            "name": "Compendium of Love"
-          },
-          {
-            "ID": 1280,
-            "icon": "inv_10_dungeonjewelry_explorer_trinket_1compass_color1",
-            "itemId": 202711,
-            "name": "Lost Compass"
           },
           {
             "ID": 1227,
@@ -216,31 +150,138 @@
             "name": "Mage's Chewed Wand"
           },
           {
-            "ID": 1240,
-            "icon": "inv_jewelry_orgrimmarraid_trinket_18",
-            "itemId": 200857,
-            "name": "Talisman of Sargha"
-          },
-          {
-            "ID": 1295,
-            "icon": "sha_spell_fire_felfire",
-            "itemId": 203757,
-            "name": "Brazier of Madness"
-          },
-          {
-            "ID": 1237,
-            "icon": "inv_10_enchanting2_elementalswirl_color1",
-            "itemId": 200636,
-            "name": "Primal Invocation Quintessence"
-          },
-          {
-            "ID": 1239,
-            "icon": "inv_60pvp_trinket4a",
-            "itemId": 200116,
-            "name": "Everlasting Horn of Lavaswimming"
+            "ID": 1244,
+            "icon": "inv_babyturtle2",
+            "itemId": 200999,
+            "name": "The Super Shellkhan Gang"
           }
         ],
-        "name": "Drop"
+        "name": "Rare"
+      },
+      {
+        "items": [
+          {
+            "ID": 1270,
+            "icon": "trade_archaeology_gemmeddrinkingcup",
+            "itemId": 202019,
+            "name": "Golden Dragon Goblet"
+          },
+          {
+            "ID": 1272,
+            "icon": "inv_misc_pet_01",
+            "itemId": 202022,
+            "name": "Yennu's Kite"
+          },
+          {
+            "ID": 1269,
+            "icon": "inv_polearm_2h_dragon_b_01",
+            "itemId": 201933,
+            "name": "Black Dragon's Challenge Dummy"
+          },
+          {
+            "ID": 1242,
+            "icon": "inv_garrison_cargoship",
+            "itemId": 200878,
+            "name": "Wheeled Floaty Boaty Controller"
+          },
+          {
+            "ID": 1241,
+            "icon": "inv_misc_archaeology_vrykuldrinkinghorn",
+            "itemId": 200869,
+            "name": "Ohn Lite Branded Horn"
+          },
+          {
+            "ID": 1280,
+            "icon": "inv_10_dungeonjewelry_explorer_trinket_1compass_color1",
+            "itemId": 202711,
+            "name": "Lost Compass"
+          },
+          {
+            "ID": 1267,
+            "icon": "oshugun_crystalfragments",
+            "itemId": 201927,
+            "name": "Gleaming Arcanocrystal"
+          }
+        ],
+        "name": "Treasure"
+      },
+      {
+        "id": "903f7671",
+        "items": [
+          {
+            "ID": 1222,
+            "icon": "inv_misc_bag_enchantedrunecloth",
+            "itemId": 199337,
+            "name": "Bag of Furious Winds"
+          },
+          {
+            "ID": 1208,
+            "icon": "inv_komododragon_stone",
+            "itemId": 198646,
+            "name": "Ornate Dragon Statue"
+          },
+          {
+            "ID": 1307,
+            "icon": "inv_misc_spyglass_03",
+            "itemId": 199900,
+            "name": "Secondhand Survey Tools"
+          },
+          {
+            "ID": 1246,
+            "icon": "inv_10_worlddroplevelingoptionalreagent_relics_hourglass_color3",
+            "itemId": 201435,
+            "name": "Shuffling Sands"
+          },
+          {
+            "ID": 1274,
+            "icon": "inv_helm_glasses_b_01_black_teal",
+            "itemId": 202042,
+            "name": "Aquatic Shades"
+          },
+          {
+            "ID": 1271,
+            "icon": "spell_lightning_lightningbolt01",
+            "itemId": 202020,
+            "name": "Chasing Storm"
+          },
+          {
+            "ID": 1273,
+            "icon": "inv_10_dungeonjewelry_dragon_trinket_3djardintrophy_black",
+            "itemId": 202021,
+            "name": "Breaker's Flag of Victory"
+          }
+        ],
+        "name": "Vendor"
+      },
+      {
+        "id": "7dd60e6c",
+        "items": [
+          {
+            "ID": 1203,
+            "icon": "achievement_profession_fishing_northrendangler",
+            "itemId": 198428,
+            "name": "Tuskarr Dinghy"
+          },
+          {
+            "ID": 1236,
+            "icon": "inv_eagle2wind",
+            "itemId": 200630,
+            "name": "Ohn'ir Windsage's Hearthstone"
+          },
+          {
+            "ID": 1238,
+            "icon": "inv_10_dungeonjewelry_primitive_trinket_tuskarrplushie_color1",
+            "itemId": 200631,
+            "name": "Happy Tuskarr Palooza"
+          },
+          {
+            "ID": 1276,
+            "icon": "achievement_profession_fishing_outlandangler",
+            "itemId": 202207,
+            "name": "Reusable Oversized Bobber"
+          }
+        ],
+        "name": "Achievement"
       },
       {
         "id": "877c9d6c",
@@ -376,48 +417,64 @@
             "icon": "inv_10_engineering2_pvpflaregun_color1",
             "itemId": 201930,
             "name": "H.E.L.P."
+          },
+          {
+            "ID": 1237,
+            "icon": "inv_10_enchanting2_elementalswirl_color1",
+            "itemId": 200636,
+            "name": "Primal Invocation Quintessence"
           }
         ],
         "name": "Profession"
       },
       {
-        "id": "7dd60e6c",
-        "items": [
+        "items":[
           {
-            "ID": 1238,
-            "icon": "inv_10_dungeonjewelry_primitive_trinket_tuskarrplushie_color1",
-            "itemId": 200631,
-            "name": "Happy Tuskarr Palooza"
+            "ID": 1252,
+            "icon": "inv_10_dungeonjewelry_explorer_trinket_1compass_color2",
+            "itemId": 199902,
+            "name": "Wayfinder's Compass"
           },
           {
-            "ID": 1236,
-            "icon": "inv_eagle2wind",
-            "itemId": 200630,
-            "name": "Ohn'ir Windsage's Hearthstone"
+            "ID": 1262,
+            "icon": "inv_10_tailoring2_pillow_black",
+            "itemId": 198722,
+            "name": "Small Triangular Pillow"
           },
           {
-            "ID": 1276,
-            "icon": "achievement_profession_fishing_outlandangler",
-            "itemId": 202207,
-            "name": "Reusable Oversized Bobber"
+            "ID": 1263,
+            "icon": "inv_10_tailoring2_pillow_red",
+            "itemId": 198721,
+            "name": "Skinny Reliquary Pillow"
+          },
+          {
+            "ID": 1264,
+            "icon": "inv_10_tailoring2_pillow_purple",
+            "itemId": 198720,
+            "name": "Soft Purple Pillow"
+          },
+          {
+            "ID": 1261,
+            "icon": "inv_misc_tabard_explorersguild",
+            "itemId": 198728,
+            "name": "Explorer's League Banner"
+          },
+          {
+            "ID": 1260,
+            "icon": "inv_misc_tabard_thereliquary",
+            "itemId": 198729,
+            "name": "Reliquary Banner"
           }
         ],
-        "name": "Achievement"
+        "name": "Renown: Dragonscale Expedition"
       },
       {
-        "id": "903f7671",
-        "items": [
+        "items":[
           {
-            "ID": 1208,
-            "icon": "inv_komododragon_stone",
-            "itemId": 198646,
-            "name": "Ornate Dragon Statue"
-          },
-          {
-            "ID": 1222,
-            "icon": "inv_misc_bag_enchantedrunecloth",
-            "itemId": 199337,
-            "name": "Bag of Furious Winds"
+            "ID": 1201,
+            "icon": "inv_misc_cauldron_arcane",
+            "itemId": 198402,
+            "name": "Maruuk Cooking Pot"
           },
           {
             "ID": 1232,
@@ -432,10 +489,68 @@
             "name": "Comfortable Pile of Pelts"
           },
           {
-            "ID": 1246,
-            "icon": "inv_10_worlddroplevelingoptionalreagent_relics_hourglass_color3",
-            "itemId": 201435,
-            "name": "Shuffling Sands"
+            "ID": 1265,
+            "icon": "ability_skyreach_castdown",
+            "itemId": 194885,
+            "name": "Ohuna Perch"
+          }
+        ],
+        "name": "Renown: Maruuk Centaur"
+      },
+      {
+        "items":[
+          {
+            "ID": 1258,
+            "icon": "archaeology_5_0_pandarenteaset",
+            "itemId": 199650,
+            "name": "Whale Bone Tea Set"
+          },
+          {
+            "ID": 1257,
+            "icon": "inv_guild_cauldron_a",
+            "itemId": 199892,
+            "name": "Tuskarr Traveling Soup Pot"
+          },
+          {
+            "ID": 1256,
+            "icon": "inv_misc_food_164_fish_seadog",
+            "itemId": 199894,
+            "name": "Fisherman's Folly"
+          },
+          {
+            "ID": 1255,
+            "icon": "inv_misc_fish_26",
+            "itemId": 199896,
+            "name": "Rubbery Fish Head"
+          },
+          {
+            "ID": 1254,
+            "icon": "inv_misc_coinbag09",
+            "itemId": 199897,
+            "name": "Blue-Covered Beanbag"
+          },
+          {
+            "ID": 1209,
+            "icon": "inv_misc_xmassled",
+            "itemId": 198827,
+            "name": "Magical Snow Sled"
+          },
+          {
+            "ID": 1253,
+            "icon": "inv_misc_xmassled",
+            "itemId": 199899,
+            "name": "Iskaara Tug Sled"
+          }
+        ],
+        "name": "Renown: Iskarra Tuskarr"
+      },
+      {
+        "items":[
+          {
+            "ID": 1259,
+            "icon": "inv_misc_pearlmilktea",
+            "itemId": 199649,
+            "name": "Dragon Tea Set"
           },
           {
             "ID": 1247,
@@ -466,96 +581,23 @@
             "icon": "inv_10_tailoring2_banner_red",
             "itemId": 199767,
             "name": "Red Dragon Banner"
-          },
+          }
+        ],
+        "name": "Renown: Valdrakken Accord"
+      },
+      {
+        "items":[
           {
-            "ID": 1254,
-            "icon": "inv_misc_coinbag09",
-            "itemId": 199897,
-            "name": "Blue-Covered Beanbag"
-          },
-          {
-            "ID": 1255,
-            "icon": "inv_misc_fish_26",
-            "itemId": 199896,
-            "name": "Rubbery Fish Head"
-          },
-          {
-            "ID": 1256,
-            "icon": "inv_misc_food_164_fish_seadog",
-            "itemId": 199894,
-            "name": "Fisherman's Folly"
-          },
-          {
-            "ID": 1257,
-            "icon": "inv_guild_cauldron_a",
-            "itemId": 199892,
-            "name": "Tuskarr Traveling Soup Pot"
-          },
-          {
-            "ID": 1258,
-            "icon": "archaeology_5_0_pandarenteaset",
-            "itemId": 199650,
-            "name": "Whale Bone Tea Set"
-          },
-          {
-            "ID": 1259,
-            "icon": "inv_misc_pearlmilktea",
-            "itemId": 199649,
-            "name": "Dragon Tea Set"
-          },
-          {
-            "ID": 1260,
-            "icon": "inv_misc_tabard_thereliquary",
-            "itemId": 198729,
-            "name": "Reliquary Banner"
-          },
-          {
-            "ID": 1261,
-            "icon": "inv_misc_tabard_explorersguild",
-            "itemId": 198728,
-            "name": "Explorer's League Banner"
-          },
-          {
-            "ID": 1262,
-            "icon": "inv_10_tailoring2_pillow_black",
-            "itemId": 198722,
-            "name": "Small Triangular Pillow"
-          },
-          {
-            "ID": 1263,
-            "icon": "inv_10_tailoring2_pillow_red",
-            "itemId": 198721,
-            "name": "Skinny Reliquary Pillow"
-          },
-          {
-            "ID": 1264,
-            "icon": "inv_10_tailoring2_pillow_purple",
-            "itemId": 198720,
-            "name": "Soft Purple Pillow"
-          },
-          {
-            "ID": 1273,
-            "icon": "inv_10_dungeonjewelry_dragon_trinket_3djardintrophy_black",
-            "itemId": 202021,
-            "name": "Breaker's Flag of Victory"
+            "ID": 1102,
+            "icon": "inv_item_dragonegg_black01",
+            "itemId": 200640,
+            "name": "Obsidian Egg Clutch"
           },
           {
             "ID": 1282,
             "icon": "inv_box_01",
             "itemId": 200707,
             "name": "Armoire of Endless Cloaks"
-          },
-          {
-            "ID": 1271,
-            "icon": "spell_lightning_lightningbolt01",
-            "itemId": 202020,
-            "name": "Chasing Storm"
-          },
-          {
-            "ID": 1277,
-            "icon": "inv_10_misc_winterpeltfurbolg_toy",
-            "itemId": 202253,
-            "name": "Primal Stave of Claw and Fur"
           },
           {
             "ID": 1278,
@@ -570,69 +612,29 @@
             "name": "Snow Blanket"
           },
           {
-            "ID": 1307,
-            "icon": "inv_misc_spyglass_03",
-            "itemId": 199900,
-            "name": "Secondhand Survey Tools"
+            "ID": 1277,
+            "icon": "inv_10_misc_winterpeltfurbolg_toy",
+            "itemId": 202253,
+            "name": "Primal Stave of Claw and Fur"
           }
         ],
-        "name": "Vendor"
+        "name": "Reputation"
       },
-      {
-        "items": [
-          {
-            "ID": 1270,
-            "icon": "trade_archaeology_gemmeddrinkingcup",
-            "itemId": 202019,
-            "name": "Golden Dragon Goblet"
-          },
-          {
-            "ID": 1272,
-            "icon": "inv_misc_pet_01",
-            "itemId": 202022,
-            "name": "Yennu's Kite"
-          },
-          {
-            "ID": 1267,
-            "icon": "oshugun_crystalfragments",
-            "itemId": 201927,
-            "name": "Gleaming Arcanocrystal"
-          },
-          {
-            "ID": 1242,
-            "icon": "inv_garrison_cargoship",
-            "itemId": 200878,
-            "name": "Wheeled Floaty Boaty Controller"
-          },
-          {
-            "ID": 1241,
-            "icon": "inv_misc_archaeology_vrykuldrinkinghorn",
-            "itemId": 200869,
-            "name": "Ohn Lite Branded Horn"
-          }
-        ],
-        "name": "Treasure"
-      },
+      
       {
         "id": "45010d6e",
         "items": [
+          {
+            "ID": 1213,
+            "icon": "inv_misc_primitive_toy04",
+            "itemId": 198857,
+            "name": "Lucky Duck"
+          },
           {
             "ID": 1199,
             "icon": "inv_misc_coin_13",
             "itemId": 198039,
             "name": "Rock of Appreciation"
-          },
-          {
-            "ID": 1201,
-            "icon": "inv_misc_cauldron_arcane",
-            "itemId": 198402,
-            "name": "Maruuk Cooking Pot"
-          },
-          {
-            "ID": 1252,
-            "icon": "inv_10_dungeonjewelry_explorer_trinket_1compass_color2",
-            "itemId": 199902,
-            "name": "Wayfinder's Compass"
           },
           {
             "ID": 1206,
@@ -641,23 +643,22 @@
             "name": "Taivan's Trumpet"
           },
           {
-            "ID": 1213,
-            "icon": "inv_misc_primitive_toy04",
-            "itemId": 198857,
-            "name": "Lucky Duck"
+            "ID": 1234,
+            "icon": "inv_misc_herb_silkweed",
+            "itemId": 200597,
+            "name": "Lover's Bouquet"
           },
           {
-            "ID": 1221,
-            "icon": "inv_misc_coinbag06",
-            "itemId": 199830,
-            "name": "Tuskarr Training Dummy",
-            "notObtainable": true
+            "ID": 1200,
+            "icon": "ability_creature_poison_02",
+            "itemId": 198090,
+            "name": "Jar of Excess Slime"
           },
           {
-            "ID": 1231,
-            "icon": "inv_icon_feather02d",
-            "itemId": 191891,
-            "name": "Professor Chirpsnide's Im-PECK-able Harpy Disguise"
+            "ID": 1205,
+            "icon": "inv_inscription_certificate",
+            "itemId": 198474,
+            "name": "Artist's Easel"
           },
           {
             "ID": 1235,
@@ -666,22 +667,28 @@
             "name": "Somewhat-Stabilized Arcana"
           },
           {
-            "ID": 1265,
-            "icon": "ability_skyreach_castdown",
-            "itemId": 194885,
-            "name": "Ohuna Perch"
+            "ID": 1275,
+            "icon": "inv_misc_book_03",
+            "itemId": 200926,
+            "name": "Compendium of Love"
+          },
+          {
+            "ID": 1221,
+            "icon": "inv_misc_coinbag06",
+            "itemId": 199830,
+            "name": "Tuskarr Training Dummy"
+          },
+          {
+            "ID": 1231,
+            "icon": "inv_icon_feather02d",
+            "itemId": 191891,
+            "name": "Professor Chirpsnide's Im-PECK-able Harpy Disguise"
           },
           {
             "ID": 1266,
             "icon": "inv_misc_cape_naxxramas_03",
             "itemId": 201815,
             "name": "Cloak of Many Faces"
-          },
-          {
-            "ID": 1234,
-            "icon": "inv_misc_herb_silkweed",
-            "itemId": 200597,
-            "name": "Lover's Bouquet"
           },
           {
             "ID": 1243,
@@ -710,6 +717,39 @@
           }
         ],
         "name": "Quest"
+      },
+      {
+        "items": [
+          {
+            "ID": 1295,
+            "icon": "sha_spell_fire_felfire",
+            "itemId": 203757,
+            "name": "Brazier of Madness"
+          }
+        ],
+        "name": "Dungeon"
+      },
+      {
+        "items": [
+          {
+            "ID": 1239,
+            "icon": "inv_60pvp_trinket4a",
+            "itemId": 200116,
+            "name": "Everlasting Horn of Lavaswimming"
+          }
+        ],
+        "name": "Events"
+      },
+      {
+        "items": [
+          {
+            "ID": 1240,
+            "icon": "inv_jewelry_orgrimmarraid_trinket_18",
+            "itemId": 200857,
+            "name": "Talisman of Sargha"
+          }
+        ],
+        "name": "World Drop"
       },
       {
         "items": [


### PR DESCRIPTION
Reorganized Dragonflight toys with the intent to fix incorrect sub-categories, improve clarity, and be consistent with sub-category formatting from other expansion groups.

**Renamed sub-category "Drop" to "Rare":**
- moved Jar of Excess Slime from Rare to Quest (obtained from One Bad Apple quest)
- moved Artist's Easel from Rare to Quest (obtained from Happy Little Accidents quest)
- moved Compendium of Love from Rare to Quest (obtained from For the Love of Others quest)
- moved Tuskarr Dinghy from Rare to Achievement (obtained from River Rapids Wrangler achieve)
- moved Black Dragon's Challenge Dummy from Rare to Treasure (obtained from Waking Shore)
- moved Aquatic Shades from Rare to Vendor (obtained from The Great Swog)
- moved Lost Compass from Rare to Treasure (obtained from Azure Span)
- moved Primal Invocation Quintessence from Rare to Profession (obtained from using enchanting items)

**Created new sub-category "Dungeon":**
- moved Brazier of Madness from Rare to Dungeon (obtained from Zul'Gurub)

**Created new sub-category "Events":**
- moved Everlasting Horn of Lavaswimming from Rare to Events (obtained from Siege event)

**Created new sub-category "World Drop":**
- moved Talisman of Sargha from Rare to World Drop (obtained from Obsidian Citadel random drop)

**Created new sub-category "Renown: Dragonscale Expedition":**
- moved Wayfinder's Compass from Quest to Renown: Dragonscale Expedition
- moved Small Triangular Pillow from Vendor to Renown: Dragonscale Expedition
- moved Skinny Reliquary Pillow from Vendor to Renown: Dragonscale Expedition
- moved Soft Purple Pillow from Vendor to Renown: Dragonscale Expedition
- moved Explorer's League Banner from Vendor to Renown: Dragonscale Expedition
- moved Reliquary Banner from Vendor to Renown: Dragonscale Expedition

**Created new sub-category "Renown: Maruuk Centaur":**
- moved Maruuk Cooking Pot from Quest to Renown: Maruuk Centaur
- moved Very Comfortable Pelt from Vendor to Renown: Maruuk Centaur
- moved Comfortable Pile of Pelts from Vendor to Renown: Maruuk Centaur
- moved Ohuna Perch from Quest to Renown: Maruuk Centaur

**Created new sub-category "Renown: Iskarra Tuskarr":**
- moved Whale Bone Tea Set from Vendor to Renown: Iskarra Tuskarr
- moved Tuskarr Traveling Soup Pot from Vendor to Renown: Iskarra Tuskarr
- moved Fisherman's Folly from Vendor to Renown: Iskarra Tuskarr
- moved Rubbery Fish Head from Vendor to Renown: Iskarra Tuskarr
- moved Blue-Covered Beanbag from Vendor to Renown: Iskarra Tuskarr
- moved Magical Snow Sled from Rare to Renown: Iskarra Tuskarr
- moved Iskaara Tug Sled from Rare to Renown: Iskarra Tuskarr

**Created new sub-category "Renown: Valdrakken Accord":**
- moved Dragon Tea Set from Vendor to Renown: Valdrakken Accord
- moved Green Dragon Banner from Vendor to Renown: Valdrakken Accord
- moved Bronze Dragon Banner from Vendor to Renown: Valdrakken Accord
- moved Blue Dragon Banner from Vendor to Renown: Valdrakken Accord
- moved Black Dragon Banner from Vendor to Renown: Valdrakken Accord
- moved Red Dragon Banner from Vendor to Renown: Valdrakken Accord

**Created new sub-category "Reputation":**
- moved Obsidian Egg Clutch from Rare to Reputation (obtained from Sabellian rep)
- moved Armoire of Endless Cloaks from Vendor to Reputation (obtained from Wrathion rep)
- moved Reading Glasses from Vendor to Reputation (obtained from Winterpelt Furbolg rep)
- moved Snow Blanket from Vendor to Reputation (obtained from Winterpelt Furbolg rep)
- moved Primal Stave of Claw and Fur from Vendor to Reputation (obtained from Winterpelt Furbolg rep)

---

**Notes:**
- As with Shadowlands, renown items are now separate from other reputations.
- Most renown toys are available from both vendor and quest rewards (such as an insta-complete quest that lets you pick 1 of 5 dragon banners as a reward and leaves the other 4 for sale from the quartermaster). This previously resulted in renown rewards being inconsistently listed in the "Vendor" and "Quest" sub-categories, which is now fixed.
- Some toys were reordered for clarity, such as renown rewards being organized left-to-right in ascending order of the required renown level.
- No toys were added or removed. This is only a reorganization of the existing Dragonflight toy data.