### PR TITLE
Mounts: removed allowed classes and changed races to faction side only to match in game counts

### DIFF
--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -8882,59 +8882,34 @@
         "items": [
           {
             "ID": 41,
-            "allowableClasses": [
-              2
-            ],
-            "allowableRaces": [
-              1,
-              3
-            ],
+            "side": "A",
             "icon": "Spell_Nature_Swiftness",
             "name": "Warhorse",
             "spellid": 13819
           },
           {
             "ID": 84,
-            "allowableClasses": [
-              2
-            ],
-            "allowableRaces": [
-              1,
-              3
-            ],
+            "side": "A",
             "icon": "Ability_Mount_Charger",
             "name": "Charger",
             "spellid": 23214
           },
           {
             "ID": 150,
-            "allowableClasses": [
-              2
-            ],
-            "allowableRaces": [
-              10
-            ],
+            "side": "H",
             "icon": "Spell_Nature_Swiftness",
             "name": "Thalassian Warhorse",
             "spellid": 34769
           },
           {
             "ID": 149,
-            "allowableClasses": [
-              2
-            ],
-            "allowableRaces": [
-              10
-            ],
+            "side": "H",
             "icon": "Ability_Mount_Charger",
             "name": "Thalassian Charger",
             "spellid": 34767
           },
           {
             "ID": 338,
-            "allowableClasses": [
-              2
-            ],
             "icon": "Ability_Mount_Charger",
             "itemId": 47179,
             "name": "Argent Charger",
@@ -8942,96 +8917,56 @@
           },
           {
             "ID": 350,
-            "allowableClasses": [
-              2
-            ],
-            "allowableRaces": [
-              6
-            ],
+            "side": "H",
             "icon": "Ability_Mount_Kodo_03",
             "name": "Sunwalker Kodo",
             "spellid": 69820
           },
           {
             "ID": 351,
-            "allowableClasses": [
-              2
-            ],
-            "allowableRaces": [
-              6
-            ],
+            "side": "H",
             "icon": "ability_mount_kodosunwalkerelite",
             "name": "Great Sunwalker Kodo",
             "spellid": 69826
           },
           {
             "ID": 367,
-            "allowableClasses": [
-              2
-            ],
-            "allowableRaces": [
-              11
-            ],
             "icon": "Spell_Nature_Swiftness",
             "name": "Exarch's Elekk",
+            "side": "A",
             "spellid": 73629
           },
           {
             "ID": 368,
-            "allowableClasses": [
-              2
-            ],
-            "allowableRaces": [
-              11
-            ],
+            "side": "A",
             "icon": "Ability_Mount_Charger",
             "name": "Great Exarch's Elekk",
             "spellid": 73630
           },
           {
             "ID": 1225,
-            "allowableClasses": [
-              2
-            ],
-            "allowableRaces": [
-              31
-            ],
+            "side": "H",
             "icon": "inv_zandalaripaladinmount",
             "name": "Crusader's Direhorn",
             "spellid": 290608
           },
           {
             "ID": 1046,
-            "allowableClasses": [
-              2
-            ],
-            "allowableRaces": [
-              34
-            ],
+            "side": "A",
             "icon": "inv_dwarfpaladinram_red",
             "name": "Darkforge Ram",
             "spellid": 270562
           },
           {
             "ID": 1047,
-            "allowableClasses": [
-              2
-            ],
-            "allowableRaces": [
-              34
-            ],
+            "side": "A",
             "icon": "inv_dwarfpaladinram_gold",
             "name": "Dawnforge Ram",
             "spellid": 270564
           },
           {
             "ID": 1568,
-            "allowableClasses": [
-              2
-            ],
-            "allowableRaces": [
-              30
-            ],
+            "side": "A",
             "icon": "inv_lightforgedtalbuk",
             "name": "Lightforged Ruinstrider",
             "spellid": 363613
@@ -9042,11 +8977,8 @@
       {
         "id": "1fadff8c",
         "items": [
-          {
+          { 
             "ID": 780,
-            "allowableClasses": [
-              12
-            ],
             "icon": "inv_dhmount_felsaber",
             "name": "Felsaber",
             "spellid": 200175
@@ -9059,18 +8991,12 @@
         "items": [
           {
             "ID": 17,
-            "allowableClasses": [
-              9
-            ],
             "icon": "Spell_Nature_Swiftness",
             "name": "Felsteed",
             "spellid": 5784
           },
           {
             "ID": 83,
-            "allowableClasses": [
-              9
-            ],
             "icon": "Ability_Mount_Dreadsteed",
             "name": "Dreadsteed",
             "spellid": 23161
@@ -9083,18 +9009,12 @@
         "items": [
           {
             "ID": 221,
-            "allowableClasses": [
-              6
-            ],
             "icon": "Spell_DeathKnight_SummonDeathCharger",
             "name": "Acherus Deathcharger",
             "spellid": 48778
           },
           {
             "ID": 236,
-            "allowableClasses": [
-              6
-            ],
             "icon": "ability_mount_ebonblade",
             "itemId": 40775,
             "name": "Winged Steed of the Ebon Blade",


### PR DESCRIPTION
I had a long flight, and spent a large portion of it trying to track down the difference I was seeing between in-game achievement score, and what simple armory was reporting as your score.  This is kind of a stylistic decision, but a lot of what the site was doing was to try and keep in line with that in game score. By score I mean the one that gets tracked for the mount achievements, not the raw mount count the mount viewwer shows.  I ended up writing a addon for the game that would allow me to debug more what was happening, and what was being reported in game and do a comparison.  When it was all said and done, what I found was that the game counts any mount that is learned, and on the same faction as you.  Before this change, I had a few restrictions around class and race.  I removed those class restrictions and changed the race ones to purely faction based.  

Side Note: to get some of these you'll need to create a difference class or character, but if it's in the same faction it will get stamped on your account as learned.  Then when you log back into your main account, your number should increase.  I did testing of this in game with real counts and real characters to prove out the behavior.
 
This should solve issues: #546, #144.  However, from my testing #231 is still kind of an edge case in that it can be learned on your account, but it won't show as learned until that specific character has finished the quest.  This is the one case I know of where the number could be out of sync with the one in the game.  To fix you have to complete the quest on the character.  

An alternative to this would be to show all mounts, or maybe make that an option.  