### PR TITLE
Categorization improvements: achievements and toys

### DIFF
--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -26493,6 +26493,12 @@
                   "id": 10770,
                   "points": 5,
                   "title": "The Tangerine Traveler"
+                },
+                {
+                  "icon": "inv_helm_armor_moleperson_b_01",
+                  "id": 17841,
+                  "points": 5,
+                  "title": "Pyramid Scheme"
                 }
               ],
               "name": "Items"
@@ -26556,18 +26562,6 @@
                 }
               ],
               "name": "Heirlooms"
-            },
-            {
-              "id": "9956b9d1",
-              "items": [
-                {
-                  "icon": "inv_helm_armor_moleperson_b_01",
-                  "id": 17841,
-                  "points": 5,
-                  "title": "Pyramid Scheme"
-                }
-              ],
-              "name": "Other"
             }
           ]
         },

--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -4085,6 +4085,12 @@
                   "title": "Explore Thaldraszus"
                 },
                 {
+                  "icon": "achievement_zone_forbiddenreach",
+                  "id": 17534,
+                  "points": 10,
+                  "title": "Explore the Forbidden Reach"
+                },
+                {
                   "icon": "achievement_zone_zaralekcavern",
                   "id": 17766,
                   "points": 10,
@@ -4127,6 +4133,12 @@
                   "title": "Treasures of Thaldraszus"
                 },
                 {
+                  "icon": "inv_misc_treasurechest03b",
+                  "id": 17526,
+                  "points": 5,
+                  "title": "Treasures of the Forbidden Reach"
+                },
+                {
                   "icon": "inv_misc_treasurechest04a",
                   "id": 17786,
                   "points": 5,
@@ -4161,6 +4173,18 @@
                   "id": 16679,
                   "points": 5,
                   "title": "Adventurer of Thaldraszus"
+                },
+                {
+                  "icon": "inv_knife_1h_centaur_b_02",
+                  "id": 17524,
+                  "points": 5,
+                  "title": "Adventurer of the Forbidden Reach"
+                },
+                {
+                  "icon": "inv_knife_1h_dragonquest_b_01",
+                  "id": 17525,
+                  "points": 15,
+                  "title": "Champion of the Forbidden Reach"
                 },
                 {
                   "icon": "achievement_zone_zaralekcavern",
@@ -4233,6 +4257,18 @@
                   "id": 17560,
                   "points": 20,
                   "title": "Ancient Stones of the Dragon Isles"
+                },
+                {
+                  "icon": "inv_10_fishing_fishlava_color1",
+                  "id": 17878,
+                  "points": 5,
+                  "title": "Me Want Bite"
+                },
+                {
+                  "icon": "inv_fyrakk_dragonbreath",
+                  "id": 17506,
+                  "points": 10,
+                  "title": "Still Standing in the Fire"
                 }
               ],
               "name": "Dragon Isles"
@@ -4557,12 +4593,6 @@
                   "id": 16461,
                   "points": 10,
                   "title": "Stormed Off"
-                },
-                {
-                  "icon": "inv_misc_stormlordsfavor",
-                  "id": 17540,
-                  "points": 15,
-                  "title": "Under the Weather"
                 }
               ],
               "name": "Storm Events"
@@ -4571,28 +4601,16 @@
               "id": "ac1bda82",
               "items": [
                 {
+                  "icon": "inv_dracthyrhead05",
+                  "id": 17543,
+                  "points": 25,
+                  "title": "You Know How to Reach Me"
+                },
+                {
                   "icon": "inv_misc_rune_09",
                   "id": 17315,
                   "points": 10,
                   "title": "While We Were Sleeping"
-                },
-                {
-                  "icon": "inv_knife_1h_centaur_b_02",
-                  "id": 17524,
-                  "points": 5,
-                  "title": "Adventurer of the Forbidden Reach"
-                },
-                {
-                  "icon": "inv_knife_1h_dragonquest_b_01",
-                  "id": 17525,
-                  "points": 15,
-                  "title": "Champion of the Forbidden Reach"
-                },
-                {
-                  "icon": "inv_misc_treasurechest03b",
-                  "id": 17526,
-                  "points": 5,
-                  "title": "Treasures of the Forbidden Reach"
                 },
                 {
                   "icon": "inv_misc_treasurechest01b",
@@ -4631,16 +4649,10 @@
                   "title": "Scroll Hunter"
                 },
                 {
-                  "icon": "achievement_zone_forbiddenreach",
-                  "id": 17534,
-                  "points": 10,
-                  "title": "Explore the Forbidden Reach"
-                },
-                {
-                  "icon": "inv_dracthyrhead05",
-                  "id": 17543,
-                  "points": 25,
-                  "title": "You Know How to Reach Me"
+                  "icon": "inv_misc_stormlordsfavor",
+                  "id": 17540,
+                  "points": 15,
+                  "title": "Under the Weather"
                 }
               ],
               "name": "Forbidden Reach"
@@ -4703,10 +4715,16 @@
                   "title": "Slow and Steady Wins the Race"
                 },
                 {
-                  "icon": "inv_10_fishing_fishlava_color1",
-                  "id": 17878,
+                  "icon": "achievement_guildperk_chug-a-lug_rank2",
+                  "id": 18200,
+                  "points": 15,
+                  "title": "Cooling the Research Field"
+                },
+                {
+                  "icon": "inv_axe_1h_blackdragonoutdoor_d_01",
+                  "id": 18209,
                   "points": 5,
-                  "title": "Me Want Bite"
+                  "title": "Nothing Stops the Research"
                 },
                 {
                   "icon": "shaman_talent_primalelementalist",
@@ -4719,12 +4737,6 @@
                   "id": 18199,
                   "points": 10,
                   "title": "Zaqali Ritual Buster"
-                },
-                {
-                  "icon": "achievement_guildperk_chug-a-lug_rank2",
-                  "id": 18200,
-                  "points": 15,
-                  "title": "Cooling the Research Field"
                 },
                 {
                   "icon": "achievement_dungeon_ulduarraid_titan_01",
@@ -4775,10 +4787,10 @@
                   "title": "The Small Disruptions"
                 },
                 {
-                  "icon": "inv_axe_1h_blackdragonoutdoor_d_01",
-                  "id": 18209,
-                  "points": 5,
-                  "title": "Nothing Stops the Research"
+                  "icon": "ability_racial_molemachine",
+                  "id": 18284,
+                  "points": 0,
+                  "title": "A Niffen's Best Buddy"
                 },
                 {
                   "icon": "ui_majorfaction_niffen",
@@ -4809,18 +4821,6 @@
                   "id": 18271,
                   "points": 15,
                   "title": "He'sSss All Mine"
-                },
-                {
-                  "icon": "ability_racial_molemachine",
-                  "id": 18284,
-                  "points": 0,
-                  "title": "A Niffen's Best Buddy"
-                },
-                {
-                  "icon": "inv_fyrakk_dragonbreath",
-                  "id": 17506,
-                  "points": 10,
-                  "title": "Still Standing in the Fire"
                 }
               ],
               "name": "Zaralek Cavern"

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -449,20 +449,20 @@
             "spellid": 375043
           },
           {
-            "ID": 3407,
-            "creatureId": 192108,
-            "icon": "inv_aussiepup_bcollie",
-            "itemId": 201441,
-            "name": "Scout",
-            "spellid": 374678
-          },
-          {
             "ID": 3530,
             "creatureId": 204293,
             "icon": "inv_dogprimalbaby_black",
             "itemId": 205052,
             "name": "Miloh",
             "spellid": 408100
+          },
+          {
+            "ID": 3407,
+            "creatureId": 192108,
+            "icon": "inv_aussiepup_bcollie",
+            "itemId": 201441,
+            "name": "Scout",
+            "spellid": 374678
           }
         ],
         "name": "Pet Charm"

--- a/static/data/toys.json
+++ b/static/data/toys.json
@@ -103,6 +103,18 @@
           }
         ],
         "name": "Heirlooms"
+      },
+      {
+        "id": "117dffb7",
+        "items": [
+          {
+            "ID": 1303,
+            "icon": "achievement_general_hordeslayer",
+            "itemId": 204170,
+            "name": "Clan Banner"
+          }
+        ],
+        "name": "Racial"
       }
     ]
   },
@@ -593,22 +605,10 @@
             "name": "Cloak of Many Faces"
           },
           {
-            "ID": 1243,
-            "icon": "ability_nightfae_flicker",
-            "itemId": 200960,
-            "name": "Seed of Renewed Souls"
-          },
-          {
             "ID": 1290,
             "icon": "ability_warrior_strengthofarms",
             "itemId": 203725,
             "name": "Display of Strength"
-          },
-          {
-            "ID": 1303,
-            "icon": "achievement_general_hordeslayer",
-            "itemId": 204170,
-            "name": "Clan Banner"
           },
           {
             "ID": 1302,
@@ -637,17 +637,6 @@
           }
         ],
         "name": "Quest"
-      },
-      {
-        "items": [
-          {
-            "ID": 1295,
-            "icon": "sha_spell_fire_felfire",
-            "itemId": 203757,
-            "name": "Brazier of Madness"
-          }
-        ],
-        "name": "Dungeon"
       },
       {
         "items": [
@@ -1153,6 +1142,12 @@
             "icon": "inv_wand_1h_ardenweald_d_01",
             "itemId": 187705,
             "name": "Choofa's Call"
+          },
+          {
+            "ID": 1243,
+            "icon": "ability_nightfae_flicker",
+            "itemId": 200960,
+            "name": "Seed of Renewed Souls"
           }
         ],
         "name": "Night Fae"
@@ -4351,9 +4346,15 @@
             "icon": "inv_misc_flute_01",
             "itemId": 13379,
             "name": "Piccolo of the Flaming Fire"
+          },
+          {
+            "ID": 1295,
+            "icon": "sha_spell_fire_felfire",
+            "itemId": 203757,
+            "name": "Brazier of Madness"
           }
         ],
-        "name": "Dungeon Drop"
+        "name": "Dungeon"
       },
       {
         "id": "2b03cbb4",

--- a/static/data/toys.json
+++ b/static/data/toys.json
@@ -3942,6 +3942,17 @@
         "name": "Rare"
       },
       {
+        "items": [
+          {
+            "ID": 1295,
+            "icon": "sha_spell_fire_felfire",
+            "itemId": 203757,
+            "name": "Brazier of Madness"
+          }
+        ],
+        "name": "Dungeon"
+      },
+      {
         "id": "653cf16c",
         "items": [
           {
@@ -4346,15 +4357,9 @@
             "icon": "inv_misc_flute_01",
             "itemId": 13379,
             "name": "Piccolo of the Flaming Fire"
-          },
-          {
-            "ID": 1295,
-            "icon": "sha_spell_fire_felfire",
-            "itemId": 203757,
-            "name": "Brazier of Madness"
           }
         ],
-        "name": "Dungeon"
+        "name": "Dungeon Drop"
       },
       {
         "id": "2b03cbb4",


### PR DESCRIPTION
This PR contains a few categorization improvements for achievements and toys added in Dragonflight patches (10.0.7 and 10.1) that I found while using SimpleArmory.

Most of the improvements come from achievements/toys added in these patches but are meant for older content (Night Fae soulshape toy for example or Brazier of Madness Zul'Gurub item)