### PR TITLE
Add progress bar for each subcategory

### DIFF
--- a/src/components/Category/Category.svelte
+++ b/src/components/Category/Category.svelte
@@ -1,16 +1,37 @@
 <script>
   import Item from "./Item.svelte";
+  import ProgressBar from '$components/ProgressBar.svelte';
+  import { percent, percentFormat } from '$util/utils'
 
   export let category;
   export let getItemPath = undefined;
   export let superCat = "";
   export let subCategoriesKey = "subCategories"
   export let itemsKey = "items"
+
+  let totalItems = 0;
+  let totalItemsCompleted = 0;
+  category[subCategoriesKey].forEach((subCategory) => {
+    subCategory[itemsKey].forEach((item) => {
+      totalItems += 1;
+      if (item.completed || item.collected) {
+        totalItemsCompleted += 1;
+      }
+    });
+  });
 </script>
 
-{#if category.name != superCat}
-  <h3 class="categoryHeader">{category.name}</h3>
-{/if}
+<div class="categoryHeader">
+  <h3>{category.name !== superCat ? category.name : "General"}</h3>
+
+  <ProgressBar
+    rightSide={true}
+    width={percent(totalItemsCompleted, totalItems)}
+    percentage={percentFormat(totalItemsCompleted, totalItems)}
+    isEmpty={totalItemsCompleted === 0}
+    emptyValue={`${totalItemsCompleted} / ${totalItems} (${percent(totalItemsCompleted, totalItems)}%)`}
+  />
+</div>
 
 {#each category[subCategoriesKey] as subCategory}
   <div class="sect">

--- a/src/components/Category/Category.svelte
+++ b/src/components/Category/Category.svelte
@@ -1,7 +1,5 @@
 <script>
   import Item from "./Item.svelte";
-  import ProgressBar from '$components/ProgressBar.svelte';
-  import { percent, percentFormat } from '$util/utils'
 
   export let category;
   export let getItemPath = undefined;
@@ -23,14 +21,6 @@
 
 <div class="categoryHeader">
   <h3>{category.name !== superCat ? category.name : "General"}</h3>
-
-  <ProgressBar
-    rightSide={true}
-    width={percent(totalItemsCompleted, totalItems)}
-    percentage={percentFormat(totalItemsCompleted, totalItems)}
-    isEmpty={totalItemsCompleted === 0}
-    emptyValue={`${totalItemsCompleted} / ${totalItems} (${percent(totalItemsCompleted, totalItems)}%)`}
-  />
 </div>
 
 {#each category[subCategoriesKey] as subCategory}

--- a/src/components/Category/Category.svelte
+++ b/src/components/Category/Category.svelte
@@ -27,9 +27,13 @@
 <div class="categoryHeader">
   <h3>
     {category.name !== superCat ? category.name : "General"}
-    {#if totalItems > 0}
-      <small class="pbSmall">({`${totalItemsCompleted}/${totalItems}`})</small>
-    {/if}
+    <small class="pbSmall">
+      {#if superCat === 'Feats of Strength' || superCat === 'Legacy'}
+        ({`${totalItemsCompleted}`})
+      {:else}
+        ({`${totalItemsCompleted}/${totalItems}`})
+      {/if}
+    </small>
   </h3>
 </div>
 

--- a/src/components/Category/Category.svelte
+++ b/src/components/Category/Category.svelte
@@ -9,18 +9,28 @@
 
   let totalItems = 0;
   let totalItemsCompleted = 0;
-  category[subCategoriesKey].forEach((subCategory) => {
-    subCategory[itemsKey].forEach((item) => {
-      totalItems += 1;
-      if (item.completed || item.collected) {
-        totalItemsCompleted += 1;
-      }
+
+  $: {
+    totalItems = 0;
+    totalItemsCompleted = 0;
+    category[subCategoriesKey].forEach((subCategory) => {
+      subCategory[itemsKey].forEach((item) => {
+        totalItems += 1;
+        if (item.completed || item.collected) {
+          totalItemsCompleted += 1;
+        }
+      });
     });
-  });
+  }
 </script>
 
 <div class="categoryHeader">
-  <h3>{category.name !== superCat ? category.name : "General"}</h3>
+  <h3>
+    {category.name !== superCat ? category.name : "General"}
+    {#if totalItems > 0}
+      <small class="pbSmall">({`${totalItemsCompleted}/${totalItems}`})</small>
+    {/if}
+  </h3>
 </div>
 
 {#each category[subCategoriesKey] as subCategory}

--- a/src/components/ProgressBar.svelte
+++ b/src/components/ProgressBar.svelte
@@ -1,22 +1,24 @@
-<script>   
+<script>
     export let width = 0;
     export let styleWidth = 250;
     export let percentage = "";
     export let rightSide = false;
     export let url = "";
     export let name = "";
+    export let isEmpty = false;
+    export let emptyValue = "";
 </script>
 
 <div class="progress" class:progressRight={rightSide} style="width: { styleWidth == 'auto' ? 'auto' : styleWidth + 'px' }">
 {#if url !== ""}
     <a href={url} aria-label="{name}">
         <div class="progress-bar progress-bar-success" style="width: {width}%;">
-            <span>{ percentage }</span>
+            <span>{ isEmpty ? emptyValue : percentage }</span>
         </div>
     </a>
 {:else}
     <div class="progress-bar progress-bar-success" style="width: {width}%;">
-        <span>{ percentage }</span>
+        <span>{ isEmpty ? emptyValue : percentage }</span>
     </div>
 {/if}
 </div>

--- a/src/components/ProgressBar.svelte
+++ b/src/components/ProgressBar.svelte
@@ -5,20 +5,18 @@
     export let rightSide = false;
     export let url = "";
     export let name = "";
-    export let isEmpty = false;
-    export let emptyValue = "";
 </script>
 
 <div class="progress" class:progressRight={rightSide} style="width: { styleWidth == 'auto' ? 'auto' : styleWidth + 'px' }">
 {#if url !== ""}
     <a href={url} aria-label="{name}">
         <div class="progress-bar progress-bar-success" style="width: {width}%;">
-            <span>{ isEmpty ? emptyValue : percentage }</span>
+            <span>{ percentage }</span>
         </div>
     </a>
 {:else}
     <div class="progress-bar progress-bar-success" style="width: {width}%;">
-        <span>{ isEmpty ? emptyValue : percentage }</span>
+        <span>{ percentage }</span>
     </div>
 {/if}
 </div>

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -28,19 +28,7 @@ body {
 	  float: left;
   }
   .categoryHeader {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-end;
-    column-gap: 20px;
-    flex-wrap: wrap;
-  }
-  .categoryHeader h3 {
     margin-bottom: 0px;
-    white-space: nowrap;
-  }
-  .categoryHeader .progressRight {
-    float: none;
-    margin-bottom: 5px;
   }
   .subCatHeader {
 	margin-bottom:0px;
@@ -368,12 +356,6 @@ body {
   /* Footer */
   .footer {
 	display:none;
-  }
-
-  /* Progress bar */
-  .progress-bar span {
-    white-space: nowrap;
-    padding: 0 10px;
   }
 
   /* Darkmode overwrites */

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -28,7 +28,19 @@ body {
 	  float: left;
   }
   .categoryHeader {
-	margin-bottom:0px;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    column-gap: 20px;
+    flex-wrap: wrap;
+  }
+  .categoryHeader h3 {
+    margin-bottom: 0px;
+    white-space: nowrap;
+  }
+  .categoryHeader .progressRight {
+    float: none;
+    margin-bottom: 5px;
   }
   .subCatHeader {
 	margin-bottom:0px;
@@ -357,7 +369,13 @@ body {
   .footer {
 	display:none;
   }
-  
+
+  /* Progress bar */
+  .progress-bar span {
+    white-space: nowrap;
+    padding: 0 10px;
+  }
+
   /* Darkmode overwrites */
   .toggleTheme {
 	  cursor: pointer;


### PR DESCRIPTION
A progress bar has been implemented for each subcategory to track them individually. Works for all categories.

- Added CSS fix to prevent progress labels from wrapping if the progress width is smaller than the text width
- Updated `ProgressBar` to allow a custom value when `totalItemsCompleted` is `0` so that the progress bar is not empty

I also added “General” as the headline for the first subcategory to prevent the progress bar from becoming disjointed. Please let me know what you think about this. Could also remove the `<h3>` again and set the progress bar to `margin-left: auto`.

![image](https://github.com/kevinclement/SimpleArmory/assets/11848713/21f26eea-9260-432a-81de-4c9239740553)