### PR TITLE
Kyrian Mounts and Unobtainables

### DIFF
--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -632,6 +632,7 @@
             "icon": "4216725",
             "itemId": 190170,
             "name": "Jigglesworth Sr.",
+            "notObtainable": true,
             "spellid": 366791
           },
           {
@@ -991,6 +992,7 @@
             "icon": "inv_progenitorbotminemount",
             "itemId": 190771,
             "name": "Carcinized Zerethsteed",
+            "notObtainable": true,
             "spellid": 359545
           }
         ],
@@ -1365,18 +1367,18 @@
             "spellid": 334398
           },
           {
-            "ID": 1492,
-            "icon": "inv_automatonfliermount",
-            "itemId": 186482,
-            "name": "Elysian Aquilon",
-            "spellid": 353875
-          },
-          {
             "ID": 1399,
             "icon": "inv_automatonlionmount_silver",
             "itemId": 180765,
             "name": "Eternal Phalynx of Purity",
             "spellid": 334403
+          },
+          {
+            "ID": 1492,
+            "icon": "inv_automatonfliermount",
+            "itemId": 186482,
+            "name": "Elysian Aquilon",
+            "spellid": 353875
           },
           {
             "ID": 1494,


### PR DESCRIPTION
It's been a while since I made a change but I felt these needed to be added!

- Added the Unobtainable tag to Jigglesworth Sr. and Carcinized Zerethsteed as their sources are now unavailable since the ending of shadowlands.

- Rearranged the Kyrian mounts to put the 9.0 campaign mounts before the 9.1 mounts to remain consistent across all other covenants on the page.

Before:
![image](https://github.com/kevinclement/SimpleArmory/assets/82674021/c3ec41a0-322a-4f3d-8291-3e683fe5237e)

After:
![image](https://github.com/kevinclement/SimpleArmory/assets/82674021/14c4e36a-7a66-4708-98a1-fc9ffa68ee1b)


I hope these changes are to everyone's likings!
