### PR TITLE
Add 10.1 blue dragonflight questline rewards

### DIFF
--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -235,6 +235,19 @@
         "name": "Campaign"
       },
       {
+        "id": "0efe19ce",
+        "items": [
+          {
+            "ID": 1727,
+            "icon": "stave_2h_tarecgosa_e_01stagefinal",
+            "itemId": 206162,
+            "name": "Tarecgosa's Visage",
+            "spellid": 407555
+          }
+        ],
+        "name": "Quest"
+      },
+      {
         "id": "b594ef86",
         "items": [
           {

--- a/static/data/toys.json
+++ b/static/data/toys.json
@@ -159,7 +159,7 @@
             "ID": 1320,
             "icon": "inv_misc_drum_01",
             "itemId": 205419,
-            "name": "Jrumm's Drum"
+            "name": "Dinn's Drum"
           },
           {
             "ID": 1323,
@@ -622,6 +622,12 @@
             "icon": "ability_earthen_pillar",
             "itemId": 204389,
             "name": "Stone Breaker"
+          },
+          {
+            "ID": 1324,
+            "icon": "inv_misc_head_dragon_blue",
+            "itemId": 205908,
+            "name": "Inherited Wisdom of Senegos"
           }
         ],
         "name": "Quest"


### PR DESCRIPTION
10.1 features a new questline about the Blue Dragonflight. The toy is a reward at the end of the questline and the mount is obtainable when you have the legendary staff from Firelands.