### PR TITLE
Show greyed out icon for mounts/pets/items etc, that are not obtained yet

### DIFF
--- a/src/api/achievements.js
+++ b/src/api/achievements.js
@@ -168,6 +168,8 @@ function parseAchievementObject(db, earned, character, faction) {
                 }
             })
 
+            myCat.subCategories = cat.subcats
+
             // Add the category to the obj
             obj[supercat.name].categories.push(myCat);
         })

--- a/src/components/Category/Category.svelte
+++ b/src/components/Category/Category.svelte
@@ -2,7 +2,7 @@
   import Item from "./Item.svelte";
 
   export let category;
-  export let getItemPath = (item) => item.link;
+  export let getItemPath;
   export let superCat = "";
 </script>
 

--- a/src/components/Category/Category.svelte
+++ b/src/components/Category/Category.svelte
@@ -1,0 +1,26 @@
+<script>
+  import Item from "./Item.svelte";
+
+  export let category;
+  export let getItemPath = (item) => item.link;
+  export let superCat = "";
+</script>
+
+{#if category.name != superCat}
+  <h3 class="categoryHeader">{category.name}</h3>
+{/if}
+
+{#each category.subCategories as subCategory}
+  <div class="sect">
+    <div class="subCatHeader">{subCategory.name}</div>
+    {#each subCategory.items as item}
+      {#if $$slots.item}
+        <slot name="item" {item} />
+      {:else}
+        <Item {item} {getItemPath}></Item>
+      {/if}
+    {/each}
+  </div>
+{/each}
+
+<div class="clear" />

--- a/src/components/Category/Item.svelte
+++ b/src/components/Category/Item.svelte
@@ -11,9 +11,8 @@
 <a
   target={settings.anchorTarget}
   {href}
-  class:borderOn={!(item.collected || item.completed)}
-  class:borderOff={item.collected || item.completed}
+  class:notCollected={!(item.collected || item.completed)}
   class="thumbnail"
 >
-  <img height="36" width="36" src={getImageSrc(item)} alt />
+  <img height="36" width="36" src={ getImageSrc(item, true) } alt />
 </a>

--- a/src/components/Category/Item.svelte
+++ b/src/components/Category/Item.svelte
@@ -5,7 +5,7 @@
   export let item;
   export let getItemPath;
 
-  $: href = "//" + settings.WowHeadUrl + "/" + getItemPath(item);
+  const href = "//" + settings.WowHeadUrl + "/" + getItemPath(item);
 </script>
 
 <a

--- a/src/components/Category/Item.svelte
+++ b/src/components/Category/Item.svelte
@@ -1,0 +1,19 @@
+<script>
+  import settings from "$util/settings";
+  import { getImageSrc } from "$util/utils";
+
+  export let item;
+  export let getItemPath;
+
+  $: href = "//" + settings.WowHeadUrl + "/" + getItemPath(item);
+</script>
+
+<a
+  target={settings.anchorTarget}
+  {href}
+  class:borderOn={!(item.collected || item.completed)}
+  class:borderOff={item.collected || item.completed}
+  class="thumbnail"
+>
+  <img height="36" width="36" src={getImageSrc(item)} alt />
+</a>

--- a/src/components/Category/Item.svelte
+++ b/src/components/Category/Item.svelte
@@ -3,7 +3,7 @@
   import { getImageSrc } from "$util/utils";
 
   export let item;
-  export let getItemPath;
+  export let getItemPath = (item) => item.link;
 
   const href = "//" + settings.WowHeadUrl + "/" + getItemPath(item);
 </script>

--- a/src/components/Category/Item.svelte
+++ b/src/components/Category/Item.svelte
@@ -11,6 +11,7 @@
 <a
   target={settings.anchorTarget}
   {href}
+  rel={item.rel}
   class:notCollected={!(item.collected || item.completed)}
   class="thumbnail"
 >

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -203,7 +203,7 @@
 					</a>
 
 					<ul class="dropdown-menu" aria-labelledby="profileDrop">
-					  <li class="signin-label">Signed in as</li>
+					  <li class="signin-label"><span>Signed in as</span></li>
 					  <li><strong class="signin-name">{$character} @ {$realm}</strong></li>
 					  <li role="separator" class="divider"></li> 
 					  <li><a href="/#/">Signout</a></li>
@@ -221,6 +221,7 @@
 						  {/each}
 						</ul>
 					  </li>
+					  <li><a href="{getUrl($region, $realm, $character, 'settings')}">Settings</a></li>
 					  <li role="separator" class="divider"></li>
 					  <li><a href="https://github.com/kevinclement/SimpleArmory/issues" target="_blank">Report Bug</a></li>
 					</ul>

--- a/src/pages/Achievements.svelte
+++ b/src/pages/Achievements.svelte
@@ -2,10 +2,10 @@
     import { onMount } from 'svelte'
     import { region, realm, character, category } from '$stores/user'
     import { getAchievements } from '$api/achievements'
-    import { percent, percentFormat, getTitle, getImageSrc } from '$util/utils'
-    import settings from '$util/settings'
+    import { percent, percentFormat, getTitle } from '$util/utils'
     import ProgressBar from '$components/ProgressBar.svelte';
     import Loading from '$components/Loading.svelte';
+    import Category from '$components/Category/Category.svelte';
 
     $: superCat = prettySuperCategory($category);
 
@@ -104,26 +104,7 @@
 {:then value}
 {#if achievements}
     {#each achievements.categories as category}
-        {#if category.name != superCat}
-            <h3 class="categoryHeader">{ category.name }</h3>
-        {/if}
-        {#each category.subcats as subcat}
-            <div class="sect">
-                <div class="subCatHeader">{ subcat.name }</div>
-                {#each subcat.achievements as achievement}
-                    <a 
-                        target="{settings.anchorTarget}"
-                        href="//{settings.WowHeadUrl}/achievement={achievement.id}"
-                        class="thumbnail"
-                        class:borderOn={!achievement.completed}
-                        class:borderOff={achievement.completed}
-                        rel={achievement.rel}>
-                        <img height="36" width="36" src="{getImageSrc(achievement)}" alt={achievement.icon}>
-                    </a>
-                {/each}
-            </div>
-        {/each}
-        <div class="clear"/>
+        <Category {category} getItemPath={item => `achievement=${item.id}`} {superCat}></Category>
     {/each}
 {/if}   
 {/await}

--- a/src/pages/BattlePets.svelte
+++ b/src/pages/BattlePets.svelte
@@ -73,9 +73,9 @@
             class="thumbnail pbThumbnail" 
             target="{settings.anchorTarget}"
             href="//{settings.WowHeadUrl}/battle-pet/{ item.ID }"
-            class:borderOn={!item.collected}
-            class:borderOff={item.collected}>
-                <img height="36" width="36" src="{getImageSrc(item)}" alt>
+            class:notCollected={!item.collected}
+            >
+                <img height="36" width="36" src="{ getImageSrc(item, true) }" alt>
                 <div class="pbLevel" class:opacityOn={showLevel}>{ item.level }</div>
                 <div class="pbBreed" class:opacityOn={showLevel}>{ item.breed }</div>
             </a> 

--- a/src/pages/BattlePets.svelte
+++ b/src/pages/BattlePets.svelte
@@ -7,6 +7,7 @@
     import ProgressBar from '$components/ProgressBar.svelte';
     import Loading from '$components/Loading.svelte';
     import ErrorInline from '$components/ErrorInline.svelte';
+    import Category from '$components/Category/Category.svelte';
 
     let showLevel
     let battlePets
@@ -66,29 +67,21 @@
 
 {#if battlePets}
 {#each battlePets.categories as category}
-  <h3 class="categoryHeader">{ category.name }</h3>
-
-  {#each category.subCategories as subCategory}
-    <div class="sect">
-        <div class="subCatHeader">{ subCategory.name }</div>
-        {#each subCategory.items as item}
-            <div class="pbCell">
-                <a 
-                  class="thumbnail pbThumbnail" 
-                  target="{settings.anchorTarget}"
-                  href="//{settings.WowHeadUrl}/battle-pet/{ item.ID }"
-                  class:borderOn={!item.collected}
-                  class:borderOff={item.collected}>
-	        	    <img height="36" width="36" src="{getImageSrc(item)}" alt>
-	        	    <div class="pbLevel" class:opacityOn={showLevel}>{ item.level }</div>
-	        	    <div class="pbBreed" class:opacityOn={showLevel}>{ item.breed }</div>
-	      	    </a> 
-	   		    <div class="pbQual" style="{ qualityToBackground(item) }"></div>        		      	
-            </div>
-        {/each}
-    </div>
-  {/each}
-  <div class="clear"/> 
+    <Category {category} getItemPath={item => `battle-pet/${ item.ID }`}>
+        <div class="pbCell" slot="item" let:item>
+            <a 
+            class="thumbnail pbThumbnail" 
+            target="{settings.anchorTarget}"
+            href="//{settings.WowHeadUrl}/battle-pet/{ item.ID }"
+            class:borderOn={!item.collected}
+            class:borderOff={item.collected}>
+                <img height="36" width="36" src="{getImageSrc(item)}" alt>
+                <div class="pbLevel" class:opacityOn={showLevel}>{ item.level }</div>
+                <div class="pbBreed" class:opacityOn={showLevel}>{ item.breed }</div>
+            </a> 
+            <div class="pbQual" style="{ qualityToBackground(item) }"></div>        		      	
+        </div>
+    </Category>
 {/each}
 {:else}
 <ErrorInline page="pets"/>

--- a/src/pages/BattlePets.svelte
+++ b/src/pages/BattlePets.svelte
@@ -67,7 +67,7 @@
 
 {#if battlePets}
 {#each battlePets.categories as category}
-    <Category {category} getItemPath={item => `battle-pet/${ item.ID }`}>
+    <Category {category}>
         <div class="pbCell" slot="item" let:item>
             <a 
             class="thumbnail pbThumbnail" 

--- a/src/pages/Companions.svelte
+++ b/src/pages/Companions.svelte
@@ -2,11 +2,11 @@
     import { onMount } from 'svelte'
     import { region, realm, character } from '$stores/user'
     import { getCompanions } from '$api/companions'
-    import { percent, percentFormat, getTitle, getImageSrc } from '$util/utils'
-    import settings from '$util/settings'
+    import { percent, percentFormat, getTitle } from '$util/utils'
     import ProgressBar from '$components/ProgressBar.svelte';
     import Loading from '$components/Loading.svelte';
     import ErrorInline from '$components/ErrorInline.svelte';
+    import Category from '$components/Category/Category.svelte';
 
     let companions
     $: promise = getCompanions($region, $realm, $character).then(_ => {
@@ -44,26 +44,7 @@
 
 {#if companions}
 {#each companions.categories as category}
-  <h3 class="categoryHeader">{ category.name }</h3>
-
-  {#each category.subCategories as subCategory}
-    <div class="sect">
-        <div class="subCatHeader">{ subCategory.name }</div>
-        {#each subCategory.items as item}
-            <div class="pbCell">
-                <a 
-                  class="thumbnail pbThumbnail" 
-                  target="{settings.anchorTarget}"
-                  href="//{settings.WowHeadUrl}/battle-pet/{ item.ID }"
-                  class:borderOn={!item.collected}
-                  class:borderOff={item.collected}>
-	        	    <img height="36" width="36" src="{getImageSrc(item)}" alt>
-	      	    </a>
-            </div>
-        {/each}
-    </div>
-  {/each}
-  <div class="clear"/> 
+    <Category {category} getItemPath={item => `battle-pet/${ item.ID }`}></Category>
 {/each}
 {:else}
 <ErrorInline page="companions"/>

--- a/src/pages/Heirlooms.svelte
+++ b/src/pages/Heirlooms.svelte
@@ -2,10 +2,10 @@
     import { onMount } from 'svelte'
     import { region, realm, character } from '$stores/user'
     import { getHeirlooms } from '$api/heirlooms'
-    import { percent, percentFormat, getTitle, getImageSrc } from '$util/utils'
-    import settings from '$util/settings'
+    import { percent, percentFormat, getTitle } from '$util/utils'
     import ProgressBar from '$components/ProgressBar.svelte';
     import Loading from '$components/Loading.svelte';
+    import Category from '$components/Category/Category.svelte';
 
     let heirlooms
     $: promise = getHeirlooms($region, $realm, $character).then(_ => {
@@ -43,25 +43,7 @@
   <div>
     {#if heirlooms}
     {#each heirlooms.categories as category}
-        {#if category.name !== 'Heirlooms'}
-            <h3 class="categoryHeader">{ category.name }</h3>
-        {/if}
-        {#each category.subCategories as subCategory}
-            <div class="sect">
-                <div class="subCatHeader">{ subCategory.name }</div>
-                {#each subCategory.items as item}
-                    <a 
-                      target="{settings.anchorTarget}" 
-                      href="//{settings.WowHeadUrl}/{ item.link }" 
-                      class="thumbnail"
-                      class:borderOn={!item.collected}
-                      class:borderOff={item.collected}>
-                        <img height="36" width="36" src="{getImageSrc(item)}" alt>
-                    </a>
-                {/each}
-            </div>
-        {/each}
-        <div class="clear"/>
+        <Category {category} superCat="Heirlooms"></Category>
     {/each}
     {/if}
   </div>

--- a/src/pages/Mounts.svelte
+++ b/src/pages/Mounts.svelte
@@ -2,13 +2,13 @@
     import { onMount } from 'svelte'
     import { region, realm, character } from '$stores/user'
     import { getMounts } from '$api/mounts'
-    import { percent, percentFormat, getTitle, getImageSrc } from '$util/utils'
+    import { percent, percentFormat, getTitle } from '$util/utils'
     import { navigate } from '$util/url'
-    import settings from '$util/settings'
     import ProgressBar from '$components/ProgressBar.svelte';
     import MountsPlanner from '$components/MountsPlanner.svelte';
     import Loading from '$components/Loading.svelte';
     import ErrorInline from '$components/ErrorInline.svelte';
+    import Category from '$components/Category/Category.svelte';
 
     export let planner
 
@@ -71,29 +71,7 @@
          condition since it is faster to toggle it -->
     <div style="display: {planner ? 'none' : 'block' }">
     {#each mounts.categories as category}
- 
-        {#if category.name !== "Mounts" }
-        <h3 class="categoryHeader">{ category.name }</h3>
-        {/if}
-        
-        {#each category.subCategories as subCategory}
-            <div class="sect">
-                <div class="subCatHeader">{ subCategory.name }</div>
-                {#each subCategory.items as item}
-                    <a 
-                      target="{settings.anchorTarget}"
-                      href="//{settings.WowHeadUrl}/{item.link}"
-                      class:borderOn={!item.collected}
-                      class:borderOff={item.collected}
-                      class="thumbnail">
-                        <img height="36" width="36" src="{getImageSrc(item)}" alt>
-                    </a>
-                {/each}
-            </div>
-
-        {/each}
-        
-        <div class="clear" />
+        <Category {category}  superCat="Mounts"></Category>
     {/each}
     </div>
 {:else}

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -1,7 +1,8 @@
 <script>
-  import { region, realm, character, page, category } from "$stores/user";
+  import { region, realm, character } from "$stores/user";
   import { preferences } from "$stores/preferences";
   import { getWowheadUrl } from "$util/utils";
+  import Category from "$components/Category/Category.svelte";
 
   let locales = [
     { txt: "EN", link: "wowhead.com" },
@@ -15,11 +16,40 @@
     { txt: "CN", link: "cn.wowhead.com" },
   ];
 
+  let exampleCategory = {
+    name: "Example Category",
+    subCategories: [
+      {
+        name: "Example Subcategory",
+        items: [
+          {
+            collected: true,
+            icon: "inv_infernalmount",
+            link: "item=137574",
+          },
+          {
+            collected: false,
+            icon: "inv_infernalmount",
+            link: "item=137574",
+          },
+        ],
+      },
+    ],
+  };
+
   const toggleTheme = (e) => {
     e.preventDefault();
     $preferences.theme = $preferences.theme === "light" ? "dark" : "light";
 
     localStorage.setItem("darkTheme", $preferences.theme !== "light");
+  };
+
+  const toggleItemSkin = (e) => {
+    e.preventDefault();
+    $preferences.itemSkin =
+      $preferences.itemSkin === "classic" ? "new" : "classic";
+
+    localStorage.setItem("itemSkin", $preferences.itemSkin);
   };
 
   function setLocale(e, wowhead_url) {
@@ -41,34 +71,43 @@
   <div class="page-header">
     <h2>Settings</h2>
   </div>
+  <div class="sect">
+    <div>
+      Signed in as
+      <strong class="signin-name">
+        {$character} @ {$realm}
+        <span class="text-uppercase">({$region})</span>
+      </strong>
+      <a class="ml-2" href="/#/">Signout</a>
+    </div>
 
-  <div>
-    Signed in as
-    <strong class="signin-name">
-      {$character} @ {$realm}
-      <span class="text-uppercase">({$region})</span>
-    </strong>
-    <a class="ml-2" href="/#/">Signout</a>
-  </div>
+    <div>
+      <a href="#/" on:click={toggleTheme}
+        >Use {$preferences.theme === "light" ? "Dark" : "Light"} Theme
+      </a>
+    </div>
 
-  <div>
-    <a href="#/" on:click={toggleTheme}
-      >Use {$preferences.theme === "light" ? "Dark" : "Light"} Theme</a
-    >
-  </div>
+    <div>
+      <a href="#/" on:click={toggleItemSkin}
+        >Use {$preferences.itemSkin === "classic" ? "New" : "Classic"} Item Skin
+      </a>
+    </div>
 
-  <div>
-    Locale
-    <select
-      name="locale"
-      bind:value={selectedLocale}
-      on:change={(e) => setLocale(e, selectedLocale)}
-    >
-      {#each locales as locale}
-        <option value={locale.link}>
-          {locale.txt}
-        </option>
-      {/each}
-    </select>
+    <div>
+      Locale
+      <select
+        name="locale"
+        bind:value={selectedLocale}
+        on:change={(e) => setLocale(e, selectedLocale)}
+      >
+        {#each locales as locale}
+          <option value={locale.link}>
+            {locale.txt}
+          </option>
+        {/each}
+      </select>
+    </div>
   </div>
+  <div class="clear"></div>
+  <Category category={exampleCategory}></Category>
 </div>

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -1,0 +1,74 @@
+<script>
+  import { region, realm, character, page, category } from "$stores/user";
+  import { preferences } from "$stores/preferences";
+  import { getWowheadUrl } from "$util/utils";
+
+  let locales = [
+    { txt: "EN", link: "wowhead.com" },
+    { txt: "DE", link: "de.wowhead.com" },
+    { txt: "ES", link: "es.wowhead.com" },
+    { txt: "FR", link: "fr.wowhead.com" },
+    { txt: "IT", link: "it.wowhead.com" },
+    { txt: "PT", link: "pt.wowhead.com" },
+    { txt: "RU", link: "ru.wowhead.com" },
+    { txt: "KO", link: "ko.wowhead.com" },
+    { txt: "CN", link: "cn.wowhead.com" },
+  ];
+
+  const toggleTheme = (e) => {
+    e.preventDefault();
+    $preferences.theme = $preferences.theme === "light" ? "dark" : "light";
+
+    localStorage.setItem("darkTheme", $preferences.theme !== "light");
+  };
+
+  function setLocale(e, wowhead_url) {
+    e.preventDefault();
+
+    // if clicked on same locale already set ignore it
+    if (getWowheadUrl() === wowhead_url) {
+      return;
+    }
+
+    localStorage.setItem("wowhead_url", wowhead_url);
+    window.location.reload();
+  }
+
+  let selectedLocale = getWowheadUrl();
+</script>
+
+<div class="container">
+  <div class="page-header">
+    <h2>Settings</h2>
+  </div>
+
+  <div>
+    Signed in as
+    <strong class="signin-name">
+      {$character} @ {$realm}
+      <span class="text-uppercase">({$region})</span>
+    </strong>
+    <a class="ml-2" href="/#/">Signout</a>
+  </div>
+
+  <div>
+    <a href="#/" on:click={toggleTheme}
+      >Use {$preferences.theme === "light" ? "Dark" : "Light"} Theme</a
+    >
+  </div>
+
+  <div>
+    Locale
+    <select
+      name="locale"
+      bind:value={selectedLocale}
+      on:change={(e) => setLocale(e, selectedLocale)}
+    >
+      {#each locales as locale}
+        <option value={locale.link}>
+          {locale.txt}
+        </option>
+      {/each}
+    </select>
+  </div>
+</div>

--- a/src/pages/Titles.svelte
+++ b/src/pages/Titles.svelte
@@ -2,11 +2,11 @@
     import { onMount } from 'svelte'
     import { region, realm, character } from '$stores/user'
     import { getTitles } from '$api/titles'
-    import { percent, percentFormat, getTitle, getImageSrc } from '$util/utils'
-    import settings from '$util/settings'
+    import { percent, percentFormat, getTitle } from '$util/utils'
     import ProgressBar from '$components/ProgressBar.svelte';
     import Loading from '$components/Loading.svelte';
     import ErrorInline from '$components/ErrorInline.svelte';
+    import Category from '$components/Category/Category.svelte';
 
     let promise
     let titles
@@ -49,32 +49,7 @@
 
     <div>
     {#each titles.categories as category}
- 
-        {#if category.name !== "Titles" }
-        <h3 class="categoryHeader">{ category.name }</h3>
-        {/if}
-        
-        {#each category.subCategories as subCategory}
-            <div class="sect">
-                <div class="subCatHeader">{ subCategory.name }</div>
-                {#each subCategory.items as item}
-                    <div class="thumbnail" 
-                         class:borderOn={!item.collected}
-                         class:borderOff={item.collected}>
-                        <a 
-                        target="{settings.anchorTarget}"
-                        href="//{settings.WowHeadUrl}/{item.type}={item.id}"
-                        >
-                            <img height="36" width="36" src="{getImageSrc(item)}" alt>
-                        </a>
-                        <div class="title">{item.name}</div>
-                    </div>
-                {/each}
-            </div>
-
-        {/each}
-        
-        <div class="clear" />
+     <Category {category} getItemPath={item => `${item.type}=${item.id}`} superCat="Titles"></Category>
     {/each}
     </div>
 {:else}

--- a/src/pages/Toys.svelte
+++ b/src/pages/Toys.svelte
@@ -2,10 +2,10 @@
     import { onMount } from 'svelte'
     import { region, realm, character } from '$stores/user'
     import { getToys } from '$api/toys'
-    import { percent, percentFormat, getTitle, getImageSrc } from '$util/utils'
-    import settings from '$util/settings'
+    import { percent, percentFormat, getTitle } from '$util/utils'
     import ProgressBar from '$components/ProgressBar.svelte';
     import Loading from '$components/Loading.svelte';
+    import Category from '$components/Category/Category.svelte';
 
     let toys
     $: promise = getToys($region, $realm, $character).then(_ => {
@@ -43,25 +43,7 @@
   <div>
     {#if toys}
     {#each toys.categories as category}
-        {#if category.name !== 'Toys'}
-            <h3 class="categoryHeader">{ category.name }</h3>
-        {/if}
-        {#each category.subCategories as subCategory}
-            <div class="sect">
-                <div class="subCatHeader">{ subCategory.name }</div>
-                {#each subCategory.items as item}
-                    <a 
-                      target="{settings.anchorTarget}" 
-                      href="//{settings.WowHeadUrl}/{ item.link }" 
-                      class="thumbnail"
-                      class:borderOn={!item.collected}
-                      class:borderOff={item.collected}>
-                        <img height="36" width="36" src="{getImageSrc(item)}" alt>
-                    </a>
-                {/each}
-            </div>
-        {/each}
-        <div class="clear"/>
+        <Category {category} superCat="Toys"></Category>
     {/each}
     {/if}
   </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -64,7 +64,7 @@
 			$preferences.theme = isDark ? 'dark' : 'light'
 		})
 
-		$preferences.itemSkin = localStorage.getItem('itemSkin') ?? 'classic';
+		$preferences.itemSkin = localStorage.getItem('itemSkin') ?? 'new';
 	})
 
     function getCharInfoFromURL() {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -30,6 +30,15 @@
 			} else {
 				document.body.classList.remove('dark')
 			}
+
+			const isClassic= value.itemSkin === 'classic';
+			if (isClassic) {
+				document.body.classList.add('itemSkinClassic')
+				document.body.classList.remove('itemSkinNew')
+			} else {
+				document.body.classList.add('itemSkinNew')
+				document.body.classList.remove('itemSkinClassic')
+			}
 		});
 
         getCharInfoFromURL();
@@ -54,6 +63,8 @@
 		getDarkMode(window, (isDark) => {
 			$preferences.theme = isDark ? 'dark' : 'light'
 		})
+
+		$preferences.itemSkin = localStorage.getItem('itemSkin') ?? 'classic';
 	})
 
     function getCharInfoFromURL() {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,6 +19,7 @@
 	import Error from '$pages/Error.svelte';
 	
 	import { onMount } from 'svelte'
+  import Settings from '../pages/Settings.svelte';
 
 	let _errorCount = 0;
     onMount(() => {
@@ -159,6 +160,10 @@
 			<!-- reputations -->
 			{:else if $page === 'reputation'}
 			<Reputations></Reputations>
+
+			<!-- settings -->
+			{:else if $page === 'settings'}
+			<Settings></Settings>
 
 			{/if}
 		{:else}

--- a/src/stores/preferences.js
+++ b/src/stores/preferences.js
@@ -1,3 +1,3 @@
 import { writable } from "svelte/store"
 
-export const preferences = writable({ theme: 'light' });
+export const preferences = writable({ theme: 'light', itemSkin: 'classic' });

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -468,14 +468,32 @@ body {
 	  background-color: rgba(255, 255, 255, .25);
   }
   
-  .notCollected {
-    filter: grayscale(1) opacity(0.2);
-    transition: filter .25s ease
-  }
+.itemSkinNew .notCollected {
+  filter: grayscale(1) opacity(0.2);
+  transition: filter .25s ease
+}
 
-  .notCollected:hover {
-    filter: grayscale(0) opacity(1);
-  }
+.itemSkinNew .notCollected:hover {
+  filter: grayscale(0) opacity(1);
+}
+
+.itemSkinClassic .notCollected {
+  border: 1px dashed grey;
+}
+
+.itemSkinClassic .notCollected img {
+  display: none;
+}
+
+body.dark.itemSkinClassic .notCollected {
+  border: 1px dashed rgba(255, 255, 255, .25);
+}
+
+body.dark.itemSkinClassic a.thumbnail.notCollected:hover,
+body.dark.itemSkinClassic a.thumbnail.notCollected:focus,
+body.dark.itemSkinClassic a.thumbnail.active {
+  border: 1px dashed rgba(255, 255, 255, .75);
+}
   
   body.dark .signin-label,
   body.dark .signin-name {

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -102,6 +102,9 @@ body {
   .dropdown-menu > li:hover > .dropdown-submenu {
     display: block;
   }
+  .dropdown-menu>li>* {
+    padding: 3px 20px
+  }
   .caret-right {
     display: inline-block;
     width: 0;
@@ -152,12 +155,10 @@ body {
   }
   .signin-label {
 	  color: #767676;
-	  padding: 3px 20px;
   }
   .signin-name {
 	  color: #767676;
 	  font-weight: 600;
-	  padding: 3px 20px;
     white-space: nowrap;
     text-transform: capitalize;
   }

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -42,13 +42,6 @@ body {
     font-size: 6px;
     text-align: center;
   }
-  .borderOn {
-	border: 1px dashed grey;
-  float: left;
-  }
-  .borderOff {
-	border: 0px;
-  }
   .progressRight {
 	float:right;
 	margin-top:10px;
@@ -175,6 +168,7 @@ body {
 	  float:left;
 	  margin-bottom:5px;
 	  margin-top:0px;
+    border:0px;
   }
   .pbThumbnail {
 	margin-bottom:0px;
@@ -473,14 +467,13 @@ body {
 	  background-color: rgba(255, 255, 255, .25);
   }
   
-  body.dark .borderOn {
-	  border: 1px dashed rgba(255, 255, 255, .25);
+  .notCollected {
+    filter: grayscale(1) opacity(0.2);
+    transition: filter .25s ease
   }
-  
-  body.dark a.thumbnail.borderOn:hover,
-  body.dark a.thumbnail.borderOn:focus,
-  body.dark a.thumbnail.active {
-	  border: 1px dashed rgba(255, 255, 255, .75);
+
+  .notCollected:hover {
+    filter: grayscale(0) opacity(1);
   }
   
   body.dark .signin-label,


### PR DESCRIPTION
Implementation of the suggestion to show greyed out icon for mounts/pets/items etc, that are not obtained yet #535

Unfortunately, there was no feedback on the idea and my design in the original ticket.

To tidy things up a bit and learn something about Svelte, I moved the code for displaying categories and items to a separate component. This was almost one-to-one the same block. Battle Pets is an exception because of the extras (breed and quality info)

Personally, I find the greyed-out icons much more attractive than the empty boxes that are currently displayed.
