### PR TITLE
Fix unobtained battle pets level display

### DIFF
--- a/src/pages/BattlePets.svelte
+++ b/src/pages/BattlePets.svelte
@@ -76,8 +76,8 @@
             class:notCollected={!item.collected}
             >
                 <img height="36" width="36" src="{ getImageSrc(item, true) }" alt>
-                <div class="pbLevel" class:opacityOn={showLevel}>{ item.level }</div>
-                <div class="pbBreed" class:opacityOn={showLevel}>{ item.breed }</div>
+                {#if item.level}<div class="pbLevel" class:opacityOn={showLevel}>{ item.level }</div>{/if}
+                {#if item.breed}<div class="pbBreed" class:opacityOn={showLevel}>{ item.breed }</div>{/if}
             </a> 
             <div class="pbQual" style="{ qualityToBackground(item) }"></div>        		      	
         </div>


### PR DESCRIPTION
Problem:
- If you select `Show levels and breeds` all unobtained pets will render as double `undefined` <img width="357" alt="image" src="https://github.com/kevinclement/SimpleArmory/assets/15669387/66a6a887-d879-4153-b674-42d1f9f6910c">


Fix:
- Added 2 if conditions around those elements, to skip rendering if they are undefined <img width="365" alt="image" src="https://github.com/kevinclement/SimpleArmory/assets/15669387/90e69700-2d60-4df3-94d9-25bac5a931e1">
