### PR TITLE
Add patch 10.1 updates

### DIFF
--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -530,6 +530,12 @@
                   "id": 16585,
                   "points": 10,
                   "title": "Loremaster of the Dragon Isles"
+                },
+                {
+                  "icon": "achievement_meta_zaralekcavern",
+                  "id": 17785,
+                  "points": 25,
+                  "title": "Que Zara(lek), Zara(lek)"
                 }
               ],
               "name": "Zones"
@@ -560,6 +566,12 @@
                   "id": 15796,
                   "points": 10,
                   "title": "Cliffside Companion"
+                },
+                {
+                  "icon": "inv_companionserpent",
+                  "id": 17779,
+                  "points": 10,
+                  "title": "A Serpentine Discovery"
                 }
               ],
               "name": "Dragonriding"
@@ -572,6 +584,12 @@
                   "id": 16808,
                   "points": 15,
                   "title": "Friend of the Dragon Isles"
+                },
+                {
+                  "icon": "achievement_zone_zaralekcavern",
+                  "id": 17739,
+                  "points": 10,
+                  "title": "Embers of Neltharion"
                 }
               ],
               "name": "Campaign"
@@ -666,6 +684,18 @@
                 }
               ],
               "name": "Storm's Fury"
+            },
+            {
+              "id": "1fed5c08",
+              "items": [
+                {
+                  "icon": "inv_elemental_mote_fire01",
+                  "id": 17735,
+                  "points": 5,
+                  "title": "We Didn't Start the Fire"
+                }
+              ],
+              "name": "Fyrakk Assaults"
             }
           ]
         },
@@ -4053,6 +4083,12 @@
                   "id": 16518,
                   "points": 10,
                   "title": "Explore Thaldraszus"
+                },
+                {
+                  "icon": "achievement_zone_zaralekcavern",
+                  "id": 17766,
+                  "points": 10,
+                  "title": "Explore Zaralek Cavern"
                 }
               ],
               "name": "Area"
@@ -4089,6 +4125,12 @@
                   "id": 16301,
                   "points": 5,
                   "title": "Treasures of Thaldraszus"
+                },
+                {
+                  "icon": "inv_misc_treasurechest04a",
+                  "id": 17786,
+                  "points": 5,
+                  "title": "Treasures of Zaralek Cavern"
                 }
               ],
               "name": "Treasure"
@@ -4119,6 +4161,18 @@
                   "id": 16679,
                   "points": 5,
                   "title": "Adventurer of Thaldraszus"
+                },
+                {
+                  "icon": "achievement_zone_zaralekcavern",
+                  "id": 17783,
+                  "points": 5,
+                  "title": "Adventurer of Zaralek Cavern"
+                },
+                {
+                  "icon": "inv_misc_claw_deepcrab_ghost",
+                  "id": 18100,
+                  "points": 10,
+                  "title": "Cavern Clawbbering"
                 }
               ],
               "name": "Encounter"
@@ -4143,6 +4197,42 @@
                   "id": 16446,
                   "points": 10,
                   "title": "That's Pretty Neat!"
+                },
+                {
+                  "icon": "inv_misc_stonetablet_07",
+                  "id": 17561,
+                  "points": 5,
+                  "title": "Ancient Stones of the Waking Shores"
+                },
+                {
+                  "icon": "inv_misc_stonetablet_07",
+                  "id": 17562,
+                  "points": 5,
+                  "title": "Ancient Stones of the Ohn'ahran Plains"
+                },
+                {
+                  "icon": "inv_misc_stonetablet_07",
+                  "id": 17563,
+                  "points": 5,
+                  "title": "Ancient Stones of the Azure Span"
+                },
+                {
+                  "icon": "inv_misc_stonetablet_07",
+                  "id": 17564,
+                  "points": 5,
+                  "title": "Ancient Stones of Thaldraszus"
+                },
+                {
+                  "icon": "inv_misc_stonetablet_07",
+                  "id": 17567,
+                  "points": 5,
+                  "title": "Ancient Stones of Zaralek"
+                },
+                {
+                  "icon": "inv_10_worlddroplevelingoptionalreagent_misc_stonetablet_color3",
+                  "id": 17560,
+                  "points": 20,
+                  "title": "Ancient Stones of the Dragon Isles"
                 }
               ],
               "name": "Dragon Isles"
@@ -4478,18 +4568,6 @@
               "name": "Storm Events"
             },
             {
-              "id": "01ee341a",
-              "items": [
-                {
-                  "icon": "inv_jewelcrafting_crimsonhare",
-                  "id": 16729,
-                  "points": 10,
-                  "title": "To All the Squirrels Hidden Til Now"
-                }
-              ],
-              "name": "Critters"
-            },
-            {
               "id": "ac1bda82",
               "items": [
                 {
@@ -4585,11 +4663,185 @@
                 {
                   "icon": "spell_holy_borrowedtime",
                   "id": 17509,
-                  "points": 10,
+                  "points": 0,
                   "title": "Every Door, Everywhere, All At Once"
                 }
               ],
               "name": "Zskera Vault"
+            },
+            {
+              "id": "53cbfa7f",
+              "items": [
+                {
+                  "icon": "archaeology_5_0_mogucoin",
+                  "id": 17781,
+                  "points": 5,
+                  "title": "The Smell of Money"
+                },
+                {
+                  "icon": "inv_10_gearupgrade_flightstone_currency",
+                  "id": 17830,
+                  "points": 10,
+                  "title": "Stones Can't Fly!"
+                },
+                {
+                  "icon": "inv_10_gearupgrade_flightstone_currency",
+                  "id": 17977,
+                  "points": 10,
+                  "title": "Stones Can Try To Fly!"
+                },
+                {
+                  "icon": "inv_10_gearupgrade_flightstone_currency",
+                  "id": 17978,
+                  "points": 10,
+                  "title": "Stones Can Fly!"
+                },
+                {
+                  "icon": "inv_snailrockmount_black",
+                  "id": 17741,
+                  "points": 10,
+                  "title": "Slow and Steady Wins the Race"
+                },
+                {
+                  "icon": "inv_10_fishing_fishlava_color1",
+                  "id": 17878,
+                  "points": 5,
+                  "title": "Me Want Bite"
+                },
+                {
+                  "icon": "shaman_talent_primalelementalist",
+                  "id": 18174,
+                  "points": 10,
+                  "title": "Contaminant Cleaner"
+                },
+                {
+                  "icon": "inv_shield_1h_revenantfire_d_01",
+                  "id": 18199,
+                  "points": 10,
+                  "title": "Zaqali Ritual Buster"
+                },
+                {
+                  "icon": "achievement_guildperk_chug-a-lug_rank2",
+                  "id": 18200,
+                  "points": 15,
+                  "title": "Cooling the Research Field"
+                },
+                {
+                  "icon": "achievement_dungeon_ulduarraid_titan_01",
+                  "id": 18201,
+                  "points": 5,
+                  "title": "Lockdown Mystery"
+                },
+                {
+                  "icon": "inv_ore_blackrock_ore",
+                  "id": 18202,
+                  "points": 10,
+                  "title": "Rockin Research"
+                },
+                {
+                  "icon": "inv_10_mining_traceore_color4",
+                  "id": 18203,
+                  "points": 5,
+                  "title": "A Research Sampler"
+                },
+                {
+                  "icon": "inv_crab2_vermillian",
+                  "id": 18204,
+                  "points": 5,
+                  "title": "Research Mishap"
+                },
+                {
+                  "icon": "ability_earthen_pillar",
+                  "id": 18205,
+                  "points": 5,
+                  "title": "A Pillar of the Research Community"
+                },
+                {
+                  "icon": "inv_relics_6orunestone_ogremissive",
+                  "id": 18206,
+                  "points": 10,
+                  "title": "A Djaradin Puzzle"
+                },
+                {
+                  "icon": "achievement_zone_burningsteppes_01",
+                  "id": 18207,
+                  "points": 10,
+                  "title": "Hot Research Zone"
+                },
+                {
+                  "icon": "inv_misc_claw_lobstrok_red",
+                  "id": 18208,
+                  "points": 10,
+                  "title": "The Small Disruptions"
+                },
+                {
+                  "icon": "inv_axe_1h_blackdragonoutdoor_d_01",
+                  "id": 18209,
+                  "points": 5,
+                  "title": "Nothing Stops the Research"
+                },
+                {
+                  "icon": "ui_majorfaction_niffen",
+                  "id": 17832,
+                  "points": 5,
+                  "title": "Sniffen Around"
+                },
+                {
+                  "icon": "ui_majorfaction_niffen",
+                  "id": 17833,
+                  "points": 10,
+                  "title": "Sniffen Sage"
+                },
+                {
+                  "icon": "inv_pet_mole",
+                  "id": 18255,
+                  "points": 5,
+                  "title": "Proof of Myrrit"
+                },
+                {
+                  "icon": "inv_misc_2h_farmshovel_a_01",
+                  "id": 18257,
+                  "points": 5,
+                  "title": "Can You Dig It?"
+                },
+                {
+                  "icon": "ability_hunter_aspectoftheviper",
+                  "id": 18271,
+                  "points": 15,
+                  "title": "He'sSss All Mine"
+                },
+                {
+                  "icon": "ability_racial_molemachine",
+                  "id": 18284,
+                  "points": 0,
+                  "title": "A Niffen's Best Buddy"
+                },
+                {
+                  "icon": "inv_fyrakk_dragonbreath",
+                  "id": 17506,
+                  "points": 10,
+                  "title": "Still Standing in the Fire"
+                }
+              ],
+              "name": "Zaralek Cavern"
+            },
+            {
+              "id": "01ee341a",
+              "items": [
+                {
+                  "icon": "inv_jewelcrafting_crimsonhare",
+                  "id": 16729,
+                  "points": 10,
+                  "title": "To All the Squirrels Hidden Til Now"
+                },
+                {
+                  "icon": "inv_jewelcrafting_crimsonhare",
+                  "id": 18361,
+                  "points": 10,
+                  "title": "To All the Squirrels Burrowed Beneath"
+                }
+              ],
+              "name": "Critters"
             }
           ]
         },
@@ -9604,24 +9856,6 @@
                 }
               ],
               "name": "Solo Shuffle"
-            },
-            {
-              "id": "c4185dcd",
-              "items": [
-                {
-                  "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 15957,
-                  "points": 0,
-                  "title": "Gladiator: Dragonflight Season 1"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_04",
-                  "id": 17339,
-                  "points": 0,
-                  "title": "Legend: Dragonflight Season 1"
-                }
-              ],
-              "name": "Rated Arena"
             }
           ]
         },
@@ -9965,6 +10199,12 @@
                   "title": "Tour of Duty: Ohn'ahran Plains"
                 },
                 {
+                  "icon": "achievement_zone_zaralekcavern",
+                  "id": 17851,
+                  "points": 10,
+                  "title": "Tour of Duty: Zaralek Cavern"
+                },
+                {
                   "icon": "inv_shield_1h_drakonid_c_01",
                   "id": 16589,
                   "points": 5,
@@ -10041,6 +10281,12 @@
                   "id": 17345,
                   "points": 5,
                   "title": "Airborne Tumbler"
+                },
+                {
+                  "icon": "inv_10_elementalcombinedfoozles_primordial",
+                  "id": 17852,
+                  "points": 10,
+                  "title": "Elemental Conjuror"
                 }
               ],
               "name": "Dragonflight"
@@ -10131,6 +10377,12 @@
                   "id": 16355,
                   "points": 25,
                   "title": "Glory of the Vault Raider"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_raid",
+                  "id": 18251,
+                  "points": 25,
+                  "title": "Glory of the Aberrus Raider"
                 }
               ],
               "name": "Dragonflight"
@@ -10614,6 +10866,162 @@
                 }
               ],
               "name": "Vault of the Incarnates"
+            },
+            {
+              "id": "fbecf2f5",
+              "items": [
+                {
+                  "icon": "inv_achievement_raiddragon_forgottenexperiments",
+                  "id": 18163,
+                  "points": 10,
+                  "title": "Discarded Works"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_zskarn",
+                  "id": 18164,
+                  "points": 10,
+                  "title": "Fury of Giants"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_neltharion",
+                  "id": 18165,
+                  "points": 10,
+                  "title": "Neltharion's Shadow"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_sarkareth",
+                  "id": 18167,
+                  "points": 10,
+                  "title": "Edge of the Void"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_raid",
+                  "id": 18160,
+                  "points": 10,
+                  "title": "Aberrus, the Shadowed Crucible"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_raid",
+                  "id": 18161,
+                  "points": 10,
+                  "title": "Heroic: Aberrus, the Shadowed Crucible"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_raid",
+                  "id": 18162,
+                  "points": 10,
+                  "title": "Mythic: Aberrus, the Shadowed Crucible"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_kazzara",
+                  "id": 18151,
+                  "points": 10,
+                  "title": "Mythic: Kazzara, the Hellforged"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_amalgamationchamber",
+                  "id": 18152,
+                  "points": 10,
+                  "title": "Mythic: The Amalgamation Chamber"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_forgottenexperiments",
+                  "id": 18153,
+                  "points": 10,
+                  "title": "Mythic: The Forgotten Experiments"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_zaqaliassault",
+                  "id": 18154,
+                  "points": 10,
+                  "title": "Mythic: Assault of the Zaqali"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_rashok",
+                  "id": 18155,
+                  "points": 10,
+                  "title": "Mythic: Rashok, the Elder"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_zskarn",
+                  "id": 18156,
+                  "points": 10,
+                  "title": "Mythic: The Vigilant Steward, Zskarn"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_magmorax",
+                  "id": 18157,
+                  "points": 10,
+                  "title": "Mythic: Magmorax"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_neltharion",
+                  "id": 18158,
+                  "points": 10,
+                  "title": "Mythic: Echo of Neltharion"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_sarkareth",
+                  "id": 18159,
+                  "points": 10,
+                  "title": "Mythic: Scalecommander Sarkareth"
+                },
+                {
+                  "icon": "inv_eng_crate",
+                  "id": 18149,
+                  "points": 10,
+                  "title": "Objects in Transit May Shatter"
+                },
+                {
+                  "icon": "inv_babyfireelemental_shadowflame",
+                  "id": 18168,
+                  "points": 10,
+                  "title": "I'll Make My Own Shadowflame"
+                },
+                {
+                  "icon": "inv_snailmount_orange",
+                  "id": 18172,
+                  "points": 10,
+                  "title": "Escar-Go-Go-Go"
+                },
+                {
+                  "icon": "inv_dracthyrhead08",
+                  "id": 18173,
+                  "points": 10,
+                  "title": "Tabula Rasa"
+                },
+                {
+                  "icon": "inv_item_dragonegg_black01",
+                  "id": 18193,
+                  "points": 0,
+                  "title": "Eggscellent Eggsecution"
+                },
+                {
+                  "icon": "shaman_pvp_rockshield",
+                  "id": 18228,
+                  "points": 10,
+                  "title": "Are You Even Trying?"
+                },
+                {
+                  "icon": "achievment_boss_spineofdeathwing",
+                  "id": 18229,
+                  "points": 10,
+                  "title": "Cosplate"
+                },
+                {
+                  "icon": "inv_babyhornswog_red",
+                  "id": 18230,
+                  "points": 10,
+                  "title": "Whac-A-Swog"
+                },
+                {
+                  "icon": "artifactability_blooddeathknight_umbilicuseternus",
+                  "id": 17877,
+                  "points": 10,
+                  "title": "We'll Never See That Again, Surely"
+                }
+              ],
+              "name": "Aberrus"
             }
           ]
         },
@@ -19951,6 +20359,12 @@
                   "id": 12747,
                   "points": 25,
                   "title": "Catering for Combat"
+                },
+                {
+                  "icon": "achievement_rat",
+                  "id": 17736,
+                  "points": 5,
+                  "title": "The Gift of Cheese"
                 }
               ],
               "name": "Other"
@@ -21565,6 +21979,12 @@
                   "id": 17427,
                   "points": 10,
                   "title": "Winterpelt Conversationalist"
+                },
+                {
+                  "icon": "ui_majorfaction_niffen",
+                  "id": 17763,
+                  "points": 5,
+                  "title": "There's No Place Like Loamm"
                 }
               ],
               "name": ""
@@ -23490,6 +23910,20 @@
                   "points": 10,
                   "side": "A",
                   "title": "Flame Warden of Kul Tiras"
+                },
+                {
+                  "icon": "inv_summerfest_firespirit",
+                  "id": 17737,
+                  "points": 10,
+                  "side": "A",
+                  "title": "Flame Warden of the Dragon Isles"
+                },
+                {
+                  "icon": "inv_summerfest_firespirit",
+                  "id": 17738,
+                  "points": 10,
+                  "side": "H",
+                  "title": "Flame Keeper of the Dragon Isles"
                 }
               ],
               "name": "Honor"
@@ -24940,6 +25374,12 @@
                   "id": 16519,
                   "points": 5,
                   "title": "Dragon Isles Safari"
+                },
+                {
+                  "icon": "inv_mouserock_teal",
+                  "id": 17879,
+                  "points": 5,
+                  "title": "Zaralek Cavern Safari"
                 }
               ],
               "name": "Zones"
@@ -25194,6 +25634,12 @@
                   "id": 17406,
                   "points": 10,
                   "title": "Battle on the Dragon Isles II"
+                },
+                {
+                  "icon": "inv_pet_achievement_pandaria",
+                  "id": 17880,
+                  "points": 10,
+                  "title": "Battle in Zaralek Cavern"
                 }
               ],
               "name": "World Quests"
@@ -25769,6 +26215,78 @@
               "name": "Species: Dragonflight"
             },
             {
+              "id": "b36461ed",
+              "items": [
+                {
+                  "icon": "icon_petfamily_water",
+                  "id": 17881,
+                  "points": 5,
+                  "title": "Aquatic Battler of Zaralek Cavern"
+                },
+                {
+                  "icon": "icon_petfamily_beast",
+                  "id": 17882,
+                  "points": 5,
+                  "title": "Beast Battler of Zaralek Cavern"
+                },
+                {
+                  "icon": "icon_petfamily_critter",
+                  "id": 17883,
+                  "points": 5,
+                  "title": "Critter Battler of Zaralek Cavern"
+                },
+                {
+                  "icon": "icon_petfamily_dragon",
+                  "id": 17890,
+                  "points": 5,
+                  "title": "Dragonkin Battler of Zaralek Cavern"
+                },
+                {
+                  "icon": "icon_petfamily_elemental",
+                  "id": 17904,
+                  "points": 5,
+                  "title": "Elemental Battler of Zaralek Cavern"
+                },
+                {
+                  "icon": "icon_petfamily_flying",
+                  "id": 17905,
+                  "points": 5,
+                  "title": "Flying Battler of Zaralek Cavern"
+                },
+                {
+                  "icon": "icon_petfamily_humanoid",
+                  "id": 17915,
+                  "points": 5,
+                  "title": "Humanoid Battler of Zaralek Cavern"
+                },
+                {
+                  "icon": "icon_petfamily_magical",
+                  "id": 17916,
+                  "points": 5,
+                  "title": "Magic Battler of Zaralek Cavern"
+                },
+                {
+                  "icon": "icon_petfamily_mechanical",
+                  "id": 17917,
+                  "points": 5,
+                  "title": "Mechanical Battler of Zaralek Cavern"
+                },
+                {
+                  "icon": "icon_petfamily_undead",
+                  "id": 17918,
+                  "points": 5,
+                  "title": "Undead Battler of Zaralek Caverm"
+                },
+                {
+                  "icon": "inv_phoenix2pet_yellow",
+                  "id": 17934,
+                  "points": 10,
+                  "title": "Family Battler of Zaralek Cavern"
+                }
+              ],
+              "name": "Species: Zaralek Cavern"
+            },
+            {
               "id": "4bbaf263",
               "items": [
                 {
@@ -26025,6 +26543,18 @@
                 }
               ],
               "name": "Heirlooms"
+            },
+            {
+              "id": "9956b9d1",
+              "items": [
+                {
+                  "icon": "inv_helm_armor_moleperson_b_01",
+                  "id": 17841,
+                  "points": 5,
+                  "title": "Pyramid Scheme"
+                }
+              ],
+              "name": "Other"
             }
           ]
         },
@@ -26656,6 +27186,12 @@
                   "id": 17119,
                   "points": 10,
                   "title": "Deep Cuts From the Vault"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_raid",
+                  "id": 17765,
+                  "points": 10,
+                  "title": "What We Wear In The Shadowflame"
                 }
               ],
               "name": "Dragonflight"
@@ -26836,6 +27372,12 @@
                   "id": 16764,
                   "points": 10,
                   "title": "Crimson Carpet Fashion"
+                },
+                {
+                  "icon": "inv_shirt_basic_a_04_purple",
+                  "id": 18249,
+                  "points": 10,
+                  "title": "Obsidian Tie Event"
                 }
               ],
               "name": "PvP"
@@ -27034,201 +27576,27 @@
                   "id": 17298,
                   "points": 20,
                   "title": "Forbidden Reach Racing Completionist: Gold"
+                },
+                {
+                  "icon": "inv_checkered_flag",
+                  "id": 17492,
+                  "points": 20,
+                  "title": "Zaralek Cavern Racing Completionist"
+                },
+                {
+                  "icon": "inv_checkered_flag",
+                  "id": 17493,
+                  "points": 20,
+                  "title": "Zaralek Cavern Racing Completionist: Silver"
+                },
+                {
+                  "icon": "inv_checkered_flag",
+                  "id": 17494,
+                  "points": 20,
+                  "title": "Zaralek Cavern Racing Completionist: Gold"
                 }
               ],
               "name": "Completionist"
-            },
-            {
-              "id": "9d982695",
-              "items": [
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_bronze",
-                  "id": 15915,
-                  "points": 10,
-                  "title": "Waking Shores: Bronze"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_bronze",
-                  "id": 15918,
-                  "points": 10,
-                  "title": "Ohn'ahran Plains: Bronze"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_bronze",
-                  "id": 15921,
-                  "points": 10,
-                  "title": "Azure Span: Bronze"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_bronze",
-                  "id": 15924,
-                  "points": 10,
-                  "title": "Thaldraszus: Bronze"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_silver",
-                  "id": 15916,
-                  "points": 10,
-                  "title": "Waking Shores: Silver"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_silver",
-                  "id": 15919,
-                  "points": 10,
-                  "title": "Ohn'ahran Plains: Silver"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_silver",
-                  "id": 15922,
-                  "points": 10,
-                  "title": "Azure Span: Silver"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_silver",
-                  "id": 15925,
-                  "points": 10,
-                  "title": "Thaldraszus: Silver"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_gold",
-                  "id": 15917,
-                  "points": 10,
-                  "title": "Waking Shores: Gold"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_gold",
-                  "id": 15920,
-                  "points": 10,
-                  "title": "Ohn'ahran Plains: Gold"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_gold",
-                  "id": 15923,
-                  "points": 10,
-                  "title": "Azure Span: Gold"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_gold",
-                  "id": 15926,
-                  "points": 10,
-                  "title": "Thaldraszus: Gold"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_bronze",
-                  "id": 17279,
-                  "points": 10,
-                  "title": "Forbidden Reach: Bronze"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_silver",
-                  "id": 17280,
-                  "points": 10,
-                  "title": "Forbidden Reach: Silver"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_gold",
-                  "id": 17281,
-                  "points": 10,
-                  "title": "Forbidden Reach: Gold"
-                }
-              ],
-              "name": "Normal Races"
-            },
-            {
-              "id": "1666568d",
-              "items": [
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_bronze",
-                  "id": 15927,
-                  "points": 10,
-                  "title": "Waking Shores Advanced: Bronze"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_bronze",
-                  "id": 15930,
-                  "points": 10,
-                  "title": "Ohn'ahran Plains Advanced: Bronze"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_bronze",
-                  "id": 15933,
-                  "points": 10,
-                  "title": "Azure Span Advanced: Bronze"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_bronze",
-                  "id": 15936,
-                  "points": 10,
-                  "title": "Thaldraszus Advanced: Bronze"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_silver",
-                  "id": 15928,
-                  "points": 10,
-                  "title": "Waking Shores Advanced: Silver"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_silver",
-                  "id": 15931,
-                  "points": 10,
-                  "title": "Ohn'ahran Plains Advanced: Silver"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_silver",
-                  "id": 15934,
-                  "points": 10,
-                  "title": "Azure Span Advanced: Silver"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_silver",
-                  "id": 15937,
-                  "points": 10,
-                  "title": "Thaldraszus Advanced: Silver"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_gold",
-                  "id": 15929,
-                  "points": 10,
-                  "title": "Waking Shores Advanced: Gold"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_gold",
-                  "id": 15932,
-                  "points": 10,
-                  "title": "Ohn'ahran Plains Advanced: Gold"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_gold",
-                  "id": 15935,
-                  "points": 10,
-                  "title": "Azure Span Advanced: Gold"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_gold",
-                  "id": 15938,
-                  "points": 10,
-                  "title": "Thaldraszus Advanced: Gold"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_bronze",
-                  "id": 17284,
-                  "points": 10,
-                  "title": "Forbidden Reach Advanced: Bronze"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_silver",
-                  "id": 17286,
-                  "points": 10,
-                  "title": "Forbidden Reach Advanced: Silver"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_gold",
-                  "id": 17287,
-                  "points": 10,
-                  "title": "Forbidden Reach Advanced: Gold"
-                }
-              ],
-              "name": "Advanced Races"
             },
             {
               "id": "ce7230c2",
@@ -27262,9 +27630,243 @@
                   "id": 17411,
                   "points": 20,
                   "title": "Forbidden Reach Glyph Hunter"
+                },
+                {
+                  "icon": "achievement_zone_zaralekcavern",
+                  "id": 18150,
+                  "points": 20,
+                  "title": "Zaralek Cavern Glyph Hunter"
                 }
               ],
               "name": "Glyphs"
+            },
+            {
+              "id": "9d982695",
+              "items": [
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 15915,
+                  "points": 10,
+                  "title": "Waking Shores: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 15918,
+                  "points": 10,
+                  "title": "Ohn'ahran Plains: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 15921,
+                  "points": 10,
+                  "title": "Azure Span: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 15924,
+                  "points": 10,
+                  "title": "Thaldraszus: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 17279,
+                  "points": 10,
+                  "title": "Forbidden Reach: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 17483,
+                  "points": 10,
+                  "title": "Zaralek Cavern: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 15916,
+                  "points": 10,
+                  "title": "Waking Shores: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 15919,
+                  "points": 10,
+                  "title": "Ohn'ahran Plains: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 15922,
+                  "points": 10,
+                  "title": "Azure Span: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 15925,
+                  "points": 10,
+                  "title": "Thaldraszus: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 17280,
+                  "points": 10,
+                  "title": "Forbidden Reach: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 17484,
+                  "points": 10,
+                  "title": "Zaralek Cavern: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 15917,
+                  "points": 10,
+                  "title": "Waking Shores: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 15920,
+                  "points": 10,
+                  "title": "Ohn'ahran Plains: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 15923,
+                  "points": 10,
+                  "title": "Azure Span: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 15926,
+                  "points": 10,
+                  "title": "Thaldraszus: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 17281,
+                  "points": 10,
+                  "title": "Forbidden Reach: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 17485,
+                  "points": 10,
+                  "title": "Zaralek Cavern: Gold"
+                }
+              ],
+              "name": "Normal Races"
+            },
+            {
+              "id": "1666568d",
+              "items": [
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 15927,
+                  "points": 10,
+                  "title": "Waking Shores Advanced: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 15930,
+                  "points": 10,
+                  "title": "Ohn'ahran Plains Advanced: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 15933,
+                  "points": 10,
+                  "title": "Azure Span Advanced: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 15936,
+                  "points": 10,
+                  "title": "Thaldraszus Advanced: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 17284,
+                  "points": 10,
+                  "title": "Forbidden Reach Advanced: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 17486,
+                  "points": 10,
+                  "title": "Zaralek Cavern Advanced: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 15928,
+                  "points": 10,
+                  "title": "Waking Shores Advanced: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 15931,
+                  "points": 10,
+                  "title": "Ohn'ahran Plains Advanced: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 15934,
+                  "points": 10,
+                  "title": "Azure Span Advanced: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 15937,
+                  "points": 10,
+                  "title": "Thaldraszus Advanced: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 17286,
+                  "points": 10,
+                  "title": "Forbidden Reach Advanced: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 17487,
+                  "points": 10,
+                  "title": "Zaralek Cavern Advanced: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 15929,
+                  "points": 10,
+                  "title": "Waking Shores Advanced: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 15932,
+                  "points": 10,
+                  "title": "Ohn'ahran Plains Advanced: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 15935,
+                  "points": 10,
+                  "title": "Azure Span Advanced: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 15938,
+                  "points": 10,
+                  "title": "Thaldraszus Advanced: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 17287,
+                  "points": 10,
+                  "title": "Forbidden Reach Advanced: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 17488,
+                  "points": 10,
+                  "title": "Zaralek Cavern Advanced: Gold"
+                }
+              ],
+              "name": "Advanced Races"
             },
             {
               "id": "e9685e48",
@@ -27276,34 +27878,10 @@
                   "title": "Waking Shores Reverse: Bronze"
                 },
                 {
-                  "icon": "achievement_challengemode_arakkoaspires_silver",
-                  "id": 17196,
-                  "points": 10,
-                  "title": "Waking Shores Reverse: Silver"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_gold",
-                  "id": 17197,
-                  "points": 10,
-                  "title": "Waking Shores Reverse: Gold"
-                },
-                {
                   "icon": "achievement_challengemode_arakkoaspires_bronze",
                   "id": 17198,
                   "points": 10,
                   "title": "Ohn'ahran Plains Reverse: Bronze"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_silver",
-                  "id": 17199,
-                  "points": 10,
-                  "title": "Ohn'ahran Plains Reverse: Silver"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_gold",
-                  "id": 17200,
-                  "points": 10,
-                  "title": "Ohn'ahran Plains Reverse: Gold"
                 },
                 {
                   "icon": "achievement_challengemode_arakkoaspires_bronze",
@@ -27312,52 +27890,10 @@
                   "title": "Azure Span Reverse: Bronze"
                 },
                 {
-                  "icon": "achievement_challengemode_arakkoaspires_silver",
-                  "id": 17202,
-                  "points": 10,
-                  "title": "Azure Span Reverse: Silver"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_gold",
-                  "id": 17203,
-                  "points": 10,
-                  "title": "Azure Span Reverse: Gold"
-                },
-                {
                   "icon": "achievement_challengemode_arakkoaspires_bronze",
                   "id": 17204,
                   "points": 10,
                   "title": "Thaldraszus Reverse: Bronze"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_silver",
-                  "id": 17205,
-                  "points": 10,
-                  "title": "Thaldraszus Reverse: Silver"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_gold",
-                  "id": 17206,
-                  "points": 10,
-                  "title": "Thaldraszus Reverse: Gold"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_bronze",
-                  "id": 17288,
-                  "points": 10,
-                  "title": "Forbidden Reach Reverse: Bronze"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_silver",
-                  "id": 17289,
-                  "points": 10,
-                  "title": "Forbidden Reach Reverse: Silver"
-                },
-                {
-                  "icon": "achievement_challengemode_arakkoaspires_gold",
-                  "id": 17290,
-                  "points": 10,
-                  "title": "Forbidden Reach Reverse: Gold"
                 },
                 {
                   "icon": "achievement_challengemode_arakkoaspires_bronze",
@@ -27366,16 +27902,100 @@
                   "title": "Reverse Racer: Bronze"
                 },
                 {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 17288,
+                  "points": 10,
+                  "title": "Forbidden Reach Reverse: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_bronze",
+                  "id": 17489,
+                  "points": 10,
+                  "title": "Zaralek Cavern Reverse: Bronze"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 17196,
+                  "points": 10,
+                  "title": "Waking Shores Reverse: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 17199,
+                  "points": 10,
+                  "title": "Ohn'ahran Plains Reverse: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 17202,
+                  "points": 10,
+                  "title": "Azure Span Reverse: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 17205,
+                  "points": 10,
+                  "title": "Thaldraszus Reverse: Silver"
+                },
+                {
                   "icon": "achievement_challengemode_arakkoaspires_silver",
                   "id": 17331,
                   "points": 10,
                   "title": "Reverse Racer: Silver"
                 },
                 {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 17289,
+                  "points": 10,
+                  "title": "Forbidden Reach Reverse: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_silver",
+                  "id": 17490,
+                  "points": 10,
+                  "title": "Zaralek Cavern Reverse: Silver"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 17197,
+                  "points": 10,
+                  "title": "Waking Shores Reverse: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 17200,
+                  "points": 10,
+                  "title": "Ohn'ahran Plains Reverse: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 17203,
+                  "points": 10,
+                  "title": "Azure Span Reverse: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 17206,
+                  "points": 10,
+                  "title": "Thaldraszus Reverse: Gold"
+                },
+                {
                   "icon": "achievement_challengemode_arakkoaspires_gold",
                   "id": 17332,
                   "points": 10,
                   "title": "Reverse Racer: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 17290,
+                  "points": 10,
+                  "title": "Forbidden Reach Reverse: Gold"
+                },
+                {
+                  "icon": "achievement_challengemode_arakkoaspires_gold",
+                  "id": 17491,
+                  "points": 10,
+                  "title": "Zaralek Cavern Reverse: Gold"
                 }
               ],
               "name": "Reverse Races"
@@ -32682,6 +33302,12 @@
                   "id": 16730,
                   "points": 0,
                   "title": "Crimson Gladiator's Drake"
+                },
+                {
+                  "icon": "inv_serpentmountgladiator",
+                  "id": 17778,
+                  "points": 0,
+                  "title": "Obsidian Gladiator's Slitherdrake"
                 }
               ],
               "name": "PVP"
@@ -33180,6 +33806,60 @@
                   "id": 16661,
                   "points": 0,
                   "title": "Keystone Hero: Temple of the Jade Serpent"
+                },
+                {
+                  "icon": "achievement_challengemode_silver",
+                  "id": 17842,
+                  "points": 0,
+                  "title": "Dragonflight Keystone Explorer: Season Two"
+                },
+                {
+                  "icon": "achievement_challengemode_gold",
+                  "id": 17843,
+                  "points": 0,
+                  "title": "Dragonflight Keystone Conqueror: Season Two"
+                },
+                {
+                  "icon": "achievement_challengemode_platinum",
+                  "id": 17844,
+                  "points": 0,
+                  "title": "Dragonflight Keystone Master: Season Two"
+                },
+                {
+                  "icon": "achievement_challengemode_scholomance_platinum",
+                  "id": 17845,
+                  "points": 0,
+                  "title": "Dragonflight Keystone Hero: Season Two"
+                },
+                {
+                  "icon": "achievement_challengemode_platinum",
+                  "id": 17846,
+                  "points": 0,
+                  "title": "Smoldering Hero: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_dungeon_skywall",
+                  "id": 17847,
+                  "points": 0,
+                  "title": "Keystone Hero: The Vortex Pinnacle"
+                },
+                {
+                  "icon": "achievement_dungeon_freehold",
+                  "id": 17848,
+                  "points": 0,
+                  "title": "Keystone Hero: Freehold"
+                },
+                {
+                  "icon": "achievement_dungeon_underrot",
+                  "id": 17849,
+                  "points": 0,
+                  "title": "Keystone Hero: The Underrot"
+                },
+                {
+                  "icon": "achievement_dungeon_neltharionslair",
+                  "id": 17850,
+                  "points": 0,
+                  "title": "Keystone Hero: Neltharion's Lair"
                 }
               ],
               "name": "Mythic Keystone: Dragonflight"
@@ -33555,6 +34235,18 @@
                   "id": 17108,
                   "points": 0,
                   "title": "Cutting Edge: Raszageth the Storm-Eater"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_sarkareth",
+                  "id": 18253,
+                  "points": 0,
+                  "title": "Ahead of the Curve: Scalecommander Sarkareth"
+                },
+                {
+                  "icon": "inv_achievement_raiddragon_sarkareth",
+                  "id": 18254,
+                  "points": 0,
+                  "title": "Cutting Edge: Scalecommander Sarkareth"
                 }
               ],
               "name": "Lost Content"
@@ -35515,6 +36207,20 @@
                   "points": 0,
                   "side": "A",
                   "title": "Hero of the Alliance: Crimson"
+                },
+                {
+                  "icon": "achievement_pvp_a_a",
+                  "id": 17768,
+                  "points": 0,
+                  "side": "A",
+                  "title": "Hero of the Alliance: Obsidian"
+                },
+                {
+                  "icon": "achievement_pvp_h_h",
+                  "id": 17772,
+                  "points": 0,
+                  "side": "H",
+                  "title": "Hero of the Horde: Obsidian"
                 }
               ],
               "name": "Rated Battleground"
@@ -35580,6 +36286,96 @@
                 }
               ],
               "name": "Highmaul Coliseum"
+            },
+            {
+              "id": "ecc6c104",
+              "items": [
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 15957,
+                  "points": 0,
+                  "title": "Gladiator: Dragonflight Season 1"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_04",
+                  "id": 17339,
+                  "points": 0,
+                  "title": "Legend: Dragonflight Season 1"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17740,
+                  "points": 0,
+                  "title": "Gladiator: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_04",
+                  "id": 17801,
+                  "points": 0,
+                  "title": "Legend: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_07",
+                  "id": 17764,
+                  "points": 0,
+                  "title": "Obsidian Gladiator: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_07",
+                  "id": 17767,
+                  "points": 0,
+                  "title": "Obsidian Legend: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17794,
+                  "points": 0,
+                  "title": "Duelist: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17795,
+                  "points": 0,
+                  "title": "Rival I: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17796,
+                  "points": 0,
+                  "title": "Rival II: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17797,
+                  "points": 0,
+                  "title": "Challenger I: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17798,
+                  "points": 0,
+                  "title": "Challenger II: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_10",
+                  "id": 17799,
+                  "points": 0,
+                  "title": "Combatant I: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_10",
+                  "id": 17800,
+                  "points": 0,
+                  "title": "Combatant II: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17831,
+                  "points": 0,
+                  "title": "Elite: Dragonflight Season 2"
+                }
+              ],
+              "name": "[R]Rated Arena"
             }
           ]
         },
@@ -36072,10 +36868,10 @@
                   "title": "Sarge's Tale"
                 },
                 {
-                  "icon": "4679804",
-                  "id": 17426,
+                  "icon": "4396090",
+                  "id": 15640,
                   "points": 0,
-                  "title": "Toolbox Trouble"
+                  "title": "Return to Darkness"
                 }
               ],
               "name": "Mounts"
@@ -36094,6 +36890,18 @@
                   "id": 12454,
                   "points": 0,
                   "title": "Salute to StarCraft"
+                },
+                {
+                  "icon": "inv_demongoat",
+                  "id": 18258,
+                  "points": 0,
+                  "title": "Little Lord of Lies"
+                },
+                {
+                  "icon": "4679804",
+                  "id": 17426,
+                  "points": 0,
+                  "title": "Toolbox Trouble"
                 }
               ],
               "name": "Pets"
@@ -36378,12 +37186,6 @@
                   "id": 15594,
                   "points": 0,
                   "title": "Fearless Spectator"
-                },
-                {
-                  "icon": "4396090",
-                  "id": 15640,
-                  "points": 0,
-                  "title": "Return to Darkness"
                 }
               ],
               "name": "Other"
@@ -37277,7 +38079,7 @@
                 {
                   "icon": "Achievement_Leader_Cairne-Bloodhoof",
                   "id": 611,
-                  "points": 10,
+                  "points": 0,
                   "side": "A",
                   "title": "Bleeding Bloodhoof"
                 },
@@ -38183,7 +38985,7 @@
                 {
                   "icon": "inv_relics_hourglass",
                   "id": 11181,
-                  "points": 10,
+                  "points": 0,
                   "title": "Legion Keymaster"
                 }
               ],
@@ -40138,7 +40940,7 @@
                 {
                   "icon": "achievement_arena_5v5_2",
                   "id": 10747,
-                  "points": 10,
+                  "points": 0,
                   "title": "Fighting with Style: Upgraded"
                 }
               ],

--- a/static/data/battlepets.json
+++ b/static/data/battlepets.json
@@ -660,6 +660,96 @@
           }
         ],
         "name": "Thaldraszus"
+      },
+      {
+        "id": "fcdc9792",
+        "items": [
+          {
+            "ID": 3477,
+            "creatureId": 203287,
+            "icon": "inv_babyhornswog_black",
+            "name": "Puddlehopper"
+          },
+          {
+            "ID": 3478,
+            "creatureId": 203288,
+            "icon": "inv_caveswallow_red",
+            "name": "Rock Martin"
+          },
+          {
+            "ID": 3479,
+            "creatureId": 203289,
+            "icon": "inv_primaldragonflymount_yellow",
+            "name": "Yellabon"
+          },
+          {
+            "ID": 3480,
+            "creatureId": 203292,
+            "icon": "inv_beetleprimal_black",
+            "name": "Endmite"
+          },
+          {
+            "ID": 3481,
+            "creatureId": 203308,
+            "icon": "inv_mouserock_yellow",
+            "name": "Stonewhisker"
+          },
+          {
+            "ID": 3482,
+            "creatureId": 203310,
+            "icon": "inv_snailrockmount_black",
+            "name": "Cobbleshell"
+          },
+          {
+            "ID": 3483,
+            "creatureId": 203311,
+            "icon": "inv_viperrock_red",
+            "name": "Boulderfang"
+          },
+          {
+            "ID": 3484,
+            "creatureId": 203312,
+            "icon": "inv_sporebatrock_deepred",
+            "name": "Slabwing"
+          },
+          {
+            "ID": 3485,
+            "creatureId": 203313,
+            "icon": "inv_mothunderlight_orange",
+            "name": "Hollow Moth"
+          },
+          {
+            "ID": 3486,
+            "creatureId": 203358,
+            "icon": "inv_caveswallow_orange",
+            "name": "Lithengale"
+          },
+          {
+            "ID": 3487,
+            "creatureId": 203364,
+            "icon": "inv_snailrockmount_red",
+            "name": "Scarlapod"
+          },
+          {
+            "ID": 3488,
+            "creatureId": 203367,
+            "icon": "inv_sporebatrock_red",
+            "name": "Deepridger"
+          },
+          {
+            "ID": 3489,
+            "creatureId": 203372,
+            "icon": "inv_viperrock_yellow",
+            "name": "Sunglow Cobra"
+          },
+          {
+            "ID": 3490,
+            "creatureId": 203377,
+            "icon": "inv_mothunderlight_rockred",
+            "name": "Ebonwing Moth"
+          }
+        ],
+        "name": "Zaralek Cavern"
       }
     ]
   },

--- a/static/data/factions.json
+++ b/static/data/factions.json
@@ -43,6 +43,14 @@
         }
       },
       {
+        "id": 2564,
+        "name": "Loamm Niffen",
+        "renown": {
+          "max": 20,
+          "step": 2500
+        }
+      },
+      {
         "id": 2523,
         "name": "Dark Talons"
       },
@@ -54,11 +62,11 @@
         "id": 2517,
         "levels": {
           "0": "Acquaintance",
-          "8400": "Cohort",
           "16800": "Ally",
           "25200": "Fang",
           "33600": "Friend",
-          "42000": "True Friend"
+          "42000": "True Friend",
+          "8400": "Cohort"
         },
         "name": "Wrathion"
       },
@@ -66,11 +74,11 @@
         "id": 2518,
         "levels": {
           "0": "Acquaintance",
-          "8400": "Cohort",
           "16800": "Ally",
           "25200": "Fang",
           "33600": "Friend",
-          "42000": "True Friend"
+          "42000": "True Friend",
+          "8400": "Cohort"
         },
         "name": "Sabellian"
       },
@@ -78,10 +86,10 @@
         "id": 2544,
         "levels": {
           "0": "Neutral",
-          "500": "Preferred",
+          "12500": "Esteemed",
           "2500": "Respected",
-          "5500": "Valued",
-          "12500": "Esteemed"
+          "500": "Preferred",
+          "5500": "Valued"
         },
         "name": "Artisan's Consortium - Dragon Isles Branch"
       },
@@ -89,10 +97,10 @@
         "id": 2550,
         "levels": {
           "0": "Empty",
-          "300": "Low",
+          "10000": "Maximum",
           "1200": "Medium",
-          "3600": "High",
-          "10000": "Maximum"
+          "300": "Low",
+          "3600": "High"
         },
         "name": "Cobalt Assembly"
       },
@@ -101,16 +109,27 @@
         "name": "Clan Nokhud"
       },
       {
-        "id": 2526,
-        "name": "Winterpelt Furbolg"
-      },
-      {
         "id": 2542,
         "name": "Clan Ukhel"
       },
       {
         "id": 2555,
         "name": "Clan Kaighan"
+      },
+      {
+        "id": 2526,
+        "name": "Winterpelt Furbolg"
+      },
+      {
+        "id": 2568,
+        "levels": {
+          "0": "Aspirational",
+          "1400": "Competent",
+          "2100": "Skilled",
+          "2800": "Professional",
+          "700": "Ameteur"
+        },
+        "name": "Glimmerogg Racer"
       }
     ],
     "name": "Dragonflight"
@@ -138,10 +157,10 @@
         "levels": {
           "0": "Dubious",
           "1000": "Apprehensive",
-          "7000": "Tentative",
           "14000": "Ambivalent",
           "21000": "Cordial",
-          "42000": "Appreciative"
+          "42000": "Appreciative",
+          "7000": "Tentative"
         },
         "name": "Ve'nari"
       },
@@ -157,10 +176,10 @@
         "id": 2464,
         "levels": {
           "0": "Neutral",
-          "3000": "Friendly",
-          "9000": "Honored",
           "21000": "Revered",
-          "42000": "Exalted"
+          "3000": "Friendly",
+          "42000": "Exalted",
+          "9000": "Honored"
         },
         "name": "Court of Night"
       },
@@ -168,10 +187,10 @@
         "id": 2462,
         "levels": {
           "0": "Neutral",
-          "3000": "Friendly",
-          "9000": "Honored",
           "21000": "Revered",
-          "42000": "Exalted"
+          "3000": "Friendly",
+          "42000": "Exalted",
+          "9000": "Honored"
         },
         "name": "Stitchmasters"
       },
@@ -183,11 +202,11 @@
         "id": 2472,
         "levels": {
           "0": "Tier 1",
-          "3000": "Tier 2",
-          "7500": "Tier 3",
           "14000": "Tier 4",
           "25000": "Tier 5",
-          "41000": "Tier 6"
+          "3000": "Tier 2",
+          "41000": "Tier 6",
+          "7500": "Tier 3"
         },
         "name": "The Archivists' Codex"
       },
@@ -204,11 +223,11 @@
         "id": 2446,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Baroness Vashj"
       },
@@ -216,11 +235,11 @@
         "id": 2447,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Lady Moonberry"
       },
@@ -228,11 +247,11 @@
         "id": 2448,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Mikanikos"
       },
@@ -240,11 +259,11 @@
         "id": 2449,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "The Countess"
       },
@@ -252,11 +271,11 @@
         "id": 2450,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Alexandros Mograine"
       },
@@ -264,11 +283,11 @@
         "id": 2451,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Hunt-Captain Korayn"
       },
@@ -276,11 +295,11 @@
         "id": 2452,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Polemarch Adrestes"
       },
@@ -288,11 +307,11 @@
         "id": 2453,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Rendle and Cudgelface"
       },
@@ -300,11 +319,11 @@
         "id": 2454,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Choofa"
       },
@@ -312,11 +331,11 @@
         "id": 2455,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Cryptkeeper Kassir"
       },
@@ -324,11 +343,11 @@
         "id": 2456,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Droman Aliothe"
       },
@@ -336,11 +355,11 @@
         "id": 2457,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Grandmaster Vole"
       },
@@ -348,11 +367,11 @@
         "id": 2458,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Kleia and Pelagos"
       },
@@ -360,11 +379,11 @@
         "id": 2459,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Sika"
       },
@@ -372,11 +391,11 @@
         "id": 2460,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Stonehead"
       },
@@ -384,11 +403,11 @@
         "id": 2461,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Plague Deviser Marileth"
       }
@@ -483,11 +502,11 @@
         "levels": {
           "0": "Whelpling",
           "1000": "Temporal Trainee",
+          "10000": "Epoch-Mender",
+          "15000": "Timelord",
           "2500": "Timehopper",
           "4500": "Chrono-Friend",
-          "7000": "Bronze Ally",
-          "10000": "Epoch-Mender",
-          "15000": "Timelord"
+          "7000": "Bronze Ally"
         },
         "name": "Chromie"
       },
@@ -550,11 +569,11 @@
         "id": 1975,
         "levels": {
           "0": "Stranger",
-          "8400": "Pal",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Pal"
         },
         "name": "Conjurer Margoss"
       },
@@ -562,11 +581,11 @@
         "id": 2097,
         "levels": {
           "0": "Stranger",
-          "8400": "Pal",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Pal"
         },
         "name": "Ilyssia of the Waters"
       },
@@ -574,11 +593,11 @@
         "id": 2098,
         "levels": {
           "0": "Stranger",
-          "8400": "Pal",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Pal"
         },
         "name": "Keeper Raynae"
       },
@@ -586,11 +605,11 @@
         "id": 2099,
         "levels": {
           "0": "Stranger",
-          "8400": "Pal",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Pal"
         },
         "name": "Akule Riverhorn"
       },
@@ -598,11 +617,11 @@
         "id": 2100,
         "levels": {
           "0": "Stranger",
-          "8400": "Curiosity",
           "16800": "Non-Threat",
           "25200": "Friend",
           "33600": "Helpful Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Curiosity"
         },
         "name": "Corbyn"
       },
@@ -610,11 +629,11 @@
         "id": 2101,
         "levels": {
           "0": "Stranger",
-          "8400": "Pal",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Pal"
         },
         "name": "Sha'leth"
       },
@@ -622,11 +641,11 @@
         "id": 2102,
         "levels": {
           "0": "Stranger",
-          "8400": "Pal",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Pal"
         },
         "name": "Impus"
       }
@@ -784,11 +803,11 @@
         "id": 1358,
         "levels": {
           "0": "Stranger",
-          "8400": "Pal",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Pal"
         },
         "name": "Nat Pagle"
       },
@@ -849,11 +868,11 @@
         "id": 1277,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Chee Chee"
       },
@@ -861,11 +880,11 @@
         "id": 1275,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Ella"
       },
@@ -873,11 +892,11 @@
         "id": 1283,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Farmer Fung"
       },
@@ -885,11 +904,11 @@
         "id": 1282,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Fish Fellreed"
       },
@@ -897,11 +916,11 @@
         "id": 1281,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Gina Mudclaw"
       },
@@ -909,11 +928,11 @@
         "id": 1279,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Haohan Mudclaw"
       },
@@ -921,11 +940,11 @@
         "id": 1273,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Jogu the Drunk"
       },
@@ -937,11 +956,11 @@
         "id": 1276,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Old Hillpaw"
       },
@@ -949,11 +968,11 @@
         "id": 1278,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Sho"
       },
@@ -961,11 +980,11 @@
         "id": 1280,
         "levels": {
           "0": "Stranger",
-          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend"
+          "42000": "Best Friend",
+          "8400": "Acquaintance"
         },
         "name": "Tina Mudclaw"
       }

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -169,11 +169,26 @@
             "spellid": 374275
           },
           {
+            "ID": 1734,
+            "icon": "inv_sporebatrock_deepred",
+            "itemId": 205205,
+            "name": "Shadowflame Shalewing",
+            "spellid": 408649
+          },
+          {
             "ID": 1681,
             "icon": "inv_rhinoprimalmountice",
             "itemId": 199412,
             "name": "Hailstorm Armoredon",
+            "notObtainable": true,
             "spellid": 387231
+          },
+          {
+            "ID": 1725,
+            "icon": "inv_rhinoprimalmountfire",
+            "itemId": 204798,
+            "name": "Inferno Armoredon",
+            "spellid": 406637
           }
         ],
         "name": "Achievement"
@@ -221,6 +236,13 @@
             "itemId": 192799,
             "name": "Lizi, Thunderspine Tramper",
             "spellid": 374247
+          },
+          {
+            "ID": 1729,
+            "icon": "inv_snailrockmount_pink",
+            "itemId": 205155,
+            "name": "Big Slick in the City",
+            "spellid": 408313
           }
         ],
         "name": "Daily Activities"
@@ -248,6 +270,13 @@
             "itemId": 192772,
             "name": "Ancient Salamanther",
             "spellid": 374090
+          },
+          {
+            "ID": 1732,
+            "icon": "inv_sporebatrock_blue",
+            "itemId": 205203,
+            "name": "Cobalt Shalewing",
+            "spellid": 408647
           }
         ],
         "name": "Rare Spawn"
@@ -274,13 +303,6 @@
             "itemId": 198870,
             "name": "Otto",
             "spellid": 376873
-          },
-          {
-            "ID": 1634,
-            "icon": "Inv_mammoth2mount_green",
-            "itemId": 192790,
-            "name": "Mossy Mammoth",
-            "spellid": 374194
           }
         ],
         "name": "Riddle"
@@ -329,6 +351,13 @@
             "itemId": 201425,
             "name": "Yellow War Ottuk",
             "spellid": 376913
+          },
+          {
+            "ID": 1738,
+            "icon": "inv_sporebatrock_stoneblack",
+            "itemId": 205207,
+            "name": "Morsel Sniffer",
+            "spellid": 408655
           }
         ],
         "name": "Renown"
@@ -361,6 +390,18 @@
         "name": "Obsidian Citadel"
       },
       {
+        "items": [
+          {
+            "ID": 1634,
+            "icon": "Inv_mammoth2mount_green",
+            "itemId": 192790,
+            "name": "Mossy Mammoth",
+            "spellid": 374194
+          }
+        ],
+        "name": "Zskera Vaults"
+      },
+      {
         "id": "4d7efe56",
         "items": [
           {
@@ -369,6 +410,13 @@
             "itemId": 192764,
             "name": "Verdant Skitterfly",
             "spellid": 374048
+          },
+          {
+            "ID": 1623,
+            "icon": "inv_slugmount_red",
+            "itemId": 192779,
+            "name": "Seething Slug",
+            "spellid": 374138
           }
         ],
         "name": "Treasure"
@@ -403,6 +451,13 @@
             "itemId": 192785,
             "name": "Gooey Snailemental",
             "spellid": 374157
+          },
+          {
+            "ID": 1735,
+            "icon": "inv_sporebatrock_orange",
+            "itemId": 205204,
+            "name": "Cataloged Shalewing",
+            "spellid": 408651
           }
         ],
         "name": "Events"
@@ -430,6 +485,27 @@
             "itemId": 204382,
             "name": "Noble Bruffalon",
             "spellid": 349935
+          },
+          {
+            "ID": 1603,
+            "icon": "inv_mammoth2lavamount_blue",
+            "itemId": 191838,
+            "name": "Subterranean Magmammoth",
+            "spellid": 371176
+          },
+          {
+            "ID": 1730,
+            "icon": "inv_sporebatrock_red",
+            "itemId": 205197,
+            "name": "Igneous Shalewing",
+            "spellid": 408627
+          },
+          {
+            "ID": 1736,
+            "icon": "inv_sporebatrock_stonered",
+            "itemId": 205209,
+            "name": "Boulder Hauler",
+            "spellid": 408653
           }
         ],
         "name": "Vendor"
@@ -6957,6 +7033,22 @@
             "name": "Vicious Sabertooth",
             "side": "H",
             "spellid": 394738
+          },
+          {
+            "ID": 1740,
+            "icon": "inv_vicioussnail_alliance",
+            "itemId": 205246,
+            "name": "Vicious War Snail",
+            "side": "A",
+            "spellid": 409034
+          },
+          {
+            "ID": 1741,
+            "icon": "inv_vicioussnail_horde",
+            "itemId": 205245,
+            "name": "Vicious War Snail",
+            "side": "H",
+            "spellid": 409032
           }
         ],
         "name": "Vicious Saddle"
@@ -7233,7 +7325,15 @@
             "icon": "inv_drake2mountgladiator",
             "itemId": 202086,
             "name": "Crimson Gladiator's Drake",
+            "notObtainable": true,
             "spellid": 377071
+          },
+          {
+            "ID": 1739,
+            "icon": "inv_serpentmountgladiator",
+            "itemId": 205233,
+            "name": "Obsidian Gladiator's Slitherdrake",
+            "spellid": 408977
           }
         ],
         "name": "Gladiator"
@@ -8227,6 +8327,20 @@
             "itemId": 189978,
             "name": "Magenta Cloud Serpent",
             "spellid": 366647
+          },
+          {
+            "ID": 1742,
+            "icon": "ability_mount_hordescorpiongreen",
+            "itemId": 206027,
+            "name": "Felcrystal Scorpion",
+            "spellid": 411565
+          },
+          {
+            "ID": 1582,
+            "icon": "4329767",
+            "itemId": 190613,
+            "name": "Savage Green Battle Turtle",
+            "spellid": 367826
           }
         ],
         "name": "Trading Post"

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -259,6 +259,30 @@
             "itemId": 199688,
             "name": "Bronze Racing Enthusiast",
             "spellid": 387685
+          },
+          {
+            "ID": 3294,
+            "creatureId": 189119,
+            "icon": "inv_phoenix2pet_yellow",
+            "itemId": 193377,
+            "name": "Gerald",
+            "spellid": 375089
+          },
+          {
+            "ID": 3493,
+            "creatureId": 204036,
+            "icon": "achievement_rat",
+            "itemId": 204894,
+            "name": "Roland",
+            "spellid": 407492
+          },
+          {
+            "ID": 3557,
+            "creatureId": 204621,
+            "icon": "inv_snailrockmount_black",
+            "itemId": 205231,
+            "name": "Roggy",
+            "spellid": 408949
           }
         ],
         "name": "Achievement"
@@ -345,6 +369,38 @@
             "itemId": 193373,
             "name": "Phoenix Wishwing",
             "spellid": 375084
+          },
+          {
+            "ID": 3536,
+            "creatureId": 204321,
+            "icon": "inv_snailrockmount_teal",
+            "itemId": 205119,
+            "name": "Bashful",
+            "spellid": 408153
+          },
+          {
+            "ID": 3538,
+            "creatureId": 204324,
+            "icon": "inv_snailrockmount_yellow",
+            "itemId": 205121,
+            "name": "Tricky",
+            "spellid": 408161
+          },
+          {
+            "ID": 3540,
+            "creatureId": 204326,
+            "icon": "inv_snailrockmount_teal",
+            "itemId": 205232,
+            "name": "Brulee",
+            "spellid": 408165
+          },
+          {
+            "ID": 3578,
+            "creatureId": 205359,
+            "icon": "inv_snailrockmount_red",
+            "itemId": 205937,
+            "name": "Newsy",
+            "spellid": 411110
           }
         ],
         "name": "Quest"
@@ -399,6 +455,14 @@
             "itemId": 201441,
             "name": "Scout",
             "spellid": 374678
+          },
+          {
+            "ID": 3530,
+            "creatureId": 204293,
+            "icon": "inv_dogprimalbaby_black",
+            "itemId": 205052,
+            "name": "Miloh",
+            "spellid": 408100
           }
         ],
         "name": "Pet Charm"
@@ -469,6 +533,38 @@
             "itemId": 202255,
             "name": "Driftling",
             "spellid": 398170
+          },
+          {
+            "ID": 3528,
+            "creatureId": 204286,
+            "icon": "inv_beetleprimal_mint",
+            "itemId": 205050,
+            "name": "Paulie",
+            "spellid": 408081
+          },
+          {
+            "ID": 3529,
+            "creatureId": 204288,
+            "icon": "inv_beetleprimal_yellow",
+            "itemId": 205051,
+            "name": "Rango",
+            "spellid": 408088
+          },
+          {
+            "ID": 3535,
+            "creatureId": 204320,
+            "icon": "inv_snailrockmount_black",
+            "itemId": 205118,
+            "name": "Diamondshell",
+            "spellid": 408150
+          },
+          {
+            "ID": 3537,
+            "creatureId": 204323,
+            "icon": "inv_snailrockmount_green",
+            "itemId": 205120,
+            "name": "Thimblerig",
+            "spellid": 408158
           }
         ],
         "name": "Vendor"
@@ -577,6 +673,30 @@
             "itemId": 193908,
             "name": "Kobaldt",
             "spellid": 375642
+          },
+          {
+            "ID": 3521,
+            "creatureId": 204263,
+            "icon": "inv_makruralava_blue",
+            "itemId": 205021,
+            "name": "Lord Stantley",
+            "spellid": 408027
+          },
+          {
+            "ID": 3533,
+            "creatureId": 204303,
+            "icon": "misc_drogbartotem02",
+            "itemId": 205114,
+            "name": "Brul",
+            "spellid": 408110
+          },
+          {
+            "ID": 3545,
+            "creatureId": 204343,
+            "icon": "inv_viperrock_blue",
+            "itemId": 205151,
+            "name": "Salverun",
+            "spellid": 408257
           }
         ],
         "name": "Treasure"
@@ -838,6 +958,72 @@
         "name": "Zskera Vaults"
       },
       {
+        "items": [
+          {
+            "ID": 3511,
+            "creatureId": 204217,
+            "icon": "inv_babyfireelemental_orange",
+            "itemId": 205002,
+            "name": "Blaise",
+            "spellid": 407918
+          },
+          {
+            "ID": 3512,
+            "creatureId": 204221,
+            "icon": "inv_babyfireelemental_yellow",
+            "itemId": 205003,
+            "name": "Ambre",
+            "spellid": 407921
+          },
+          {
+            "ID": 3524,
+            "creatureId": 204269,
+            "icon": "inv_makruralava_red",
+            "itemId": 205026,
+            "name": "Devourer Lobstrok",
+            "spellid": 408039
+          }
+        ],
+        "name": "World Events"
+      },
+      {
+        "items": [
+          {
+            "ID": 3541,
+            "creatureId": 204339,
+            "icon": "inv_sporebatrock_blue",
+            "itemId": 205147,
+            "name": "Ridged Shalewing",
+            "spellid": 408251
+          },
+          {
+            "ID": 3546,
+            "creatureId": 204345,
+            "icon": "inv_viperrock2_blue",
+            "itemId": 205152,
+            "name": "Skaarn",
+            "spellid": 408264
+          },
+          {
+            "ID": 3548,
+            "creatureId": 204359,
+            "icon": "inv_sulfurelemental_water",
+            "itemId": 205154,
+            "name": "Aquapo",
+            "spellid": 408308
+          },
+          {
+            "ID": 3551,
+            "creatureId": 204363,
+            "icon": "inv_mothunderlight_teal",
+            "itemId": 205159,
+            "name": "Teardrop Moth",
+            "spellid": 408317
+          }
+        ],
+        "name": "Rare"
+      },
+      {
         "id": "ccca067e",
         "items": [
           {
@@ -850,6 +1036,204 @@
           }
         ],
         "name": "Pre-launch Event"
+      },
+      {
+        "id": "332ea2f0",
+        "items": [
+          {
+            "ID": 3513,
+            "creatureId": 204222,
+            "icon": "inv_babyhornswog_blue",
+            "itemId": 205004,
+            "name": "Azure Swoglet",
+            "spellid": 407926
+          },
+          {
+            "ID": 3514,
+            "creatureId": 204224,
+            "icon": "inv_babyhornswog_green",
+            "itemId": 205008,
+            "name": "Emerald Swoglet",
+            "spellid": 407930
+          },
+          {
+            "ID": 3516,
+            "creatureId": 204226,
+            "icon": "inv_babyhornswog_red",
+            "itemId": 205010,
+            "name": "Crimson Swoglet",
+            "spellid": 407933
+          },
+          {
+            "ID": 3517,
+            "creatureId": 204227,
+            "icon": "inv_babyhornswog_yellow",
+            "itemId": 205011,
+            "name": "Bronze Swoglet",
+            "spellid": 407935
+          },
+          {
+            "ID": 3518,
+            "creatureId": 204237,
+            "icon": "inv_caveswallow_green",
+            "itemId": 205013,
+            "name": "Lettuce",
+            "spellid": 407946
+          },
+          {
+            "ID": 3519,
+            "creatureId": 204240,
+            "icon": "inv_corehoundsmall_orange",
+            "itemId": 205017,
+            "name": "Byrn",
+            "spellid": 407955
+          },
+          {
+            "ID": 3520,
+            "creatureId": 204261,
+            "icon": "inv_primaldragonflymount_green",
+            "itemId": 205018,
+            "name": "Jade Skitterbug",
+            "spellid": 408023
+          },
+          {
+            "ID": 3522,
+            "creatureId": 204266,
+            "icon": "inv_makruralava_green",
+            "itemId": 205023,
+            "name": "Savage Lobstrok",
+            "spellid": 408032
+          },
+          {
+            "ID": 3523,
+            "creatureId": 204268,
+            "icon": "inv_makruralava_orange",
+            "itemId": 205024,
+            "name": "Cheddar",
+            "spellid": 408036
+          },
+          {
+            "ID": 3531,
+            "creatureId": 204295,
+            "icon": "inv_dogprimalbaby_red",
+            "itemId": 205053,
+            "name": "Rusty",
+            "spellid": 408106
+          },
+          {
+            "ID": 3532,
+            "creatureId": 204296,
+            "icon": "inv_dogprimalbaby_yellow",
+            "itemId": 205054,
+            "name": "Amador",
+            "spellid": 408108
+          },
+          {
+            "ID": 3534,
+            "creatureId": 204305,
+            "icon": "inv_mouserock_purple",
+            "itemId": 205116,
+            "name": "Jerrie",
+            "spellid": 408130
+          },
+          {
+            "ID": 3539,
+            "creatureId": 204325,
+            "icon": "inv_snailrockmount_pink",
+            "itemId": 205122,
+            "name": "Roseshell",
+            "spellid": 408163
+          },
+          {
+            "ID": 3542,
+            "creatureId": 204340,
+            "icon": "inv_sporebatrock_stoneblack",
+            "itemId": 205148,
+            "name": "Dread Shalewing",
+            "spellid": 408252
+          },
+          {
+            "ID": 3543,
+            "creatureId": 204341,
+            "icon": "inv_sporebatrock_stonered",
+            "itemId": 205149,
+            "name": "Ravenous Shalewing",
+            "spellid": 408253
+          },
+          {
+            "ID": 3544,
+            "creatureId": 204342,
+            "icon": "inv_sporebatrock_stoneorange",
+            "itemId": 205150,
+            "name": "Shalewing Devourer",
+            "spellid": 408254
+          },
+          {
+            "ID": 3547,
+            "creatureId": 204354,
+            "icon": "inv_viperrock2_green",
+            "itemId": 205153,
+            "name": "Mikah",
+            "spellid": 408265
+          },
+          {
+            "ID": 3549,
+            "creatureId": 204360,
+            "icon": "inv_mothunderlight_pink",
+            "itemId": 205156,
+            "name": "Heartseeker Moth",
+            "spellid": 408311
+          },
+          {
+            "ID": 3550,
+            "creatureId": 204361,
+            "icon": "inv_mothunderlight_red",
+            "itemId": 205157,
+            "name": "Undermoth",
+            "spellid": 408314
+          },
+          {
+            "ID": 3552,
+            "creatureId": 201008,
+            "icon": "inv_wyvernpetblackdragon_green",
+            "itemId": 205160,
+            "name": "Rithro",
+            "spellid": 408323
+          },
+          {
+            "ID": 3553,
+            "creatureId": 204367,
+            "icon": "inv_wyvernpetblackdragon_black",
+            "itemId": 205162,
+            "name": "Nelthara",
+            "spellid": 408325
+          },
+          {
+            "ID": 3554,
+            "creatureId": 204368,
+            "icon": "inv_wyvernpetblackdragon_blue",
+            "itemId": 205164,
+            "name": "Senega",
+            "spellid": 408328
+          },
+          {
+            "ID": 3556,
+            "creatureId": 204370,
+            "icon": "inv_wyvernpetblackdragon_yellow",
+            "itemId": 205166,
+            "name": "Kromos",
+            "spellid": 408332
+          },
+          {
+            "ID": 3580,
+            "creatureId": 205637,
+            "icon": "inv_demongoat_crimson",
+            "itemId": 206018,
+            "name": "Baa'lial",
+            "spellid": 411791
+          }
+        ],
+        "name": "Unknown"
       }
     ]
   },
@@ -4088,14 +4472,6 @@
         "id": "3f4ea958",
         "items": [
           {
-            "ID": 199,
-            "creatureId": 32643,
-            "icon": "ability_creature_disease_05",
-            "itemId": 44738,
-            "name": "Kirin Tor Familiar",
-            "spellid": 61472
-          },
-          {
             "ID": 1930,
             "creatureId": 112167,
             "icon": "inv_misc_fish_11",
@@ -6101,6 +6477,19 @@
           }
         ],
         "name": "Reputation"
+      },
+      {
+        "items": [
+          {
+            "ID": 199,
+            "creatureId": 32643,
+            "icon": "ability_creature_disease_05",
+            "itemId": 44738,
+            "name": "Kirin Tor Familiar",
+            "spellid": 61472
+          }
+        ],
+        "name": "Achievement"
       },
       {
         "items": [
@@ -8230,6 +8619,30 @@
             "itemId": 174456,
             "name": "Gloop",
             "spellid": 315285
+          },
+          {
+            "ID": 3525,
+            "creatureId": 204271,
+            "icon": "inv_nzothfish_green",
+            "itemId": 205032,
+            "name": "Bestial Lurker",
+            "spellid": 408048
+          },
+          {
+            "ID": 3526,
+            "creatureId": 204275,
+            "icon": "inv_nzothfish",
+            "itemId": 205035,
+            "name": "Snapjaw Lurker",
+            "spellid": 408062
+          },
+          {
+            "ID": 3527,
+            "creatureId": 204276,
+            "icon": "inv_nzothfish_void",
+            "itemId": 205037,
+            "name": "Void Lurker",
+            "spellid": 408063
           }
         ],
         "name": "Fishing"

--- a/static/data/titles.json
+++ b/static/data/titles.json
@@ -313,6 +313,13 @@
             "name": "Agent of the Black Prince",
             "titleId": 484,
             "type": "achievement"
+          },
+          {
+            "icon": "ability_creature_amber_02",
+            "id": 14721,
+            "name": "Smelly",
+            "titleId": 501,
+            "type": "achievement"
           }
         ],
         "name": "Reputation"
@@ -701,18 +708,6 @@
           }
         ],
         "name": "Exploration"
-      },
-      {
-        "items": [
-          {
-            "icon": "ability_creature_amber_02",
-            "id": 14721,
-            "name": "Smelly",
-            "titleId": 501,
-            "type": "achievement"
-          }
-        ],
-        "name": "Other"
       }
     ]
   },

--- a/static/data/titles.json
+++ b/static/data/titles.json
@@ -239,16 +239,32 @@
         "items": [
           {
             "icon": "achievement_raidprimalist_raszageth",
-            "id": 17116,
-            "name": "Famed Slayer of Raszageth",
-            "titleId": 487,
+            "id": 16353,
+            "name": "The Storm-Eater",
+            "notObtainable": true,
+            "titleId": 488,
             "type": "achievement"
           },
           {
             "icon": "achievement_raidprimalist_raszageth",
-            "id": 16353,
-            "name": "The Storm-Eater",
-            "titleId": 488,
+            "id": 17116,
+            "name": "Famed Slayer of Raszageth",
+            "notObtainable": true,
+            "titleId": 487,
+            "type": "achievement"
+          },
+          {
+            "icon": "inv_achievement_raiddragon_sarkareth",
+            "id": 18159,
+            "name": "Heir to the Void",
+            "titleId": 505,
+            "type": "achievement"
+          },
+          {
+            "icon": "inv_achievement_raiddragon_sarkareth",
+            "id": 18176,
+            "name": "Famed Slayer of Sarkareth",
+            "titleId": 506,
             "type": "achievement"
           }
         ],
@@ -304,17 +320,33 @@
       {
         "items": [
           {
+            "icon": "achievement_challengemode_gold",
+            "id": 16648,
+            "name": "The Thundering",
+            "notObtainable": true,
+            "titleId": 477,
+            "type": "achievement"
+          },
+          {
             "icon": "achievement_challengemode_platinum",
             "id": 16429,
             "name": "The Thundering Hero",
+            "notObtainable": true,
             "titleId": 470,
             "type": "achievement"
           },
           {
             "icon": "achievement_challengemode_gold",
-            "id": 16648,
-            "name": "The Thundering",
-            "titleId": 477,
+            "id": 17843,
+            "name": "The Smoldering",
+            "titleId": 503,
+            "type": "achievement"
+          },
+          {
+            "icon": "achievement_challengemode_platinum",
+            "id": 17846,
+            "name": "The Smoldering Hero",
+            "titleId": 504,
             "type": "achievement"
           }
         ],
@@ -362,6 +394,53 @@
             "type": "achievement"
           },
           {
+            "icon": "inv_treasurevault_key01",
+            "id": 17413,
+            "name": "The Key Master",
+            "titleId": 494,
+            "type": "achievement"
+          },
+          {
+            "icon": "inv_dracthyrhead05",
+            "id": 17543,
+            "name": "The Forbidden",
+            "titleId": 495,
+            "type": "achievement"
+          },
+          {
+            "icon": "ability_evoker_dragonrage2_green",
+            "id": 17734,
+            "name": "The Reconciler",
+            "titleId": 498,
+            "type": "achievement"
+          },
+          {
+            "icon": "inv_helm_armor_moleperson_b_01",
+            "id": 17841,
+            "name": "Barter Boss",
+            "titleId": 502,
+            "type": "achievement"
+          },
+          {
+            "icon": "ability_racial_molemachine",
+            "id": 18284,
+            "name": "Sniffenseeker",
+            "titleId": 507,
+            "type": "achievement"
+          },
+          {
+            "icon": "achievement_guildperk_chug-a-lug_rank2",
+            "id": 18200,
+            "name": "Field Researcher",
+            "titleId": 508,
+            "type": "achievement"
+          }
+        ],
+        "name": "Exploration"
+      },
+      {
+        "items": [
+          {
             "icon": "inv_checkered_flag",
             "id": 15941,
             "name": "Isles Racer",
@@ -383,21 +462,14 @@
             "type": "achievement"
           },
           {
-            "icon": "inv_treasurevault_key01",
-            "id": 17413,
-            "name": "The Key Master",
-            "titleId": 494,
-            "type": "achievement"
-          },
-          {
-            "icon": "inv_dracthyrhead05",
-            "id": 17543,
-            "name": "The Forbidden",
-            "titleId": 495,
+            "icon": "inv_checkered_flag",
+            "id": 17494,
+            "name": "Zaralek Cavern Racer",
+            "titleId": 509,
             "type": "achievement"
           }
         ],
-        "name": "Exploration"
+        "name": "Dragon Racing"
       }
     ]
   },
@@ -629,6 +701,18 @@
           }
         ],
         "name": "Exploration"
+      },
+      {
+        "items": [
+          {
+            "icon": "ability_creature_amber_02",
+            "id": 14721,
+            "name": "Smelly",
+            "titleId": 501,
+            "type": "achievement"
+          }
+        ],
+        "name": "Other"
       }
     ]
   },
@@ -2457,6 +2541,7 @@
             "icon": "achievement_featsofstrength_gladiator_04",
             "id": 17339,
             "name": "Legend",
+            "notObtainable": true,
             "titleId": 491,
             "type": "achievement"
           },
@@ -2464,7 +2549,15 @@
             "icon": "achievement_featsofstrength_gladiator_07",
             "id": 16734,
             "name": "Crimson Legend",
+            "notObtainable": true,
             "titleId": 482,
+            "type": "achievement"
+          },
+          {
+            "icon": "achievement_featsofstrength_gladiator_07",
+            "id": 17767,
+            "name": "Obsidian Legend",
+            "titleId": 500,
             "type": "achievement"
           }
         ],
@@ -2476,7 +2569,15 @@
             "icon": "achievement_featsofstrength_gladiator_07",
             "id": 15951,
             "name": "Crimson Gladiator",
+            "notObtainable": true,
             "titleId": 468,
+            "type": "achievement"
+          },
+          {
+            "icon": "achievement_featsofstrength_gladiator_07",
+            "id": 17764,
+            "name": "Obsidian Gladiator",
+            "titleId": 499,
             "type": "achievement"
           }
         ],

--- a/static/data/toys.json
+++ b/static/data/toys.json
@@ -154,6 +154,18 @@
             "icon": "inv_babyturtle2",
             "itemId": 200999,
             "name": "The Super Shellkhan Gang"
+          },
+          {
+            "ID": 1320,
+            "icon": "inv_misc_drum_01",
+            "itemId": 205419,
+            "name": "Jrumm's Drum"
+          },
+          {
+            "ID": 1323,
+            "icon": "inv_alchemy_70_cauldron",
+            "itemId": 205796,
+            "name": "Molten Lava Pack"
           }
         ],
         "name": "Rare"
@@ -201,6 +213,12 @@
             "icon": "oshugun_crystalfragments",
             "itemId": 201927,
             "name": "Gleaming Arcanocrystal"
+          },
+          {
+            "ID": 1317,
+            "icon": "inv_shadowflame_nova",
+            "itemId": 205418,
+            "name": "Blazing Shadowflame Cinder"
           }
         ],
         "name": "Treasure"
@@ -249,186 +267,18 @@
             "icon": "inv_10_dungeonjewelry_dragon_trinket_3djardintrophy_black",
             "itemId": 202021,
             "name": "Breaker's Flag of Victory"
+          },
+          {
+            "ID": 1332,
+            "icon": "inv_alchemy_70_flask03orange",
+            "itemId": 205936,
+            "name": "New Niffen No-Sniffin' Tonic"
           }
         ],
         "name": "Vendor"
       },
       {
-        "id": "7dd60e6c",
         "items": [
-          {
-            "ID": 1203,
-            "icon": "achievement_profession_fishing_northrendangler",
-            "itemId": 198428,
-            "name": "Tuskarr Dinghy"
-          },
-          {
-            "ID": 1236,
-            "icon": "inv_eagle2wind",
-            "itemId": 200630,
-            "name": "Ohn'ir Windsage's Hearthstone"
-          },
-          {
-            "ID": 1238,
-            "icon": "inv_10_dungeonjewelry_primitive_trinket_tuskarrplushie_color1",
-            "itemId": 200631,
-            "name": "Happy Tuskarr Palooza"
-          },
-          {
-            "ID": 1276,
-            "icon": "achievement_profession_fishing_outlandangler",
-            "itemId": 202207,
-            "name": "Reusable Oversized Bobber"
-          }
-        ],
-        "name": "Achievement"
-      },
-      {
-        "id": "877c9d6c",
-        "items": [
-          {
-            "ID": 1191,
-            "icon": "inv_jewelry_necklace_15",
-            "itemId": 193032,
-            "name": "Jeweled Offering"
-          },
-          {
-            "ID": 1193,
-            "icon": "inv_10_jewelcrafting3_rainbowprism_color1",
-            "itemId": 193033,
-            "name": "Convergent Prism"
-          },
-          {
-            "ID": 1194,
-            "icon": "inv_misc_bag_10",
-            "itemId": 193478,
-            "name": "Tuskarr Beanbag"
-          },
-          {
-            "ID": 1195,
-            "icon": "inv_10_tailoring2_tent_color3",
-            "itemId": 193476,
-            "name": "Gnoll Tent"
-          },
-          {
-            "ID": 1196,
-            "icon": "inv_misc_clipboard01",
-            "itemId": 197719,
-            "name": "Artisan's Sign"
-          },
-          {
-            "ID": 1204,
-            "icon": "item_embercloth",
-            "itemId": 194052,
-            "name": "Forlorn Funeral Pall"
-          },
-          {
-            "ID": 1210,
-            "icon": "inv_10_tailoring2_tent_color5",
-            "itemId": 194060,
-            "name": "Dragonscale Expedition's Expedition Tent"
-          },
-          {
-            "ID": 1214,
-            "icon": "inv_duckbaby_white",
-            "itemId": 194056,
-            "name": "Duck-Stuffed Duck Lovie"
-          },
-          {
-            "ID": 1217,
-            "icon": "inv_10_tailoring2_pillow_yellow",
-            "itemId": 194057,
-            "name": "Cushion of Time Travel"
-          },
-          {
-            "ID": 1218,
-            "icon": "inv_10_tailoring2_pillow_blue",
-            "itemId": 194058,
-            "name": "Cold Cushion"
-          },
-          {
-            "ID": 1219,
-            "icon": "inv_10_tailoring2_tent_color1",
-            "itemId": 194059,
-            "name": "Market Tent"
-          },
-          {
-            "ID": 1230,
-            "icon": "inv_enchanting_70_toy_leyshocker",
-            "itemId": 200469,
-            "name": "Khadgar's Disenchanting Rod"
-          },
-          {
-            "ID": 1220,
-            "icon": "inv_gizmo_03",
-            "itemId": 199554,
-            "name": "S.E.A.T."
-          },
-          {
-            "ID": 1190,
-            "icon": "inv_misc_enggizmos_36",
-            "itemId": 192495,
-            "name": "Malfunctioning Stealthman 54"
-          },
-          {
-            "ID": 1245,
-            "icon": "ability_mount_rocketmount",
-            "itemId": 192443,
-            "name": "Element-Infused Rocket Helmet"
-          },
-          {
-            "ID": 1281,
-            "icon": "inv_mechacycle",
-            "itemId": 198173,
-            "name": "Atomic Recalibrator"
-          },
-          {
-            "ID": 1207,
-            "icon": "inv_gizmo_newgoggles",
-            "itemId": 198227,
-            "name": "Giggle Goggles"
-          },
-          {
-            "ID": 1211,
-            "icon": "inv_10_engineering_device_gadget3_color1",
-            "itemId": 198264,
-            "name": "Centralized Precipitation Emitter"
-          },
-          {
-            "ID": 1212,
-            "icon": "inv_10_engineering_device_gadget2_color1",
-            "itemId": 198206,
-            "name": "Environmental Emulator"
-          },
-          {
-            "ID": 1215,
-            "icon": "inv_10_engineering_device_gadget3_color3",
-            "itemId": 198156,
-            "name": "Wyrmhole Generator: Dragon Isles"
-          },
-          {
-            "ID": 1301,
-            "icon": "inv_drink_21",
-            "itemId": 202360,
-            "name": "Dented Can"
-          },
-          {
-            "ID": 1309,
-            "icon": "inv_10_engineering2_pvpflaregun_color1",
-            "itemId": 201930,
-            "name": "H.E.L.P."
-          },
-          {
-            "ID": 1237,
-            "icon": "inv_10_enchanting2_elementalswirl_color1",
-            "itemId": 200636,
-            "name": "Primal Invocation Quintessence"
-          }
-        ],
-        "name": "Profession"
-      },
-      {
-        "items":[
           {
             "ID": 1252,
             "icon": "inv_10_dungeonjewelry_explorer_trinket_1compass_color2",
@@ -469,7 +319,7 @@
         "name": "Renown: Dragonscale Expedition"
       },
       {
-        "items":[
+        "items": [
           {
             "ID": 1201,
             "icon": "inv_misc_cauldron_arcane",
@@ -498,7 +348,7 @@
         "name": "Renown: Maruuk Centaur"
       },
       {
-        "items":[
+        "items": [
           {
             "ID": 1258,
             "icon": "archaeology_5_0_pandarenteaset",
@@ -545,7 +395,7 @@
         "name": "Renown: Iskarra Tuskarr"
       },
       {
-        "items":[
+        "items": [
           {
             "ID": 1259,
             "icon": "inv_misc_pearlmilktea",
@@ -586,7 +436,24 @@
         "name": "Renown: Valdrakken Accord"
       },
       {
-        "items":[
+        "items": [
+          {
+            "ID": 1316,
+            "icon": "inv_10_specialreagentfoozles_tuskclaw-black",
+            "itemId": 205255,
+            "name": "Niffen Diggin' Mitts"
+          },
+          {
+            "ID": 1326,
+            "icon": "inv_misc_food_legion_flaked-sea-salt",
+            "itemId": 205963,
+            "name": "Sniffin' Salts"
+          }
+        ],
+        "name": "Renown: Loamm Niffen"
+      },
+      {
+        "items": [
           {
             "ID": 1102,
             "icon": "inv_item_dragonegg_black01",
@@ -620,7 +487,42 @@
         ],
         "name": "Reputation"
       },
-      
+      {
+        "id": "7dd60e6c",
+        "items": [
+          {
+            "ID": 1203,
+            "icon": "achievement_profession_fishing_northrendangler",
+            "itemId": 198428,
+            "name": "Tuskarr Dinghy"
+          },
+          {
+            "ID": 1236,
+            "icon": "inv_eagle2wind",
+            "itemId": 200630,
+            "name": "Ohn'ir Windsage's Hearthstone"
+          },
+          {
+            "ID": 1238,
+            "icon": "inv_10_dungeonjewelry_primitive_trinket_tuskarrplushie_color1",
+            "itemId": 200631,
+            "name": "Happy Tuskarr Palooza"
+          },
+          {
+            "ID": 1276,
+            "icon": "achievement_profession_fishing_outlandangler",
+            "itemId": 202207,
+            "name": "Reusable Oversized Bobber"
+          },
+          {
+            "ID": 1325,
+            "icon": "inv_misc_claw_deepcrab_ghost",
+            "itemId": 205904,
+            "name": "Vibrant Clacking Claw"
+          }
+        ],
+        "name": "Achievement"
+      },
       {
         "id": "45010d6e",
         "items": [
@@ -714,6 +616,12 @@
             "itemId": 204220,
             "name": "Hraxian's Unbreakable Will",
             "notObtainable": true
+          },
+          {
+            "ID": 1310,
+            "icon": "ability_earthen_pillar",
+            "itemId": 204389,
+            "name": "Stone Breaker"
           }
         ],
         "name": "Quest"
@@ -736,6 +644,24 @@
             "icon": "inv_60pvp_trinket4a",
             "itemId": 200116,
             "name": "Everlasting Horn of Lavaswimming"
+          },
+          {
+            "ID": 1322,
+            "icon": "inv_enchant_essencemagiclarge",
+            "itemId": 205688,
+            "name": "Glutinous Glitterscale Glob"
+          },
+          {
+            "ID": 1327,
+            "icon": "ability_evoker_deepbreath",
+            "itemId": 206043,
+            "name": "Fyrakk's Frenzy"
+          },
+          {
+            "ID": 1331,
+            "icon": "inv_misc_nightmarebanner",
+            "itemId": 206008,
+            "name": "Nightmare Banner"
           }
         ],
         "name": "Events"
@@ -4551,6 +4477,144 @@
         "name": "Archaeology"
       },
       {
+        "id": "bd30e8a9",
+        "items": [
+          {
+            "ID": 610,
+            "icon": "ability_garrison_orangebird",
+            "itemId": 143662,
+            "name": "Crate of Bobbers: Wooden Pepe"
+          },
+          {
+            "ID": 599,
+            "icon": "inv_garrison_cargoship",
+            "itemId": 142530,
+            "name": "Crate of Bobbers: Tugboat"
+          },
+          {
+            "ID": 600,
+            "icon": "inv_g_fishingbobber_05",
+            "itemId": 142531,
+            "name": "Crate of Bobbers: Squeaky Duck"
+          },
+          {
+            "ID": 601,
+            "icon": "inv_misc_head_murloc_01",
+            "itemId": 142532,
+            "name": "Crate of Bobbers: Murloc Head"
+          },
+          {
+            "ID": 598,
+            "icon": "trade_archaeology_catstatueemeraldeyes",
+            "itemId": 142529,
+            "name": "Crate of Bobbers: Cat Head"
+          },
+          {
+            "ID": 597,
+            "icon": "ability_hunter_pet_worm",
+            "itemId": 142528,
+            "name": "Crate of Bobbers: Can of Worms"
+          },
+          {
+            "ID": 485,
+            "icon": "inv_mace_27",
+            "itemId": 85973,
+            "name": "Ancient Pandaren Fishing Charm"
+          },
+          {
+            "ID": 486,
+            "icon": "inv_misc_fishing_raft",
+            "itemId": 85500,
+            "name": "Anglers Fishing Raft"
+          },
+          {
+            "ID": 103,
+            "icon": "inv_misc_coin_18",
+            "itemId": 44430,
+            "name": "Titanium Seal of Dalaran"
+          },
+          {
+            "ID": 139,
+            "icon": "inv_fishingchair",
+            "itemId": 86596,
+            "name": "Nat's Fishing Chair"
+          },
+          {
+            "ID": 250,
+            "icon": "inv_misc_idol_05",
+            "itemId": 45984,
+            "name": "Unusual Compass"
+          }
+        ],
+        "name": "Fishing"
+      },
+      {
+        "id": "4e4ffd58",
+        "items": [
+          {
+            "ID": 472,
+            "icon": "achievement_profession_chefhat",
+            "itemId": 134020,
+            "name": "Chef's Hat"
+          }
+        ],
+        "name": "Cooking"
+      },
+      {
+        "id": "79a66987",
+        "items": [
+          {
+            "ID": 352,
+            "icon": "inv_cask_03",
+            "itemId": 120857,
+            "name": "Barrel of Bandanas",
+            "obtainClasses": [
+              4
+            ]
+          },
+          {
+            "ID": 199,
+            "icon": "inv_misc_dice_01",
+            "itemId": 36863,
+            "name": "Decahedral Dwarven Dice",
+            "obtainClasses": [
+              4
+            ]
+          },
+          {
+            "ID": 223,
+            "icon": "inv_misc_dice_02",
+            "itemId": 63269,
+            "name": "Loaded Gnomish Dice",
+            "obtainClasses": [
+              4
+            ]
+          },
+          {
+            "ID": 257,
+            "icon": "inv_misc_dice_02",
+            "itemId": 36862,
+            "name": "Worn Troll Dice",
+            "obtainClasses": [
+              4
+            ]
+          }
+        ],
+        "name": "Pickpocketing"
+      },
+      {
+        "id": "b2f64016",
+        "items": [
+          {
+            "ID": 611,
+            "icon": "inv_knife_1h_common_b_01green",
+            "itemId": 130102,
+            "name": "Mother's Skinning Knife"
+          }
+        ],
+        "name": "Skinning"
+      },
+      {
         "id": "34d351da",
         "items": [
           {
@@ -4594,6 +4658,24 @@
             "icon": "inv_misc_rune_07",
             "itemId": 186686,
             "name": "Pallid Oracle Bones"
+          },
+          {
+            "ID": 1194,
+            "icon": "inv_misc_bag_10",
+            "itemId": 193478,
+            "name": "Tuskarr Beanbag"
+          },
+          {
+            "ID": 1195,
+            "icon": "inv_10_tailoring2_tent_color3",
+            "itemId": 193476,
+            "name": "Gnoll Tent"
+          },
+          {
+            "ID": 1196,
+            "icon": "inv_misc_clipboard01",
+            "itemId": 197719,
+            "name": "Artisan's Sign"
           }
         ],
         "name": "Leatherworking"
@@ -4612,9 +4694,111 @@
             "icon": "inv_jewelcrafting_70_songcrystal",
             "itemId": 130254,
             "name": "Chatterstone"
+          },
+          {
+            "ID": 1191,
+            "icon": "inv_jewelry_necklace_15",
+            "itemId": 193032,
+            "name": "Jeweled Offering"
+          },
+          {
+            "ID": 1193,
+            "icon": "inv_10_jewelcrafting3_rainbowprism_color1",
+            "itemId": 193033,
+            "name": "Convergent Prism"
+          },
+          {
+            "ID": 1315,
+            "icon": "creatureportrait_fomorhand",
+            "itemId": 205045,
+            "name": "B.B.F. Fist"
           }
         ],
         "name": "Jewelcrafting"
+      },
+      {
+        "id": "f5098ee7",
+        "items": [
+          {
+            "ID": 410,
+            "icon": "spell_fire_twilightfire",
+            "itemId": 128536,
+            "name": "Leylight Brazier"
+          },
+          {
+            "ID": 1117,
+            "icon": "Spell_animabastion_beam",
+            "itemId": 186973,
+            "name": "Anima-ted Leash"
+          },
+          {
+            "ID": 1230,
+            "icon": "inv_enchanting_70_toy_leyshocker",
+            "itemId": 200469,
+            "name": "Khadgar's Disenchanting Rod"
+          },
+          {
+            "ID": 1237,
+            "icon": "inv_10_enchanting2_elementalswirl_color1",
+            "itemId": 200636,
+            "name": "Primal Invocation Quintessence"
+          }
+        ],
+        "name": "Enchanting"
+      },
+      {
+        "id": "01d8754d",
+        "items": [
+          {
+            "ID": 531,
+            "icon": "70_inscription_steamy_romance_novel_kit",
+            "itemId": 129211,
+            "name": "Steamy Romance Novel Kit"
+          }
+        ],
+        "name": "Inscription"
+      },
+      {
+        "id": "01d8754d",
+        "items": [
+          {
+            "ID": 1204,
+            "icon": "item_embercloth",
+            "itemId": 194052,
+            "name": "Forlorn Funeral Pall"
+          },
+          {
+            "ID": 1210,
+            "icon": "inv_10_tailoring2_tent_color5",
+            "itemId": 194060,
+            "name": "Dragonscale Expedition's Expedition Tent"
+          },
+          {
+            "ID": 1214,
+            "icon": "inv_duckbaby_white",
+            "itemId": 194056,
+            "name": "Duck-Stuffed Duck Lovie"
+          },
+          {
+            "ID": 1217,
+            "icon": "inv_10_tailoring2_pillow_yellow",
+            "itemId": 194057,
+            "name": "Cushion of Time Travel"
+          },
+          {
+            "ID": 1218,
+            "icon": "inv_10_tailoring2_pillow_blue",
+            "itemId": 194058,
+            "name": "Cold Cushion"
+          },
+          {
+            "ID": 1219,
+            "icon": "inv_10_tailoring2_tent_color1",
+            "itemId": 194059,
+            "name": "Market Tent"
+          }
+        ],
+        "name": "Tailoring"
       },
       {
         "id": "9bf8d5f8",
@@ -4780,177 +4964,75 @@
             "icon": "inv_misc_bomb_04",
             "itemId": 202309,
             "name": "Defective Doomsday Device"
+          },
+          {
+            "ID": 1220,
+            "icon": "inv_gizmo_03",
+            "itemId": 199554,
+            "name": "S.E.A.T."
+          },
+          {
+            "ID": 1190,
+            "icon": "inv_misc_enggizmos_36",
+            "itemId": 192495,
+            "name": "Malfunctioning Stealthman 54"
+          },
+          {
+            "ID": 1245,
+            "icon": "ability_mount_rocketmount",
+            "itemId": 192443,
+            "name": "Element-Infused Rocket Helmet"
+          },
+          {
+            "ID": 1281,
+            "icon": "inv_mechacycle",
+            "itemId": 198173,
+            "name": "Atomic Recalibrator"
+          },
+          {
+            "ID": 1207,
+            "icon": "inv_gizmo_newgoggles",
+            "itemId": 198227,
+            "name": "Giggle Goggles"
+          },
+          {
+            "ID": 1211,
+            "icon": "inv_10_engineering_device_gadget3_color1",
+            "itemId": 198264,
+            "name": "Centralized Precipitation Emitter"
+          },
+          {
+            "ID": 1212,
+            "icon": "inv_10_engineering_device_gadget2_color1",
+            "itemId": 198206,
+            "name": "Environmental Emulator"
+          },
+          {
+            "ID": 1215,
+            "icon": "inv_10_engineering_device_gadget3_color3",
+            "itemId": 198156,
+            "name": "Wyrmhole Generator: Dragon Isles"
+          },
+          {
+            "ID": 1301,
+            "icon": "inv_drink_21",
+            "itemId": 202360,
+            "name": "Dented Can"
+          },
+          {
+            "ID": 1309,
+            "icon": "inv_10_engineering2_pvpflaregun_color1",
+            "itemId": 201930,
+            "name": "H.E.L.P."
+          },
+          {
+            "ID": 1314,
+            "icon": "inv_weapon_rifle_19",
+            "itemId": 204818,
+            "name": "Mallard Mortar"
           }
         ],
         "name": "Engineering"
-      },
-      {
-        "id": "f5098ee7",
-        "items": [
-          {
-            "ID": 410,
-            "icon": "spell_fire_twilightfire",
-            "itemId": 128536,
-            "name": "Leylight Brazier"
-          },
-          {
-            "ID": 1117,
-            "icon": "Spell_animabastion_beam",
-            "itemId": 186973,
-            "name": "Anima-ted Leash"
-          }
-        ],
-        "name": "Enchanting"
-      },
-      {
-        "id": "01d8754d",
-        "items": [
-          {
-            "ID": 531,
-            "icon": "70_inscription_steamy_romance_novel_kit",
-            "itemId": 129211,
-            "name": "Steamy Romance Novel Kit"
-          }
-        ],
-        "name": "Inscription"
-      },
-      {
-        "id": "bd30e8a9",
-        "items": [
-          {
-            "ID": 610,
-            "icon": "ability_garrison_orangebird",
-            "itemId": 143662,
-            "name": "Crate of Bobbers: Wooden Pepe"
-          },
-          {
-            "ID": 599,
-            "icon": "inv_garrison_cargoship",
-            "itemId": 142530,
-            "name": "Crate of Bobbers: Tugboat"
-          },
-          {
-            "ID": 600,
-            "icon": "inv_g_fishingbobber_05",
-            "itemId": 142531,
-            "name": "Crate of Bobbers: Squeaky Duck"
-          },
-          {
-            "ID": 601,
-            "icon": "inv_misc_head_murloc_01",
-            "itemId": 142532,
-            "name": "Crate of Bobbers: Murloc Head"
-          },
-          {
-            "ID": 598,
-            "icon": "trade_archaeology_catstatueemeraldeyes",
-            "itemId": 142529,
-            "name": "Crate of Bobbers: Cat Head"
-          },
-          {
-            "ID": 597,
-            "icon": "ability_hunter_pet_worm",
-            "itemId": 142528,
-            "name": "Crate of Bobbers: Can of Worms"
-          },
-          {
-            "ID": 485,
-            "icon": "inv_mace_27",
-            "itemId": 85973,
-            "name": "Ancient Pandaren Fishing Charm"
-          },
-          {
-            "ID": 486,
-            "icon": "inv_misc_fishing_raft",
-            "itemId": 85500,
-            "name": "Anglers Fishing Raft"
-          },
-          {
-            "ID": 103,
-            "icon": "inv_misc_coin_18",
-            "itemId": 44430,
-            "name": "Titanium Seal of Dalaran"
-          },
-          {
-            "ID": 139,
-            "icon": "inv_fishingchair",
-            "itemId": 86596,
-            "name": "Nat's Fishing Chair"
-          },
-          {
-            "ID": 250,
-            "icon": "inv_misc_idol_05",
-            "itemId": 45984,
-            "name": "Unusual Compass"
-          }
-        ],
-        "name": "Fishing"
-      },
-      {
-        "id": "4e4ffd58",
-        "items": [
-          {
-            "ID": 472,
-            "icon": "achievement_profession_chefhat",
-            "itemId": 134020,
-            "name": "Chef's Hat"
-          }
-        ],
-        "name": "Cooking"
-      },
-      {
-        "id": "79a66987",
-        "items": [
-          {
-            "ID": 352,
-            "icon": "inv_cask_03",
-            "itemId": 120857,
-            "name": "Barrel of Bandanas",
-            "obtainClasses": [
-              4
-            ]
-          },
-          {
-            "ID": 199,
-            "icon": "inv_misc_dice_01",
-            "itemId": 36863,
-            "name": "Decahedral Dwarven Dice",
-            "obtainClasses": [
-              4
-            ]
-          },
-          {
-            "ID": 223,
-            "icon": "inv_misc_dice_02",
-            "itemId": 63269,
-            "name": "Loaded Gnomish Dice",
-            "obtainClasses": [
-              4
-            ]
-          },
-          {
-            "ID": 257,
-            "icon": "inv_misc_dice_02",
-            "itemId": 36862,
-            "name": "Worn Troll Dice",
-            "obtainClasses": [
-              4
-            ]
-          }
-        ],
-        "name": "Pickpocketing"
-      },
-      {
-        "id": "b2f64016",
-        "items": [
-          {
-            "ID": 611,
-            "icon": "inv_knife_1h_common_b_01green",
-            "itemId": 130102,
-            "name": "Mother's Skinning Knife"
-          }
-        ],
-        "name": "Skinning"
       }
     ]
   },
@@ -5037,6 +5119,24 @@
           }
         ],
         "name": "Prestige"
+      },
+      {
+        "items": [
+          {
+            "ID": 1333,
+            "icon": "inv_soloshufflepennantreward_icons_red",
+            "itemId": 206343,
+            "name": "Crimson Legend's Pennant",
+            "notObtainable": true
+          },
+          {
+            "ID": 1330,
+            "icon": "inv_soloshufflepennantreward_icons_red",
+            "itemId": 206267,
+            "name": "Obsidian Legend's Pennant"
+          }
+        ],
+        "name": "Solo Shuffle"
       }
     ]
   },
@@ -5267,6 +5367,12 @@
             "icon": "inv_chest_cloth_72",
             "itemId": 188701,
             "name": "Fire Festival Batons"
+          },
+          {
+            "ID": 1328,
+            "icon": "inv_jewelry_ring_firelandsraid_03a",
+            "itemId": 206038,
+            "name": "Flamin' Ring of Flashiness"
           }
         ],
         "name": "Midsummer"


### PR DESCRIPTION
Ran data importer for patch 10.1 (this is my first time using the data importer, so please let me know if I did anything incorrectly).

Added and Categorized:
- 126 achievements
- 14 battle pets
- 2 reputations
- 13 mounts
- 49 companions
- 12 titles
- 16 toys

Other Updates:
- marked Season 1 items as unobtainable
- reordered dragon racing achieves (was inconsistent between sub-categories)
- moved dragon racing titles into new sub-category "Dragon Racing" (was getting crowded)
- moved Mossy Mammoth mount from Riddles to new sub-category Zskera Vaults (was miscategorized)
- moved all Dragonflight profession toys to the appropriate Professions section (see conversation on pull request https://github.com/kevinclement/SimpleArmory/pull/522 ) and reordered Profession toys sub-categories for better formatting
- confirmed and resolved Issue https://github.com/kevinclement/SimpleArmory/issues/523 by moving Kirin Tor Familiar companion from Legion to Wrath category
- confirmed and resolved Issue https://github.com/kevinclement/SimpleArmory/issues/524 by moving Toolbox Trouble from Mounts to Pets sub-category and by moving Return to Darkness from Other to Mounts sub-category