### PR TITLE
Add 10.1 Hotfix data and fix [R] section

### DIFF
--- a/dataimporter/mounts.py
+++ b/dataimporter/mounts.py
@@ -40,7 +40,6 @@ IGNORE_MOUNT_ID = [
     1271,  # Swift Spectral Armored Gryphon https://www.wowhead.com/mount/1271
     1272,  # Swift Spectral Pterrordax https://www.wowhead.com/mount/1272
     1578,  # [DND] Test Mount JZB https://www.wowhead.com/mount/1578
-    1588,  # Winding Slitherdrake https://www.wowhead.com/mount/1588
     1605,  # Dragon Isles Drake Model Test https://www.wowhead.com/mount/1605
 ]
 

--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -9856,6 +9856,84 @@
                 }
               ],
               "name": "Solo Shuffle"
+            },
+            {
+              "id": "a08a25e0",
+              "items": [
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17740,
+                  "points": 0,
+                  "title": "Gladiator: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_07",
+                  "id": 17764,
+                  "points": 0,
+                  "title": "Obsidian Gladiator: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_07",
+                  "id": 17767,
+                  "points": 0,
+                  "title": "Obsidian Legend: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17794,
+                  "points": 0,
+                  "title": "Duelist: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17795,
+                  "points": 0,
+                  "title": "Rival I: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17796,
+                  "points": 0,
+                  "title": "Rival II: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17797,
+                  "points": 0,
+                  "title": "Challenger I: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17798,
+                  "points": 0,
+                  "title": "Challenger II: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_10",
+                  "id": 17799,
+                  "points": 0,
+                  "title": "Combatant I: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_10",
+                  "id": 17800,
+                  "points": 0,
+                  "title": "Combatant II: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17831,
+                  "points": 0,
+                  "title": "Elite: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_04",
+                  "id": 17801,
+                  "points": 0,
+                  "title": "Legend: Dragonflight Season 2"
+                }
+              ],
+              "name": "Rated Arena"
             }
           ]
         },
@@ -35407,6 +35485,18 @@
                   "title": "Elite: Dragonflight Season 1"
                 },
                 {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 15957,
+                  "points": 0,
+                  "title": "Gladiator: Dragonflight Season 1"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_04",
+                  "id": 17339,
+                  "points": 0,
+                  "title": "Legend: Dragonflight Season 1"
+                },
+                {
                   "icon": "achievement_featsofstrength_gladiator_07",
                   "id": 15951,
                   "points": 0,
@@ -36286,96 +36376,6 @@
                 }
               ],
               "name": "Highmaul Coliseum"
-            },
-            {
-              "id": "ecc6c104",
-              "items": [
-                {
-                  "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 15957,
-                  "points": 0,
-                  "title": "Gladiator: Dragonflight Season 1"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_04",
-                  "id": 17339,
-                  "points": 0,
-                  "title": "Legend: Dragonflight Season 1"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 17740,
-                  "points": 0,
-                  "title": "Gladiator: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_04",
-                  "id": 17801,
-                  "points": 0,
-                  "title": "Legend: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_07",
-                  "id": 17764,
-                  "points": 0,
-                  "title": "Obsidian Gladiator: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_07",
-                  "id": 17767,
-                  "points": 0,
-                  "title": "Obsidian Legend: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 17794,
-                  "points": 0,
-                  "title": "Duelist: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 17795,
-                  "points": 0,
-                  "title": "Rival I: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 17796,
-                  "points": 0,
-                  "title": "Rival II: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 17797,
-                  "points": 0,
-                  "title": "Challenger I: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 17798,
-                  "points": 0,
-                  "title": "Challenger II: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_10",
-                  "id": 17799,
-                  "points": 0,
-                  "title": "Combatant I: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_10",
-                  "id": 17800,
-                  "points": 0,
-                  "title": "Combatant II: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 17831,
-                  "points": 0,
-                  "title": "Elite: Dragonflight Season 2"
-                }
-              ],
-              "name": "[R]Rated Arena"
             }
           ]
         },

--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -9861,74 +9861,9 @@
               "id": "a08a25e0",
               "items": [
                 {
-                  "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 17740,
-                  "points": 0,
-                  "title": "Gladiator: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_07",
-                  "id": 17764,
-                  "points": 0,
-                  "title": "Obsidian Gladiator: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_07",
-                  "id": 17767,
-                  "points": 0,
-                  "title": "Obsidian Legend: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 17794,
-                  "points": 0,
-                  "title": "Duelist: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 17795,
-                  "points": 0,
-                  "title": "Rival I: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 17796,
-                  "points": 0,
-                  "title": "Rival II: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 17797,
-                  "points": 0,
-                  "title": "Challenger I: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 17798,
-                  "points": 0,
-                  "title": "Challenger II: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_10",
-                  "id": 17799,
-                  "points": 0,
-                  "title": "Combatant I: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_10",
-                  "id": 17800,
-                  "points": 0,
-                  "title": "Combatant II: Dragonflight Season 2"
-                },
-                {
-                  "icon": "achievement_featsofstrength_gladiator_09",
-                  "id": 17831,
-                  "points": 0,
-                  "title": "Elite: Dragonflight Season 2"
-                },
-                {
                   "icon": "achievement_featsofstrength_gladiator_04",
                   "id": 17801,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Legend: Dragonflight Season 2"
                 }
@@ -35525,6 +35460,72 @@
                   "id": 16734,
                   "points": 0,
                   "title": "Crimson Legend: Dragonflight Season 1"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17740,
+                  "points": 0,
+                  "title": "Gladiator: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_07",
+                  "id": 17764,
+                  "points": 0,
+                  "title": "Obsidian Gladiator: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_07",
+                  "id": 17767,
+                  "points": 0,
+                  "title": "Obsidian Legend: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17794,
+                  "points": 0,
+                  "title": "Duelist: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17795,
+                  "points": 0,
+                  "title": "Rival I: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17796,
+                  "points": 0,
+                  "title": "Rival II: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17797,
+                  "points": 0,
+                  "title": "Challenger I: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17798,
+                  "points": 0,
+                  "title": "Challenger II: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_10",
+                  "id": 17799,
+                  "points": 0,
+                  "title": "Combatant I: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_10",
+                  "id": 17800,
+                  "points": 0,
+                  "title": "Combatant II: Dragonflight Season 2"
+                },
+                {
+                  "icon": "achievement_featsofstrength_gladiator_09",
+                  "id": 17831,
+                  "points": 0,
+                  "title": "Elite: Dragonflight Season 2"
                 }
               ],
               "name": "Rated Arena"

--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -4679,19 +4679,19 @@
                   "title": "The Smell of Money"
                 },
                 {
-                  "icon": "inv_10_gearupgrade_flightstone_currency",
+                  "icon": "flightstone-dragonflight",
                   "id": 17830,
                   "points": 10,
                   "title": "Stones Can't Fly!"
                 },
                 {
-                  "icon": "inv_10_gearupgrade_flightstone_currency",
+                  "icon": "flightstone-dragonflight",
                   "id": 17977,
                   "points": 10,
                   "title": "Stones Can Try To Fly!"
                 },
                 {
-                  "icon": "inv_10_gearupgrade_flightstone_currency",
+                  "icon": "flightstone-dragonflight",
                   "id": 17978,
                   "points": 10,
                   "title": "Stones Can Fly!"
@@ -11071,7 +11071,7 @@
                 {
                   "icon": "inv_item_dragonegg_black01",
                   "id": 18193,
-                  "points": 0,
+                  "points": 10,
                   "title": "Eggscellent Eggsecution"
                 },
                 {
@@ -32922,6 +32922,18 @@
                   "id": 15654,
                   "points": 0,
                   "title": "Back from the Beyond"
+                },
+                {
+                  "icon": "inv_tabard_pvp_10season2_d_01",
+                  "id": 18027,
+                  "points": 0,
+                  "title": "Dragonflight Season 2 Master"
+                },
+                {
+                  "icon": "inv_cape_pvp_10season2_d_01",
+                  "id": 18380,
+                  "points": 0,
+                  "title": "Dragonflight Season 2 Hero"
                 }
               ],
               "name": "Other"
@@ -34403,6 +34415,12 @@
                   "id": 15191,
                   "points": 0,
                   "title": "Rae'shalare, Death's Whisper"
+                },
+                {
+                  "icon": "5098442",
+                  "id": 18256,
+                  "points": 0,
+                  "title": "Nasz'uro, the Unbound Legacy"
                 }
               ],
               "name": "Legendary"

--- a/static/data/factions.json
+++ b/static/data/factions.json
@@ -62,11 +62,11 @@
         "id": 2517,
         "levels": {
           "0": "Acquaintance",
+          "8400": "Cohort",
           "16800": "Ally",
           "25200": "Fang",
           "33600": "Friend",
-          "42000": "True Friend",
-          "8400": "Cohort"
+          "42000": "True Friend"
         },
         "name": "Wrathion"
       },
@@ -74,11 +74,11 @@
         "id": 2518,
         "levels": {
           "0": "Acquaintance",
+          "8400": "Cohort",
           "16800": "Ally",
           "25200": "Fang",
           "33600": "Friend",
-          "42000": "True Friend",
-          "8400": "Cohort"
+          "42000": "True Friend"
         },
         "name": "Sabellian"
       },
@@ -86,10 +86,10 @@
         "id": 2544,
         "levels": {
           "0": "Neutral",
-          "12500": "Esteemed",
-          "2500": "Respected",
           "500": "Preferred",
-          "5500": "Valued"
+          "2500": "Respected",
+          "5500": "Valued",
+          "12500": "Esteemed"
         },
         "name": "Artisan's Consortium - Dragon Isles Branch"
       },
@@ -97,10 +97,10 @@
         "id": 2550,
         "levels": {
           "0": "Empty",
-          "10000": "Maximum",
-          "1200": "Medium",
           "300": "Low",
-          "3600": "High"
+          "1200": "Medium",
+          "3600": "High",
+          "10000": "Maximum"
         },
         "name": "Cobalt Assembly"
       },
@@ -124,10 +124,10 @@
         "id": 2568,
         "levels": {
           "0": "Aspirational",
+          "700": "Ameteur",
           "1400": "Competent",
           "2100": "Skilled",
-          "2800": "Professional",
-          "700": "Ameteur"
+          "2800": "Professional"
         },
         "name": "Glimmerogg Racer"
       }
@@ -157,10 +157,10 @@
         "levels": {
           "0": "Dubious",
           "1000": "Apprehensive",
+          "7000": "Tentative",
           "14000": "Ambivalent",
           "21000": "Cordial",
-          "42000": "Appreciative",
-          "7000": "Tentative"
+          "42000": "Appreciative"
         },
         "name": "Ve'nari"
       },
@@ -176,10 +176,10 @@
         "id": 2464,
         "levels": {
           "0": "Neutral",
-          "21000": "Revered",
           "3000": "Friendly",
-          "42000": "Exalted",
-          "9000": "Honored"
+          "9000": "Honored",
+          "21000": "Revered",
+          "42000": "Exalted"
         },
         "name": "Court of Night"
       },
@@ -187,10 +187,10 @@
         "id": 2462,
         "levels": {
           "0": "Neutral",
-          "21000": "Revered",
           "3000": "Friendly",
-          "42000": "Exalted",
-          "9000": "Honored"
+          "9000": "Honored",
+          "21000": "Revered",
+          "42000": "Exalted"
         },
         "name": "Stitchmasters"
       },
@@ -202,11 +202,11 @@
         "id": 2472,
         "levels": {
           "0": "Tier 1",
+          "3000": "Tier 2",
+          "7500": "Tier 3",
           "14000": "Tier 4",
           "25000": "Tier 5",
-          "3000": "Tier 2",
-          "41000": "Tier 6",
-          "7500": "Tier 3"
+          "41000": "Tier 6"
         },
         "name": "The Archivists' Codex"
       },
@@ -223,11 +223,11 @@
         "id": 2446,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Baroness Vashj"
       },
@@ -235,11 +235,11 @@
         "id": 2447,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Lady Moonberry"
       },
@@ -247,11 +247,11 @@
         "id": 2448,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Mikanikos"
       },
@@ -259,11 +259,11 @@
         "id": 2449,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "The Countess"
       },
@@ -271,11 +271,11 @@
         "id": 2450,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Alexandros Mograine"
       },
@@ -283,11 +283,11 @@
         "id": 2451,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Hunt-Captain Korayn"
       },
@@ -295,11 +295,11 @@
         "id": 2452,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Polemarch Adrestes"
       },
@@ -307,11 +307,11 @@
         "id": 2453,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Rendle and Cudgelface"
       },
@@ -319,11 +319,11 @@
         "id": 2454,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Choofa"
       },
@@ -331,11 +331,11 @@
         "id": 2455,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Cryptkeeper Kassir"
       },
@@ -343,11 +343,11 @@
         "id": 2456,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Droman Aliothe"
       },
@@ -355,11 +355,11 @@
         "id": 2457,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Grandmaster Vole"
       },
@@ -367,11 +367,11 @@
         "id": 2458,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Kleia and Pelagos"
       },
@@ -379,11 +379,11 @@
         "id": 2459,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Sika"
       },
@@ -391,11 +391,11 @@
         "id": 2460,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Stonehead"
       },
@@ -403,11 +403,11 @@
         "id": 2461,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Plague Deviser Marileth"
       }
@@ -502,11 +502,11 @@
         "levels": {
           "0": "Whelpling",
           "1000": "Temporal Trainee",
-          "10000": "Epoch-Mender",
-          "15000": "Timelord",
           "2500": "Timehopper",
           "4500": "Chrono-Friend",
-          "7000": "Bronze Ally"
+          "7000": "Bronze Ally",
+          "10000": "Epoch-Mender",
+          "15000": "Timelord"
         },
         "name": "Chromie"
       },
@@ -569,11 +569,11 @@
         "id": 1975,
         "levels": {
           "0": "Stranger",
+          "8400": "Pal",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Pal"
+          "42000": "Best Friend"
         },
         "name": "Conjurer Margoss"
       },
@@ -581,11 +581,11 @@
         "id": 2097,
         "levels": {
           "0": "Stranger",
+          "8400": "Pal",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Pal"
+          "42000": "Best Friend"
         },
         "name": "Ilyssia of the Waters"
       },
@@ -593,11 +593,11 @@
         "id": 2098,
         "levels": {
           "0": "Stranger",
+          "8400": "Pal",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Pal"
+          "42000": "Best Friend"
         },
         "name": "Keeper Raynae"
       },
@@ -605,11 +605,11 @@
         "id": 2099,
         "levels": {
           "0": "Stranger",
+          "8400": "Pal",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Pal"
+          "42000": "Best Friend"
         },
         "name": "Akule Riverhorn"
       },
@@ -617,11 +617,11 @@
         "id": 2100,
         "levels": {
           "0": "Stranger",
+          "8400": "Curiosity",
           "16800": "Non-Threat",
           "25200": "Friend",
           "33600": "Helpful Friend",
-          "42000": "Best Friend",
-          "8400": "Curiosity"
+          "42000": "Best Friend"
         },
         "name": "Corbyn"
       },
@@ -629,11 +629,11 @@
         "id": 2101,
         "levels": {
           "0": "Stranger",
+          "8400": "Pal",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Pal"
+          "42000": "Best Friend"
         },
         "name": "Sha'leth"
       },
@@ -641,11 +641,11 @@
         "id": 2102,
         "levels": {
           "0": "Stranger",
+          "8400": "Pal",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Pal"
+          "42000": "Best Friend"
         },
         "name": "Impus"
       }
@@ -803,11 +803,11 @@
         "id": 1358,
         "levels": {
           "0": "Stranger",
+          "8400": "Pal",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Pal"
+          "42000": "Best Friend"
         },
         "name": "Nat Pagle"
       },
@@ -868,11 +868,11 @@
         "id": 1277,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Chee Chee"
       },
@@ -880,11 +880,11 @@
         "id": 1275,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Ella"
       },
@@ -892,11 +892,11 @@
         "id": 1283,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Farmer Fung"
       },
@@ -904,11 +904,11 @@
         "id": 1282,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Fish Fellreed"
       },
@@ -916,11 +916,11 @@
         "id": 1281,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Gina Mudclaw"
       },
@@ -928,11 +928,11 @@
         "id": 1279,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Haohan Mudclaw"
       },
@@ -940,11 +940,11 @@
         "id": 1273,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Jogu the Drunk"
       },
@@ -956,11 +956,11 @@
         "id": 1276,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Old Hillpaw"
       },
@@ -968,11 +968,11 @@
         "id": 1278,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Sho"
       },
@@ -980,11 +980,11 @@
         "id": 1280,
         "levels": {
           "0": "Stranger",
+          "8400": "Acquaintance",
           "16800": "Buddy",
           "25200": "Friend",
           "33600": "Good Friend",
-          "42000": "Best Friend",
-          "8400": "Acquaintance"
+          "42000": "Best Friend"
         },
         "name": "Tina Mudclaw"
       }

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -650,6 +650,7 @@
             "icon": "inv_deathelementalmount_purple",
             "itemId": 192557,
             "name": "Restoration Deathwalker",
+            "notObtainable": true,
             "spellid": 334482
           }
         ],

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -223,6 +223,13 @@
             "itemId": 194521,
             "name": "Cliffside Wylderdrake",
             "spellid": 368901
+          },
+          {
+            "ID": 1588,
+            "icon": "inv_companionserpent",
+            "itemId": 204361,
+            "name": "Winding Slitherdrake",
+            "spellid": 368893
           }
         ],
         "name": "Campaign"

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -8337,7 +8337,7 @@
           },
           {
             "ID": 1582,
-            "icon": "4329767",
+            "icon": "inv_turtlemount2_01",
             "itemId": 190613,
             "name": "Savage Green Battle Turtle",
             "spellid": 367826

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -833,6 +833,14 @@
             "itemId": 202085,
             "name": "Bugbiter Tortoise",
             "spellid": 377392
+          },
+          {
+            "ID": 3581,
+            "creatureId": 205649,
+            "icon": "5098442",
+            "itemId": 206040,
+            "name": "Mote of Nasz'uro",
+            "spellid": 411800
           }
         ],
         "name": "Riddle"


### PR DESCRIPTION
This PR adds the data that was added/changed in the hotfix file which is currently not supported on wago tools.

This also fixes #527 by removing the winding slitherdrake from the ignored mounts.