### PR TITLE
Updated raid achievement order

### DIFF
--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -11190,54 +11190,6 @@
                   "title": "Mythic: Vault of the Incarnates"
                 },
                 {
-                  "icon": "achievement_raidprimalist_eranog",
-                  "id": 16346,
-                  "points": 10,
-                  "title": "Mythic: Eranog"
-                },
-                {
-                  "icon": "achievement_raidprimalist_terros",
-                  "id": 16347,
-                  "points": 10,
-                  "title": "Mythic: Terros"
-                },
-                {
-                  "icon": "achievement_raidprimalist_council",
-                  "id": 16348,
-                  "points": 10,
-                  "title": "Mythic: The Primal Council"
-                },
-                {
-                  "icon": "achievement_raidprimalist_sennarth",
-                  "id": 16349,
-                  "points": 10,
-                  "title": "Mythic: Sennarth, The Cold Breath"
-                },
-                {
-                  "icon": "achievement_raidprimalist_windelemental",
-                  "id": 16350,
-                  "points": 10,
-                  "title": "Mythic: Dathea, Ascended"
-                },
-                {
-                  "icon": "achievement_raidprimalist_kurog",
-                  "id": 16351,
-                  "points": 10,
-                  "title": "Mythic: Kurog Grimtotem"
-                },
-                {
-                  "icon": "achievement_raidprimalist_diurna",
-                  "id": 16352,
-                  "points": 10,
-                  "title": "Mythic: Broodkeeper Diurna"
-                },
-                {
-                  "icon": "achievement_raidprimalist_raszageth",
-                  "id": 16353,
-                  "points": 10,
-                  "title": "Mythic: Raszageth the Storm-Eater"
-                },
-                {
                   "icon": "inv_iceelementalprimal_purple",
                   "id": 16335,
                   "points": 10,
@@ -11284,6 +11236,54 @@
                   "id": 16451,
                   "points": 10,
                   "title": "The Ol Raszle Daszle"
+                },
+                {
+                  "icon": "achievement_raidprimalist_eranog",
+                  "id": 16346,
+                  "points": 10,
+                  "title": "Mythic: Eranog"
+                },
+                {
+                  "icon": "achievement_raidprimalist_terros",
+                  "id": 16347,
+                  "points": 10,
+                  "title": "Mythic: Terros"
+                },
+                {
+                  "icon": "achievement_raidprimalist_council",
+                  "id": 16348,
+                  "points": 10,
+                  "title": "Mythic: The Primal Council"
+                },
+                {
+                  "icon": "achievement_raidprimalist_sennarth",
+                  "id": 16349,
+                  "points": 10,
+                  "title": "Mythic: Sennarth, The Cold Breath"
+                },
+                {
+                  "icon": "achievement_raidprimalist_windelemental",
+                  "id": 16350,
+                  "points": 10,
+                  "title": "Mythic: Dathea, Ascended"
+                },
+                {
+                  "icon": "achievement_raidprimalist_kurog",
+                  "id": 16351,
+                  "points": 10,
+                  "title": "Mythic: Kurog Grimtotem"
+                },
+                {
+                  "icon": "achievement_raidprimalist_diurna",
+                  "id": 16352,
+                  "points": 10,
+                  "title": "Mythic: Broodkeeper Diurna"
+                },
+                {
+                  "icon": "achievement_raidprimalist_raszageth",
+                  "id": 16353,
+                  "points": 10,
+                  "title": "Mythic: Raszageth the Storm-Eater"
                 }
               ],
               "name": "Vault of the Incarnates"
@@ -11332,6 +11332,60 @@
                   "id": 18162,
                   "points": 10,
                   "title": "Mythic: Aberrus, the Shadowed Crucible"
+                },
+                {
+                  "icon": "achievment_boss_spineofdeathwing",
+                  "id": 18229,
+                  "points": 10,
+                  "title": "Cosplate"
+                },
+                {
+                  "icon": "inv_babyfireelemental_shadowflame",
+                  "id": 18168,
+                  "points": 10,
+                  "title": "I'll Make My Own Shadowflame"
+                },
+                {
+                  "icon": "inv_dracthyrhead08",
+                  "id": 18173,
+                  "points": 10,
+                  "title": "Tabula Rasa"
+                },
+                {
+                  "icon": "shaman_pvp_rockshield",
+                  "id": 18228,
+                  "points": 10,
+                  "title": "Are You Even Trying?"
+                },
+                {
+                  "icon": "inv_babyhornswog_red",
+                  "id": 18230,
+                  "points": 10,
+                  "title": "Whac-A-Swog"
+                },
+                {
+                  "icon": "inv_item_dragonegg_black01",
+                  "id": 18193,
+                  "points": 10,
+                  "title": "Eggscellent Eggsecution"
+                },
+                {
+                  "icon": "inv_snailmount_orange",
+                  "id": 18172,
+                  "points": 10,
+                  "title": "Escar-Go-Go-Go"
+                },
+                {
+                  "icon": "inv_eng_crate",
+                  "id": 18149,
+                  "points": 10,
+                  "title": "Objects in Transit May Shatter"
+                },
+                {
+                  "icon": "artifactability_blooddeathknight_umbilicuseternus",
+                  "id": 17877,
+                  "points": 10,
+                  "title": "We'll Never See That Again, Surely"
                 },
                 {
                   "icon": "inv_achievement_raiddragon_kazzara",
@@ -11386,60 +11440,6 @@
                   "id": 18159,
                   "points": 10,
                   "title": "Mythic: Scalecommander Sarkareth"
-                },
-                {
-                  "icon": "inv_eng_crate",
-                  "id": 18149,
-                  "points": 10,
-                  "title": "Objects in Transit May Shatter"
-                },
-                {
-                  "icon": "inv_babyfireelemental_shadowflame",
-                  "id": 18168,
-                  "points": 10,
-                  "title": "I'll Make My Own Shadowflame"
-                },
-                {
-                  "icon": "inv_snailmount_orange",
-                  "id": 18172,
-                  "points": 10,
-                  "title": "Escar-Go-Go-Go"
-                },
-                {
-                  "icon": "inv_dracthyrhead08",
-                  "id": 18173,
-                  "points": 10,
-                  "title": "Tabula Rasa"
-                },
-                {
-                  "icon": "inv_item_dragonegg_black01",
-                  "id": 18193,
-                  "points": 10,
-                  "title": "Eggscellent Eggsecution"
-                },
-                {
-                  "icon": "shaman_pvp_rockshield",
-                  "id": 18228,
-                  "points": 10,
-                  "title": "Are You Even Trying?"
-                },
-                {
-                  "icon": "achievment_boss_spineofdeathwing",
-                  "id": 18229,
-                  "points": 10,
-                  "title": "Cosplate"
-                },
-                {
-                  "icon": "inv_babyhornswog_red",
-                  "id": 18230,
-                  "points": 10,
-                  "title": "Whac-A-Swog"
-                },
-                {
-                  "icon": "artifactability_blooddeathknight_umbilicuseternus",
-                  "id": 17877,
-                  "points": 10,
-                  "title": "We'll Never See That Again, Surely"
                 }
               ],
               "name": "Aberrus"
@@ -11488,60 +11488,6 @@
                   "id": 19334,
                   "points": 10,
                   "title": "Mythic: Amirdrassil, the Dream's Hope"
-                },
-                {
-                  "icon": "inv_achievement_raidemeralddream_fieryancient",
-                  "id": 19335,
-                  "points": 10,
-                  "title": "Mythic: Gnarlroot"
-                },
-                {
-                  "icon": "inv_achievement_raidemeralddream_igira-the-cruel",
-                  "id": 19336,
-                  "points": 10,
-                  "title": "Mythic: Igira the Cruel"
-                },
-                {
-                  "icon": "inv_achievement_raidemeralddream_lavaserpent",
-                  "id": 19337,
-                  "points": 10,
-                  "title": "Mythic: Volcoross"
-                },
-                {
-                  "icon": "inv_achievement_raidemeralddream_dreamcouncil",
-                  "id": 19338,
-                  "points": 10,
-                  "title": "Mythic: Council of Dreams"
-                },
-                {
-                  "icon": "inv_achievement_raidemeralddream_keeperoftheflames",
-                  "id": 19339,
-                  "points": 10,
-                  "title": "Mythic: Larodar, Keeper of the Flame"
-                },
-                {
-                  "icon": "inv_achievement_raidemeralddream_dreamweaver",
-                  "id": 19340,
-                  "points": 10,
-                  "title": "Mythic: Nymue, Weaver of the Cycle"
-                },
-                {
-                  "icon": "inv_achievement_raidemeralddream_smolderon",
-                  "id": 19341,
-                  "points": 10,
-                  "title": "Mythic: Smolderon"
-                },
-                {
-                  "icon": "inv_achievement_raidemeralddream_druidoftheflame",
-                  "id": 19342,
-                  "points": 10,
-                  "title": "Mythic: Tindral Sageswift, Seer of the Flame"
-                },
-                {
-                  "icon": "inv_achievement_raidemeralddream_fyrakk",
-                  "id": 19343,
-                  "points": 10,
-                  "title": "Mythic: Fyrakk the Blazing"
                 },
                 {
                   "icon": "inv_summerfest_fireflower",
@@ -11596,6 +11542,60 @@
                   "id": 19390,
                   "points": 10,
                   "title": "Memories of Teldrassil"
+                },
+                {
+                  "icon": "inv_achievement_raidemeralddream_fieryancient",
+                  "id": 19335,
+                  "points": 10,
+                  "title": "Mythic: Gnarlroot"
+                },
+                {
+                  "icon": "inv_achievement_raidemeralddream_igira-the-cruel",
+                  "id": 19336,
+                  "points": 10,
+                  "title": "Mythic: Igira the Cruel"
+                },
+                {
+                  "icon": "inv_achievement_raidemeralddream_lavaserpent",
+                  "id": 19337,
+                  "points": 10,
+                  "title": "Mythic: Volcoross"
+                },
+                {
+                  "icon": "inv_achievement_raidemeralddream_dreamcouncil",
+                  "id": 19338,
+                  "points": 10,
+                  "title": "Mythic: Council of Dreams"
+                },
+                {
+                  "icon": "inv_achievement_raidemeralddream_keeperoftheflames",
+                  "id": 19339,
+                  "points": 10,
+                  "title": "Mythic: Larodar, Keeper of the Flame"
+                },
+                {
+                  "icon": "inv_achievement_raidemeralddream_dreamweaver",
+                  "id": 19340,
+                  "points": 10,
+                  "title": "Mythic: Nymue, Weaver of the Cycle"
+                },
+                {
+                  "icon": "inv_achievement_raidemeralddream_smolderon",
+                  "id": 19341,
+                  "points": 10,
+                  "title": "Mythic: Smolderon"
+                },
+                {
+                  "icon": "inv_achievement_raidemeralddream_druidoftheflame",
+                  "id": 19342,
+                  "points": 10,
+                  "title": "Mythic: Tindral Sageswift, Seer of the Flame"
+                },
+                {
+                  "icon": "inv_achievement_raidemeralddream_fyrakk",
+                  "id": 19343,
+                  "points": 10,
+                  "title": "Mythic: Fyrakk the Blazing"
                 }
               ],
               "name": "Amirdrassil, the Dream's Hope"
@@ -12048,6 +12048,66 @@
                   "title": "Mythic: Castle Nathria"
                 },
                 {
+                  "icon": "spell_shadow_auraofdarkness",
+                  "id": 14293,
+                  "points": 10,
+                  "title": "Blind as a Bat"
+                },
+                {
+                  "icon": "achievement_raid_revendrethraid_huntsmangargon",
+                  "id": 14523,
+                  "points": 10,
+                  "title": "Taking Care of Business"
+                },
+                {
+                  "icon": "ability_racial_cannibalize",
+                  "id": 14376,
+                  "points": 10,
+                  "title": "Feed the Beast"
+                },
+                {
+                  "icon": "spell_animabastion_nova",
+                  "id": 14617,
+                  "points": 10,
+                  "title": "Private Stock"
+                },
+                {
+                  "icon": "inv_enchanting_70_pet_torch",
+                  "id": 14608,
+                  "points": 10,
+                  "title": "Burning Bright"
+                },
+                {
+                  "icon": "achievement_boss_darkanimus",
+                  "id": 14524,
+                  "points": 10,
+                  "title": "I Don't Know What I Expected"
+                },
+                {
+                  "icon": "inv_drink_33_bloodredale",
+                  "id": 14619,
+                  "points": 10,
+                  "title": "Pour Decision Making"
+                },
+                {
+                  "icon": "ability_warlock_empoweredimp",
+                  "id": 14294,
+                  "points": 10,
+                  "title": "Dirtflap's Revenge"
+                },
+                {
+                  "icon": "inv_rosebouquet01",
+                  "id": 14525,
+                  "points": 10,
+                  "title": "Feed Me, Seymour!"
+                },
+                {
+                  "icon": "spell_priest_pontifex",
+                  "id": 14610,
+                  "points": 10,
+                  "title": "Clear Conscience"
+                },
+                {
                   "icon": "achievement_raid_revendrethraid_shriekwing",
                   "id": 14356,
                   "points": 10,
@@ -12106,66 +12166,6 @@
                   "id": 14365,
                   "points": 10,
                   "title": "Mythic: Sire Denathrius"
-                },
-                {
-                  "icon": "spell_shadow_auraofdarkness",
-                  "id": 14293,
-                  "points": 10,
-                  "title": "Blind as a Bat"
-                },
-                {
-                  "icon": "ability_warlock_empoweredimp",
-                  "id": 14294,
-                  "points": 10,
-                  "title": "Dirtflap's Revenge"
-                },
-                {
-                  "icon": "ability_racial_cannibalize",
-                  "id": 14376,
-                  "points": 10,
-                  "title": "Feed the Beast"
-                },
-                {
-                  "icon": "achievement_raid_revendrethraid_huntsmangargon",
-                  "id": 14523,
-                  "points": 10,
-                  "title": "Taking Care of Business"
-                },
-                {
-                  "icon": "achievement_boss_darkanimus",
-                  "id": 14524,
-                  "points": 10,
-                  "title": "I Don't Know What I Expected"
-                },
-                {
-                  "icon": "inv_rosebouquet01",
-                  "id": 14525,
-                  "points": 10,
-                  "title": "Feed Me, Seymour!"
-                },
-                {
-                  "icon": "inv_enchanting_70_pet_torch",
-                  "id": 14608,
-                  "points": 10,
-                  "title": "Burning Bright"
-                },
-                {
-                  "icon": "spell_priest_pontifex",
-                  "id": 14610,
-                  "points": 10,
-                  "title": "Clear Conscience"
-                },
-                {
-                  "icon": "spell_animabastion_nova",
-                  "id": 14617,
-                  "points": 10,
-                  "title": "Private Stock"
-                },
-                {
-                  "icon": "inv_drink_33_bloodredale",
-                  "id": 14619,
-                  "points": 10,
-                  "title": "Pour Decision Making"
                 }
               ],
               "name": "Castle Nathria"
@@ -12214,66 +12214,6 @@
                   "id": 15128,
                   "points": 10,
                   "title": "Mythic: Sanctum of Domination"
-                },
-                {
-                  "icon": "achievement_raid_torghast_tarragrue",
-                  "id": 15112,
-                  "points": 10,
-                  "title": "Mythic: The Tarragrue"
-                },
-                {
-                  "icon": "achievement_raid_torghast_theeyeofthejailer",
-                  "id": 15113,
-                  "points": 10,
-                  "title": "Mythic: The Eye of the Jailer"
-                },
-                {
-                  "icon": "achievement_raid_torghast_thenine",
-                  "id": 15114,
-                  "points": 10,
-                  "title": "Mythic: The Nine"
-                },
-                {
-                  "icon": "achievement_raid_torghast_shadowscourge_prisonofnerzhul",
-                  "id": 15115,
-                  "points": 10,
-                  "title": "Mythic: Remnant of Ner'zhul"
-                },
-                {
-                  "icon": "achievement_raid_torghast_soulrenderdormazain",
-                  "id": 15116,
-                  "points": 10,
-                  "title": "Mythic: Soulrender Dormazain"
-                },
-                {
-                  "icon": "achievement_raid_torghast_painsmithraznal",
-                  "id": 15117,
-                  "points": 10,
-                  "title": "Mythic: Painsmith Raznal"
-                },
-                {
-                  "icon": "achievement_raid_torghast_guardianofthefirstones",
-                  "id": 15118,
-                  "points": 10,
-                  "title": "Mythic: Guardian of the First Ones"
-                },
-                {
-                  "icon": "achievement_raid_torghast_fatescriberoh-talo",
-                  "id": 15119,
-                  "points": 10,
-                  "title": "Mythic: Fatescribe Roh-Kalo"
-                },
-                {
-                  "icon": "achievement_raid_torghast_kel-thuzad",
-                  "id": 15120,
-                  "points": 10,
-                  "title": "Mythic: Kel'Thuzad"
-                },
-                {
-                  "icon": "achievement_raid_torghast_sylvanaswindrunner",
-                  "id": 15121,
-                  "points": 10,
-                  "title": "Mythic: Sylvanas Windrunner"
                 },
                 {
                   "icon": "inv_valentinescandy",
@@ -12334,6 +12274,66 @@
                   "id": 15133,
                   "points": 10,
                   "title": "This World is a Prism"
+                },
+                {
+                  "icon": "achievement_raid_torghast_tarragrue",
+                  "id": 15112,
+                  "points": 10,
+                  "title": "Mythic: The Tarragrue"
+                },
+                {
+                  "icon": "achievement_raid_torghast_theeyeofthejailer",
+                  "id": 15113,
+                  "points": 10,
+                  "title": "Mythic: The Eye of the Jailer"
+                },
+                {
+                  "icon": "achievement_raid_torghast_thenine",
+                  "id": 15114,
+                  "points": 10,
+                  "title": "Mythic: The Nine"
+                },
+                {
+                  "icon": "achievement_raid_torghast_shadowscourge_prisonofnerzhul",
+                  "id": 15115,
+                  "points": 10,
+                  "title": "Mythic: Remnant of Ner'zhul"
+                },
+                {
+                  "icon": "achievement_raid_torghast_soulrenderdormazain",
+                  "id": 15116,
+                  "points": 10,
+                  "title": "Mythic: Soulrender Dormazain"
+                },
+                {
+                  "icon": "achievement_raid_torghast_painsmithraznal",
+                  "id": 15117,
+                  "points": 10,
+                  "title": "Mythic: Painsmith Raznal"
+                },
+                {
+                  "icon": "achievement_raid_torghast_guardianofthefirstones",
+                  "id": 15118,
+                  "points": 10,
+                  "title": "Mythic: Guardian of the First Ones"
+                },
+                {
+                  "icon": "achievement_raid_torghast_fatescriberoh-talo",
+                  "id": 15119,
+                  "points": 10,
+                  "title": "Mythic: Fatescribe Roh-Kalo"
+                },
+                {
+                  "icon": "achievement_raid_torghast_kel-thuzad",
+                  "id": 15120,
+                  "points": 10,
+                  "title": "Mythic: Kel'Thuzad"
+                },
+                {
+                  "icon": "achievement_raid_torghast_sylvanaswindrunner",
+                  "id": 15121,
+                  "points": 10,
+                  "title": "Mythic: Sylvanas Windrunner"
                 }
               ],
               "name": "Sanctum of Domination"
@@ -12341,24 +12341,6 @@
             {
               "id": "46ceaa8d",
               "items": [
-                {
-                  "icon": "inv_achievement_raid_progenitorraid",
-                  "id": 15417,
-                  "points": 10,
-                  "title": "Sepulcher of the First Ones"
-                },
-                {
-                  "icon": "inv_achievement_raid_progenitorraid",
-                  "id": 15478,
-                  "points": 10,
-                  "title": "Heroic: Sepulcher of the First Ones"
-                },
-                {
-                  "icon": "inv_achievement_raid_progenitorraid",
-                  "id": 15490,
-                  "points": 10,
-                  "title": "Mythic: Sepulcher of the First Ones"
-                },
                 {
                   "icon": "inv_achievement_raid_progenitorraid_progenium_keeper",
                   "id": 15493,
@@ -12382,6 +12364,104 @@
                   "id": 15418,
                   "points": 10,
                   "title": "The Grand Design"
+                },
+                {
+                  "icon": "inv_achievement_raid_progenitorraid",
+                  "id": 15417,
+                  "points": 10,
+                  "title": "Sepulcher of the First Ones"
+                },
+                {
+                  "icon": "inv_achievement_raid_progenitorraid",
+                  "id": 15478,
+                  "points": 10,
+                  "title": "Heroic: Sepulcher of the First Ones"
+                },
+                {
+                  "icon": "inv_achievement_raid_progenitorraid",
+                  "id": 15490,
+                  "points": 10,
+                  "title": "Mythic: Sepulcher of the First Ones"
+                },
+                {
+                  "icon": "ability_siege_engineer_automatic_repair_beam",
+                  "id": 15381,
+                  "points": 10,
+                  "title": "Power ON"
+                },
+                {
+                  "icon": "inv_inscription_contract_enlightenedbroker01",
+                  "id": 15401,
+                  "points": 10,
+                  "title": "Wisdom Comes From the Desert"
+                },
+                {
+                  "icon": "inv_achievement_raid_progenitorraid_broker_incursion",
+                  "id": 15398,
+                  "points": 10,
+                  "title": "Xy Never, Ever Marks the Spot."
+                },
+                {
+                  "icon": "inv_progenitor_protoformsynthesis",
+                  "id": 15397,
+                  "points": 10,
+                  "title": "Four Ring Circus"
+                },
+                {
+                  "icon": "icon_upgradestone_beast_rare",
+                  "id": 15400,
+                  "points": 10,
+                  "title": "Where the Wild Corgis Are"
+                },
+                {
+                  "icon": "inv_lightforgedmatrixability_lightsjudgment",
+                  "id": 15419,
+                  "points": 10,
+                  "title": "The Protoform Matrix"
+                },
+                {
+                  "icon": "inv_trinket_progenitorraid_01_yellow",
+                  "id": 15386,
+                  "points": 10,
+                  "title": "Shimmering Secrets"
+                },
+                {
+                  "icon": "inv_misc_varianslapel-clasp",
+                  "id": 15399,
+                  "points": 10,
+                  "title": "Coming to Terms"
+                },              
+                {
+                  "icon": "ability_paladin_handoflight",
+                  "id": 15315,
+                  "points": 10,
+                  "title": "Amidst Ourselves"
+                },
+                {
+                  "icon": "achievement_boss_algalon_01",
+                  "id": 15396,
+                  "points": 10,
+                  "title": "We Are All Made of Stars"
+                },
+                {
+                  "icon": "achievement_boss_algalon_01",
+                  "id": 15468,
+                  "notObtainable": true,
+                  "points": 0,
+                  "title": "We Are All Made of Stars (Heroic)"
+                },
+                {
+                  "icon": "achievement_boss_algalon_01",
+                  "id": 15469,
+                  "notObtainable": true,
+                  "points": 0,
+                  "title": "We Are All Made of Stars (Mythic)"
+                },
+                {
+                  "icon": "spell_progenitor_orb2",
+                  "id": 15494,
+                  "points": 10,
+                  "title": "Damnation Aviation"
                 },
                 {
                   "icon": "inv_achievement_raid_progenitorraid_progenitor_defensewall_boss",
@@ -12448,86 +12528,6 @@
                   "id": 15489,
                   "points": 10,
                   "title": "Mythic: The Jailer"
-                },
-                {
-                  "icon": "ability_paladin_handoflight",
-                  "id": 15315,
-                  "points": 10,
-                  "title": "Amidst Ourselves"
-                },
-                {
-                  "icon": "ability_siege_engineer_automatic_repair_beam",
-                  "id": 15381,
-                  "points": 10,
-                  "title": "Power ON"
-                },
-                {
-                  "icon": "inv_trinket_progenitorraid_01_yellow",
-                  "id": 15386,
-                  "points": 10,
-                  "title": "Shimmering Secrets"
-                },
-                {
-                  "icon": "achievement_boss_algalon_01",
-                  "id": 15396,
-                  "points": 10,
-                  "title": "We Are All Made of Stars"
-                },
-                {
-                  "icon": "achievement_boss_algalon_01",
-                  "id": 15468,
-                  "notObtainable": true,
-                  "points": 0,
-                  "title": "We Are All Made of Stars (Heroic)"
-                },
-                {
-                  "icon": "achievement_boss_algalon_01",
-                  "id": 15469,
-                  "notObtainable": true,
-                  "points": 0,
-                  "title": "We Are All Made of Stars (Mythic)"
-                },
-                {
-                  "icon": "inv_progenitor_protoformsynthesis",
-                  "id": 15397,
-                  "points": 10,
-                  "title": "Four Ring Circus"
-                },
-                {
-                  "icon": "inv_achievement_raid_progenitorraid_broker_incursion",
-                  "id": 15398,
-                  "points": 10,
-                  "title": "Xy Never, Ever Marks the Spot."
-                },
-                {
-                  "icon": "inv_misc_varianslapel-clasp",
-                  "id": 15399,
-                  "points": 10,
-                  "title": "Coming to Terms"
-                },
-                {
-                  "icon": "icon_upgradestone_beast_rare",
-                  "id": 15400,
-                  "points": 10,
-                  "title": "Where the Wild Corgis Are"
-                },
-                {
-                  "icon": "inv_inscription_contract_enlightenedbroker01",
-                  "id": 15401,
-                  "points": 10,
-                  "title": "Wisdom Comes From the Desert"
-                },
-                {
-                  "icon": "inv_lightforgedmatrixability_lightsjudgment",
-                  "id": 15419,
-                  "points": 10,
-                  "title": "The Protoform Matrix"
-                },
-                {
-                  "icon": "spell_progenitor_orb2",
-                  "id": 15494,
-                  "points": 10,
-                  "title": "Damnation Aviation"
                 }
               ],
               "name": "Sepulcher of the First Ones"
@@ -12967,54 +12967,6 @@
                   "title": "Heart of Corruption"
                 },
                 {
-                  "icon": "achievement_nazmir_boss_talocthecorrupted",
-                  "id": 12524,
-                  "points": 10,
-                  "title": "Mythic: Taloc"
-                },
-                {
-                  "icon": "achievement_nazmir_boss_mother",
-                  "id": 12526,
-                  "points": 10,
-                  "title": "Mythic: MOTHER"
-                },
-                {
-                  "icon": "achievement_nazmir_boss_zekvoz",
-                  "id": 12527,
-                  "points": 10,
-                  "title": "Mythic: Zek'voz"
-                },
-                {
-                  "icon": "achievement_nazmir_boss_bloodofghuun",
-                  "id": 12529,
-                  "points": 10,
-                  "title": "Mythic: Vectis"
-                },
-                {
-                  "icon": "achievement_nazmir_boss_fetiddevourer",
-                  "id": 12530,
-                  "points": 10,
-                  "title": "Mythic: Fetid Devourer"
-                },
-                {
-                  "icon": "achievement_nazmir_boss_zul",
-                  "id": 12531,
-                  "points": 10,
-                  "title": "Mythic: Zul"
-                },
-                {
-                  "icon": "achievement_nazmir_boss_mythraxtheunraveler",
-                  "id": 12532,
-                  "points": 10,
-                  "title": "Mythic: Mythrax the Unraveler"
-                },
-                {
-                  "icon": "achievement_nazmir_boss_ghuun",
-                  "id": 12533,
-                  "points": 10,
-                  "title": "Mythic: G'huun"
-                },
-                {
                   "icon": "inv_gizmo_goblinboombox_01",
                   "id": 12937,
                   "points": 10,
@@ -13061,6 +13013,54 @@
                   "id": 12551,
                   "points": 10,
                   "title": "Double Dribble"
+                },
+                {
+                  "icon": "achievement_nazmir_boss_talocthecorrupted",
+                  "id": 12524,
+                  "points": 10,
+                  "title": "Mythic: Taloc"
+                },
+                {
+                  "icon": "achievement_nazmir_boss_mother",
+                  "id": 12526,
+                  "points": 10,
+                  "title": "Mythic: MOTHER"
+                },
+                {
+                  "icon": "achievement_nazmir_boss_zekvoz",
+                  "id": 12527,
+                  "points": 10,
+                  "title": "Mythic: Zek'voz"
+                },
+                {
+                  "icon": "achievement_nazmir_boss_bloodofghuun",
+                  "id": 12529,
+                  "points": 10,
+                  "title": "Mythic: Vectis"
+                },
+                {
+                  "icon": "achievement_nazmir_boss_fetiddevourer",
+                  "id": 12530,
+                  "points": 10,
+                  "title": "Mythic: Fetid Devourer"
+                },
+                {
+                  "icon": "achievement_nazmir_boss_zul",
+                  "id": 12531,
+                  "points": 10,
+                  "title": "Mythic: Zul"
+                },
+                {
+                  "icon": "achievement_nazmir_boss_mythraxtheunraveler",
+                  "id": 12532,
+                  "points": 10,
+                  "title": "Mythic: Mythrax the Unraveler"
+                },
+                {
+                  "icon": "achievement_nazmir_boss_ghuun",
+                  "id": 12533,
+                  "points": 10,
+                  "title": "Mythic: G'huun"
                 }
               ],
               "name": "Uldir"
@@ -13117,10 +13117,16 @@
                   "title": "Can I Get a Hek Hek Hek Yeah?"
                 },
                 {
-                  "icon": "ability_hunter_pet_raptor",
-                  "id": 13325,
+                  "icon": "inv_pet_monkey",
+                  "id": 13383,
                   "points": 10,
-                  "title": "Walk the Dinosaur"
+                  "title": "Barrel of Monkeys"
+                },
+                {
+                  "icon": "inv_cloudserpent_egg_green",
+                  "id": 13431,
+                  "points": 10,
+                  "title": "Hidden Dragon"
                 },
                 {
                   "icon": "inv_misc_flower_01",
@@ -13129,22 +13135,10 @@
                   "title": "Praise the Sunflower"
                 },
                 {
-                  "icon": "inv_pet_monkey",
-                  "id": 13383,
+                  "icon": "ability_hunter_pet_raptor",
+                  "id": 13325,
                   "points": 10,
-                  "title": "Barrel of Monkeys"
-                },
-                {
-                  "icon": "inv_misc_blingtron",
-                  "id": 13401,
-                  "points": 10,
-                  "title": "I Got Next!"
-                },
-                {
-                  "icon": "inv_pet_snowman",
-                  "id": 13410,
-                  "points": 10,
-                  "title": "Snow Fun Allowed"
+                  "title": "Walk the Dinosaur"
                 },
                 {
                   "icon": "spell_holy_guardianspirit",
@@ -13153,16 +13147,22 @@
                   "title": "We Got Spirit, How About You?"
                 },
                 {
+                  "icon": "inv_misc_blingtron",
+                  "id": 13401,
+                  "points": 10,
+                  "title": "I Got Next!"
+                },
+                {
                   "icon": "achievement_boss_warlord_kalithresh",
                   "id": 13430,
                   "points": 10,
                   "title": "De Lurker Be'loa"
                 },
                 {
-                  "icon": "inv_cloudserpent_egg_green",
-                  "id": 13431,
+                  "icon": "inv_pet_snowman",
+                  "id": 13410,
                   "points": 10,
-                  "title": "Hidden Dragon"
+                  "title": "Snow Fun Allowed"
                 },
                 {
                   "icon": "ability_paladin_blindinglight",
@@ -13191,16 +13191,16 @@
                   "title": "Mythic: Jadefire Masters"
                 },
                 {
-                  "icon": "achievement_boss_zuldazar_loacouncil",
-                  "id": 13300,
-                  "points": 10,
-                  "title": "Mythic: Conclave of the Chosen"
-                },
-                {
                   "icon": "achievement_boss_zuldazar_treasuregolem",
                   "id": 13299,
                   "points": 10,
                   "title": "Mythic: Opulence"
+                },
+                {
+                  "icon": "achievement_boss_zuldazar_loacouncil",
+                  "id": 13300,
+                  "points": 10,
+                  "title": "Mythic: Conclave of the Chosen"
                 },
                 {
                   "icon": "achievement_boss_zuldazar_rastakhan",
@@ -13287,10 +13287,16 @@
                   "title": "The Circle of Stars"
                 },
                 {
-                  "icon": "inv_misc_herb_zoanthid",
-                  "id": 13724,
+                  "icon": "achievement_boss_warlord_kalithresh",
+                  "id": 13684,
                   "points": 10,
-                  "title": "A Smack of Jellyfish"
+                  "title": "You and What Army?"
+                },
+                {
+                  "icon": "ability_rogue_sprint_blue",
+                  "id": 13767,
+                  "points": 10,
+                  "title": "Fun Run"
                 },
                 {
                   "icon": "inv_conchshell",
@@ -13305,29 +13311,25 @@
                   "title": "Simple Geometry"
                 },
                 {
+                  "icon": "inv_misc_herb_zoanthid",
+                  "id": 13724,
+                  "points": 10,
+                  "title": "A Smack of Jellyfish"
+                },
+                {
                   "icon": "inv_helm_crown_c_01_rose",
                   "id": 13633,
                   "points": 10,
                   "title": "If It Pleases the Court"
                 },
-                {
-                  "icon": "achievement_boss_warlord_kalithresh",
-                  "id": 13684,
-                  "points": 10,
-                  "title": "You and What Army?"
-                },
+                
                 {
                   "icon": "spell_nature_polymorph_cow",
                   "id": 13716,
                   "points": 10,
                   "title": "Lactose Intolerant"
                 },
-                {
-                  "icon": "ability_rogue_sprint_blue",
-                  "id": 13767,
-                  "points": 10,
-                  "title": "Fun Run"
-                },
+                
                 {
                   "icon": "spell_azerite_essence08",
                   "id": 13768,
@@ -14528,16 +14530,16 @@
                   "title": "Remember the Titans"
                 },
                 {
-                  "icon": "inv_herbalism_70_starlightrosedust",
-                  "id": 12257,
-                  "points": 10,
-                  "title": "Stardust Crusaders"
-                },
-                {
                   "icon": "inv_sword_1h_aggramar_d_01",
                   "id": 11915,
                   "points": 10,
                   "title": "Don't Sweat the Technique"
+                },
+                {
+                  "icon": "inv_herbalism_70_starlightrosedust",
+                  "id": 12257,
+                  "points": 10,
+                  "title": "Stardust Crusaders"
                 },
                 {
                   "icon": "achievement_boss_argus_felreaver",
@@ -16978,6 +16980,12 @@
               "id": "4b044dd7",
               "items": [
                 {
+                  "icon": "spell_fire_twilightcano",
+                  "id": 4850,
+                  "points": 10,
+                  "title": "The Bastion of Twilight"
+                },
+                {
                   "icon": "INV_Misc_Crop_01",
                   "id": 5300,
                   "points": 10,
@@ -17000,12 +17008,6 @@
                   "id": 5312,
                   "points": 10,
                   "title": "The Abyss Will Gaze Back Into You"
-                },
-                {
-                  "icon": "spell_fire_twilightcano",
-                  "id": 4850,
-                  "points": 10,
-                  "title": "The Bastion of Twilight"
                 },
                 {
                   "icon": "achievement_dungeon_bastion-of-twilight_halfus-wyrmbreaker",
@@ -17044,6 +17046,12 @@
               "id": "7ce35cc5",
               "items": [
                 {
+                  "icon": "Achievement_Boss_Murmur",
+                  "id": 4851,
+                  "points": 10,
+                  "title": "Throne of the Four Winds"
+                },
+                {
                   "icon": "Spell_DeathKnight_FrostFever",
                   "id": 5304,
                   "points": 10,
@@ -17054,13 +17062,7 @@
                   "id": 5305,
                   "points": 10,
                   "title": "Four Play"
-                },
-                {
-                  "icon": "Achievement_Boss_Murmur",
-                  "id": 4851,
-                  "points": 10,
-                  "title": "Throne of the Four Winds"
-                },
+                },               
                 {
                   "icon": "Ability_Druid_GaleWinds",
                   "id": 5122,
@@ -17079,6 +17081,12 @@
             {
               "id": "2b6afab5",
               "items": [
+                {
+                  "icon": "Achievement_Boss_Nefarion",
+                  "id": 4842,
+                  "points": 10,
+                  "title": "Blackwing Descent"
+                },
                 {
                   "icon": "ability_hunter_pet_worm",
                   "id": 5306,
@@ -17114,12 +17122,6 @@
                   "id": 4849,
                   "points": 10,
                   "title": "Keeping it in the Family"
-                },
-                {
-                  "icon": "Achievement_Boss_Nefarion",
-                  "id": 4842,
-                  "points": 10,
-                  "title": "Blackwing Descent"
                 },
                 {
                   "icon": "ability_hunter_pet_worm",
@@ -17165,6 +17167,12 @@
               "items": [
                 {
                   "icon": "achievement_zone_firelands",
+                  "id": 5802,
+                  "points": 10,
+                  "title": "Firelands"
+                },
+                {
+                  "icon": "achievement_zone_firelands",
                   "id": 5829,
                   "points": 10,
                   "title": "Bucket List"
@@ -17204,12 +17212,6 @@
                   "id": 5855,
                   "points": 10,
                   "title": "Ragnar-O's"
-                },
-                {
-                  "icon": "achievement_zone_firelands",
-                  "id": 5802,
-                  "points": 10,
-                  "title": "Firelands"
                 },
                 {
                   "icon": "achievement_boss_shannox",


### PR DESCRIPTION
I realized the achievement order has been very inconsistent over the years, with one raid having one order and the other having a completely different one. So I made a bunch of changes to streamline this and make it consistent across all raid tiers.

Every raid now follows this order if applicable:
Wings --> Full Normal/Heroic/Mythic Completion --> "Glory"-like achievements --> Highest difficulty boss achievements.

There were also a few raids that had the boss order or glory achievement order listed incorrectly, which I've fixed as well.