### PR TITLE
Added setting to show hidden items

### DIFF
--- a/dataimporter/titles.py
+++ b/dataimporter/titles.py
@@ -103,15 +103,13 @@ IGNORE_TITLE_ID = [
     396,  # %s the Elite Shaman https://www.wowhead.com/title=646
     397,  # %s the Elite Warlock https://www.wowhead.com/title=647
     398,  # %s the Elite Warrior https://www.wowhead.com/title=648
+    481,  # %s the Elite Evoker https://www.wowhead.com/title=742
     399,  # %s the T-Shirt Enthusiast https://www.wowhead.com/title=649
     406,  # Sparking %s https://www.wowhead.com/title=658
     408,  # Pilgrim %s the Mallet Bearer https://www.wowhead.com/title=660
     413,  # %s, As Themselves https://www.wowhead.com/title=666
     436,  # %s the Avowed https://www.wowhead.com/title=690
     453,  # The [PH] TBD Title https://www.wowhead.com/title=713
-    464,  # Hero of Fate https://www.wowhead.com/title=15685
-    465,  # The Shrouded https://www.wowhead.com/title=15689
-    466,  # The Shrouded Hero https://www.wowhead.com/title=15756
     467,  # Honorary Dryad https://www.wowhead.com/title=728
     469  # The Worldbreaker https://www.wowhead.com/title=13931
 ]

--- a/src/api/_cache.js
+++ b/src/api/_cache.js
@@ -1,9 +1,12 @@
+import { getShowHiddenUpdated } from "../util/utils";
+
 export default class Cache {
     constructor(region, realm, character) {
         this.region = region;
         this.realm = realm;
         this.character = character;
         this.cache = undefined;
+        this.updated = undefined;
     }
 
     isValid(reg,rel,char) {
@@ -12,7 +15,13 @@ export default class Cache {
         // console.log(`  realm - old: '${this.realm}' new: '${rel}' comp: ${this.realm === rel}`);
         // console.log(`  char - old: '${this.character}' new: '${char}' comp: ${this.character === char}`);
         // console.log(`## VALID: ${this.region === reg && this.realm === rel && this.character === char} ####`);
-        
+        var showHiddenUpdateDate = getShowHiddenUpdated();
+        if(showHiddenUpdateDate && this.updated) {
+            if(showHiddenUpdateDate > this.updated) {
+                return false;
+            }
+        }
+
         return this.region === reg && this.realm === rel && this.character === char
     }
 
@@ -21,5 +30,6 @@ export default class Cache {
         this.realm = realm;
         this.character = character;
         this.cache = cache;
+        this.updated = Date.now();
     }
 }

--- a/src/api/_collectables.js
+++ b/src/api/_collectables.js
@@ -141,7 +141,7 @@ export async function parseCollectablesObject(categories, profile, collected_dat
                 //    3) You meet the class restriction
                 //    4) You meet the race restriction
                 var hasthis = itm.collected;
-                var showthis = (hasthis || !item.notObtainable || (showHiddenItems == "true" && !item.notReleased));
+                var showthis = (hasthis || !item.notObtainable || (showHiddenItems == "shown" && !item.notReleased));
 
                 if (item.side && item.side !== profile.factionMapped) {
                     showthis = false;

--- a/src/api/_collectables.js
+++ b/src/api/_collectables.js
@@ -1,3 +1,5 @@
+import { getShowHiddenSetting } from "../util/utils"
+
 function getHigherQualityBattlePet(currentPet, newPet) {
     function getPetsQuality(type) {
         switch (type) {
@@ -22,6 +24,8 @@ export async function parseCollectablesObject(categories, profile, collected_dat
     var collected = {};
     var totalCollected = 0;
     var totalPossible = 0;
+
+    var showHiddenItems = getShowHiddenSetting();
 
     // Build up lookup for items that character has
     collected_data[collectedProperty].forEach((item) => {
@@ -137,7 +141,7 @@ export async function parseCollectablesObject(categories, profile, collected_dat
                 //    3) You meet the class restriction
                 //    4) You meet the race restriction
                 var hasthis = itm.collected;
-                var showthis = (hasthis || !item.notObtainable);
+                var showthis = (hasthis || !item.notObtainable || (showHiddenItems == "true" && !item.notReleased));
 
                 if (item.side && item.side !== profile.factionMapped) {
                     showthis = false;

--- a/src/api/titles.js
+++ b/src/api/titles.js
@@ -2,6 +2,7 @@ import { getData } from '$api/_blizzard'
 import { getProfile } from '$api/profile'
 import { getJsonDb } from '$api/_db'
 import Cache from '$api/_cache'
+import { getShowHiddenSetting } from '../util/utils'
 
 let _cache;
 export async function getTitles(region, realm, character) {   
@@ -71,7 +72,7 @@ function parseTitlesObject(db, profile, earned) {
                 }
 
                 var hasthis = item.collected;
-                var showthis = (hasthis || !item.notObtainable);
+                var showthis = (hasthis || !item.notObtainable || (getShowHiddenSetting() && !item.notReleased));
 
                 if (item.side && item.side !== profile.factionMapped) {
                     showthis = false;

--- a/src/api/titles.js
+++ b/src/api/titles.js
@@ -72,7 +72,7 @@ function parseTitlesObject(db, profile, earned) {
                 }
 
                 var hasthis = item.collected;
-                var showthis = (hasthis || !item.notObtainable || (getShowHiddenSetting() == "true" && !item.notReleased));
+                var showthis = (hasthis || !item.notObtainable || (getShowHiddenSetting() == "shown" && !item.notReleased));
 
                 if (item.side && item.side !== profile.factionMapped) {
                     showthis = false;

--- a/src/api/titles.js
+++ b/src/api/titles.js
@@ -72,7 +72,7 @@ function parseTitlesObject(db, profile, earned) {
                 }
 
                 var hasthis = item.collected;
-                var showthis = (hasthis || !item.notObtainable || (getShowHiddenSetting() && !item.notReleased));
+                var showthis = (hasthis || !item.notObtainable || (getShowHiddenSetting() == "true" && !item.notReleased));
 
                 if (item.side && item.side !== profile.factionMapped) {
                     showthis = false;

--- a/src/api/titles.js
+++ b/src/api/titles.js
@@ -44,6 +44,8 @@ function parseTitlesObject(db, profile, earned) {
     var totalCollected = 0;
     var totalPossible = 0;
 
+    var showHiddenItems = getShowHiddenSetting();
+
     // Build up lookup for titles that character has
     earned.forEach((title) => {
         collected[title.id] = title;
@@ -72,7 +74,7 @@ function parseTitlesObject(db, profile, earned) {
                 }
 
                 var hasthis = item.collected;
-                var showthis = (hasthis || !item.notObtainable || (getShowHiddenSetting() == "shown" && !item.notReleased));
+                var showthis = (hasthis || !item.notObtainable || (showHiddenItems == "shown" && !item.notReleased));
 
                 if (item.side && item.side !== profile.factionMapped) {
                     showthis = false;

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -54,7 +54,7 @@
 
   const toggleHidden = (e) => {
 		e.preventDefault();
-		$preferences.showHidden = $preferences.showHidden ? false : true;
+		$preferences.showHidden = $preferences.showHidden == "hidden" ? "shown" : "hidden";
 
 		localStorage.setItem('showHidden', $preferences.showHidden);
 	}
@@ -102,7 +102,7 @@
 
     <div>
       <a href="#/" on:click={toggleHidden}
-        >{$preferences.showHidden === false ? "Show Unobtainable Collectibles" : "Hide Unobtainable Collectibles"}
+        >{$preferences.showHidden === "hidden" ? "Show Unobtainable Collectibles" : "Hide Unobtainable Collectibles"}
     </div>
 
     <div>

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -56,6 +56,7 @@
 		e.preventDefault();
 		$preferences.showHidden = $preferences.showHidden == "hidden" ? "shown" : "hidden";
 
+    localStorage.setItem('showHiddenUpdated',Date.now());
 		localStorage.setItem('showHidden', $preferences.showHidden);
 	}
 

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -52,6 +52,13 @@
     localStorage.setItem("itemSkin", $preferences.itemSkin);
   };
 
+  const toggleHidden = (e) => {
+		e.preventDefault();
+		$preferences.showHidden = $preferences.showHidden ? false : true;
+
+		localStorage.setItem('showHidden', $preferences.showHidden);
+	}
+
   function setLocale(e, wowhead_url) {
     e.preventDefault();
 
@@ -91,6 +98,11 @@
       <a href="#/" on:click={toggleItemSkin}
         >Use {$preferences.itemSkin === "classic" ? "New" : "Classic"} Item Skin
       </a>
+    </div>
+
+    <div>
+      <a href="#/" on:click={toggleHidden}
+        >{$preferences.showHidden === false ? "Show Unobtainable Collectibles" : "Hide Unobtainable Collectibles"}
     </div>
 
     <div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -65,7 +65,7 @@
 		})
 
 		$preferences.itemSkin = localStorage.getItem('itemSkin') ?? 'new';
-		$preferences.showHidden = localStorage.getItem('showHidden') ?? false;
+		$preferences.showHidden = localStorage.getItem('showHidden') ?? "hidden";
 	})
 
     function getCharInfoFromURL() {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -65,6 +65,7 @@
 		})
 
 		$preferences.itemSkin = localStorage.getItem('itemSkin') ?? 'new';
+		$preferences.showHidden = localStorage.getItem('showHidden') ?? false;
 	})
 
     function getCharInfoFromURL() {

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -73,6 +73,10 @@ export function getDarkMode(window, cb) {
     }
 }
 
+export function getShowHiddenSetting() {
+    return(localStorage.getItem("showHidden"));
+}
+
 export function getWowheadUrl() {
     if (typeof window !== 'undefined') {
         if(localStorage.getItem('wowhead_url'))

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -77,6 +77,10 @@ export function getShowHiddenSetting() {
     return(localStorage.getItem("showHidden"));
 }
 
+export function getShowHiddenUpdated() {
+    return(localStorage.getItem("showHiddenUpdated"));
+}
+
 export function getWowheadUrl() {
     if (typeof window !== 'undefined') {
         if(localStorage.getItem('wowhead_url'))

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -176,6 +176,7 @@
             "itemId": 87784,
             "name": "Jungle Riding Crane",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 127178
           },
           {
@@ -184,6 +185,7 @@
             "itemId": 213576,
             "name": "Golden Discus",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435044
           },
           {
@@ -192,6 +194,7 @@
             "itemId": 213584,
             "name": "Mogu Hazeblazer",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435082
           },
           {
@@ -200,6 +203,7 @@
             "itemId": 213582,
             "name": "Sky Surfer",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435084
           },
           {
@@ -208,6 +212,7 @@
             "itemId": 213596,
             "name": "Daystorm Windsteed",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435108
           },
           {
@@ -216,6 +221,7 @@
             "itemId": 213597,
             "name": "Forest Windsteed",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435107
           },
           {
@@ -224,6 +230,7 @@
             "itemId": 213598,
             "name": "Dashing Windsteed",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435103
           },
           {
@@ -232,6 +239,7 @@
             "itemId": 213595,
             "name": "Feathered Windsurfer",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435109
           },
           {
@@ -240,6 +248,7 @@
             "itemId": 213601,
             "name": "Guardian Quilen",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435115
           },
           {
@@ -248,6 +257,7 @@
             "itemId": 213600,
             "name": "Marble Quilen",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435118
           },
           {
@@ -256,6 +266,7 @@
             "itemId": 213602,
             "name": "Gilded Riding Crane",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435123
           },
           {
@@ -264,6 +275,7 @@
             "itemId": 213603,
             "name": "Pale Riding Crane",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435128
           },
           {
@@ -272,6 +284,7 @@
             "itemId": 213605,
             "name": "Rose Riding Crane",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435127
           },
           {
@@ -280,6 +293,7 @@
             "itemId": 213606,
             "name": "Silver Riding Crane",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435126
           },
           {
@@ -288,6 +302,7 @@
             "itemId": 213607,
             "name": "Luxurious Riding Crane",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435124
           },
           {
@@ -296,6 +311,7 @@
             "itemId": 213604,
             "name": "Tropical Riding Crane",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435125
           },
           {
@@ -304,6 +320,7 @@
             "itemId": 213608,
             "name": "Snowy Riding Goat",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435131
           },
           {
@@ -312,6 +329,7 @@
             "itemId": 213609,
             "name": "Little Red Riding Goat",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435133
           },
           {
@@ -320,6 +338,7 @@
             "itemId": 213623,
             "name": "Bloody Skyscreamer",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435145
           },
           {
@@ -328,6 +347,7 @@
             "itemId": 213622,
             "name": "Night Pterrorwing",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435146
           },
           {
@@ -336,6 +356,7 @@
             "itemId": 213621,
             "name": "Jade Pterrordax",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435147
           },
           {
@@ -344,6 +365,7 @@
             "itemId": 213624,
             "name": "Cobalt Juggernaut",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435149
           },
           {
@@ -352,6 +374,7 @@
             "itemId": 213625,
             "name": "Fel Iron Juggernaut",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435150
           },
           {
@@ -360,6 +383,7 @@
             "itemId": 213626,
             "name": "Purple Shado-Pan Riding Tiger",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435153
           },
           {
@@ -368,6 +392,7 @@
             "itemId": 213628,
             "name": "Riverwalker Mushan",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435160
           },
           {
@@ -376,6 +401,7 @@
             "itemId": 213627,
             "name": "Palehide Mushan Beast",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 435161
           },
           {
@@ -384,6 +410,7 @@
             "itemId": 218111,
             "name": "Amber Pterrordax",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 441794
           },
           {
@@ -392,6 +419,7 @@
             "itemId": 220766,
             "name": "August Phoenix",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 446017
           },
           {
@@ -400,6 +428,7 @@
             "itemId": 220768,
             "name": "Astral Emperor's Serpent",
             "notObtainable":true,
+            "notReleased":true,
             "spellid": 446022
           }
         ],
@@ -424,7 +453,6 @@
           {
             "ID": 1733,
             "icon": "inv_sporebatrock_yellow",
-            "itemId": 205206,
             "name": "Calescent Shalewing",
             "spellid": 408648
           },
@@ -552,6 +580,7 @@
           {
             "ID": 1818,
             "icon": "inv_dreamowl_firemount",
+            "itemId": 210061,
             "name": "Anu'relos, Flame's Guidance",
             "spellid": 424484
           }
@@ -1143,6 +1172,7 @@
             "icon": "inv_pterrordax2mount_white",
             "name": "Swift Spectral Drake",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 372995
           }
         ],
@@ -5165,27 +5195,6 @@
         "id": "16bcc6b5",
         "items": [
           {
-            "ID": 445,
-            "icon": "ability_mount_drake_twilight",
-            "itemId": 78919,
-            "name": "Experiment 12-B",
-            "spellid": 110039
-          },
-          {
-            "ID": 442,
-            "icon": "ability_mount_drake_red",
-            "itemId": 77067,
-            "name": "Blazing Drake",
-            "spellid": 107842
-          },
-          {
-            "ID": 444,
-            "icon": "ability_mount_drake_red",
-            "itemId": 77069,
-            "name": "Life-Binder's Handmaiden",
-            "spellid": 107845
-          },
-          {
             "ID": 396,
             "icon": "inv_misc_stormdragonpurple",
             "itemId": 63041,
@@ -5205,6 +5214,27 @@
             "itemId": 69224,
             "name": "Pureblood Fire Hawk",
             "spellid": 97493
+          },
+          {
+            "ID": 445,
+            "icon": "ability_mount_drake_twilight",
+            "itemId": 78919,
+            "name": "Experiment 12-B",
+            "spellid": 110039
+          },
+          {
+            "ID": 442,
+            "icon": "ability_mount_drake_red",
+            "itemId": 77067,
+            "name": "Blazing Drake",
+            "spellid": 107842
+          },
+          {
+            "ID": 444,
+            "icon": "ability_mount_drake_red",
+            "itemId": 77069,
+            "name": "Life-Binder's Handmaiden",
+            "spellid": 107845
           }
         ],
         "name": "Raid Drop"
@@ -5314,6 +5344,15 @@
             "notObtainable": true,
             "side": "A",
             "spellid": 68057
+          },
+          {
+            "ID": 342,
+            "icon": "ability_mount_blackdirewolf",
+            "itemId": 49046,
+            "name": "Swift Horde Wolf",
+            "notObtainable": true,
+            "side": "H",
+            "spellid": 68056
           }
         ],
         "name": "Achievement"
@@ -5759,15 +5798,6 @@
             "itemId": 50818,
             "name": "Invincible",
             "spellid": 72286
-          },
-          {
-            "ID": 342,
-            "icon": "ability_mount_blackdirewolf",
-            "itemId": 49046,
-            "name": "Swift Horde Wolf",
-            "notObtainable": true,
-            "side": "H",
-            "spellid": 68056
           }
         ],
         "name": "Raid Drop"
@@ -8412,7 +8442,6 @@
           {
             "ID": 1737,
             "icon": "inv_sporebatrock_stoneorange",
-            "itemId": 205208,
             "name": "Sandy Shalewing",
             "notObtainable": true,
             "spellid": 408654
@@ -9304,6 +9333,7 @@
             "itemId": 137615,
             "name": "Flarecore Infernal",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 213349
           },
           {
@@ -9312,6 +9342,7 @@
             "itemId": 190539,
             "name": "Coral-Stalker Waveray",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 367620
           },
           {
@@ -9320,6 +9351,7 @@
             "itemId": 221270,
             "name": "[PH] Goblin Surfboard - Blue",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 446352
           },
           {
@@ -9328,6 +9360,7 @@
             "itemId": 221814,
             "name": "Pearlescent Goblin Wave Shredder",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 447413
           },
           {
@@ -9336,6 +9369,7 @@
             "itemId": 223282,
             "name": "[PH] Blue Old God Fish Mount",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 448845
           },
           {
@@ -9344,6 +9378,7 @@
             "itemId": 223284,
             "name": "[PH] Green Old God Fish Mount",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 448849
           },
           {
@@ -9352,6 +9387,7 @@
             "itemId": 223286,
             "name": "[PH] Red Old God Fish Mount",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 448850
           },
           {
@@ -9360,6 +9396,7 @@
             "itemId": 223285,
             "name": "[PH] Purple Old God Fish Mount",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 448851
           },
           {
@@ -9368,6 +9405,7 @@
             "itemId": 223449,
             "name": "[PH] Nightsaber Horde Mount",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 449126
           },
           {
@@ -9376,6 +9414,7 @@
             "itemId": 223459,
             "name": "[PH] Nightsaber Horde Mount Black",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 449132
           },
           {
@@ -9384,6 +9423,7 @@
             "itemId": 223460,
             "name": "[PH] Nightsaber Horde Mount White",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 449133
           },
           {
@@ -9392,6 +9432,7 @@
             "itemId": 223469,
             "name": "[PH] Alliance Wolf Mount",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 449140
           },
           {
@@ -9400,6 +9441,7 @@
             "itemId": 223470,
             "name": "[PH] Alliance Wolf Mount",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 449141
           },
           {
@@ -9408,6 +9450,7 @@
             "itemId": 223471,
             "name": "[PH] Alliance Wolf Mount",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 449142
           }
         ],
@@ -9685,6 +9728,7 @@
             "icon": "inv_misc_qirajicrystal_05",
             "name": "Black Qiraji Battle Tank",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 25863
           },
           {
@@ -9692,6 +9736,7 @@
             "icon": "inv_misc_qirajicrystal_05",
             "name": "Black Qiraji Battle Tank",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 26655
           },
           {
@@ -9845,6 +9890,7 @@
             "itemId": 8630,
             "name": "Tiger",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 10790
           }
         ],
@@ -9858,6 +9904,7 @@
             "icon": "inv_companionprotodragon",
             "name": "Whelpling",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 395095
           },
           {
@@ -9866,6 +9913,7 @@
             "itemId": 191094,
             "name": "Cerulean Marsh Hopper",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 369480
           }
         ],

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -271,6 +271,7 @@
             "itemId": 221817,
             "name": "Muskpaw Calf",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 449550
           },
           {
@@ -280,6 +281,7 @@
             "itemId": 221818,
             "name": "Astral Emperor's Serpentling",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 449626
           }
         ],
@@ -1483,6 +1485,7 @@
             "itemId": 205004,
             "name": "Azure Swoglet",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 407926
           },
           {
@@ -1492,6 +1495,7 @@
             "itemId": 205008,
             "name": "Emerald Swoglet",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 407930
           },
           {
@@ -1501,6 +1505,7 @@
             "itemId": 205011,
             "name": "Bronze Swoglet",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 407935
           },
           {
@@ -1510,6 +1515,7 @@
             "itemId": 205013,
             "name": "Lettuce",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 407946
           },
           {
@@ -1519,6 +1525,7 @@
             "itemId": 205017,
             "name": "Byrn",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 407955
           },
           {
@@ -1528,6 +1535,7 @@
             "itemId": 205018,
             "name": "Jade Skitterbug",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 408023
           },
           {
@@ -1537,6 +1545,7 @@
             "itemId": 205023,
             "name": "Savage Lobstrok",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 408032
           },
           {
@@ -1546,6 +1555,7 @@
             "itemId": 205053,
             "name": "Rusty",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 408106
           },
           {
@@ -1555,6 +1565,7 @@
             "itemId": 205054,
             "name": "Amador",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 408108
           },
           {
@@ -1564,6 +1575,7 @@
             "itemId": 205116,
             "name": "Jerrie",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 408130
           },
           {
@@ -1573,6 +1585,7 @@
             "itemId": 205122,
             "name": "Roseshell",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 408163
           },
           {
@@ -1582,6 +1595,7 @@
             "itemId": 205148,
             "name": "Dread Shalewing",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 408252
           },
           {
@@ -1591,6 +1605,7 @@
             "itemId": 205149,
             "name": "Ravenous Shalewing",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 408253
           },
           {
@@ -1600,6 +1615,7 @@
             "itemId": 205150,
             "name": "Shalewing Devourer",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 408254
           },
           {
@@ -1609,6 +1625,7 @@
             "itemId": 205153,
             "name": "Mikah",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 408265
           },
           {
@@ -1618,6 +1635,7 @@
             "itemId": 205157,
             "name": "Undermoth",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 408314
           },
           {
@@ -1627,6 +1645,7 @@
             "itemId": 205164,
             "name": "Senega",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 408328
           },
           {
@@ -1636,6 +1655,7 @@
             "itemId": 205166,
             "name": "Kromos",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 408332
           },
           {
@@ -1645,6 +1665,7 @@
             "itemId": 206174,
             "name": "Blub",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 412389
           },
           {
@@ -1654,6 +1675,7 @@
             "itemId": 208446,
             "name": "Fyrn",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 419467
           }
         ],
@@ -3140,6 +3162,7 @@
             "icon": "inv_misc_head_tiger_01",
             "name": "Trub'ul",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 360567
           }
         ],
@@ -4759,6 +4782,7 @@
             "itemId": 166358,
             "name": "Proper Parrot",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 288054
           }
         ],
@@ -8163,14 +8187,6 @@
             "itemId": 178533,
             "name": "Jingles",
             "spellid": 294211
-          },
-          {
-            "ID": 4311,
-            "creatureId": 213111,
-            "icon": "inv_helm_cloth_holiday_christmas_a_03",
-            "itemId": 210870,
-            "name": "Mitzy",
-            "spellid": 427289
           }
         ],
         "name": "Feast of Winter Veil"
@@ -9083,6 +9099,7 @@
             "itemId": 205032,
             "name": "Bestial Lurker",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 408048
           },
           {
@@ -9092,6 +9109,7 @@
             "itemId": 205035,
             "name": "Snapjaw Lurker",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 408062
           },
           {
@@ -9101,6 +9119,7 @@
             "itemId": 205037,
             "name": "Void Lurker",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 408063
           }
         ],
@@ -11067,6 +11086,14 @@
             "spellid": 367768
           },
           {
+            "ID": 4311,
+            "creatureId": 213111,
+            "icon": "inv_helm_cloth_holiday_christmas_a_03",
+            "itemId": 210870,
+            "name": "Mitzy",
+            "spellid": 427289
+          },
+          {
             "ID": 3255,
             "creatureId": 185756,
             "icon": "inv_pet_babymoose_white",
@@ -11129,6 +11156,7 @@
             "itemId": 190173,
             "name": "Lil' Maka'jin",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 366833
           },
           {
@@ -11138,6 +11166,7 @@
             "itemId": 190609,
             "name": "Watcher of the Huntress",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 367800
           },
           {
@@ -11147,6 +11176,7 @@
             "itemId": 212791,
             "name": "Beetriz",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 433098
           },
           {
@@ -11156,6 +11186,7 @@
             "itemId": 217043,
             "name": "Pokee",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 438775
           },
           {
@@ -11165,6 +11196,7 @@
             "itemId": 223145,
             "name": "Marrlok",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 448355
           },
           {
@@ -11174,6 +11206,7 @@
             "itemId": 223339,
             "name": "Trishi",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 449046
           },
           {
@@ -11183,6 +11216,7 @@
             "itemId": 223474,
             "name": "Worgli the Apprehensive",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 449173
           },
           {
@@ -11192,6 +11226,7 @@
             "itemId": 223499,
             "name": "Lil' Manny",
             "notObtainable": true,
+            "notReleased":true,
             "spellid": 449286
           }
         ],

--- a/static/data/titles.json
+++ b/static/data/titles.json
@@ -245,6 +245,7 @@
             "id": 40226,
             "name": "Mistrunner",
             "notObtainable": true,
+            "notReleased":true,
             "titleId": 539,
             "type": "achievement"
           },
@@ -253,6 +254,7 @@
             "id": 20004,
             "name": "Timerunner",
             "notObtainable": true,
+            "notReleased":true,
             "titleId": 551,
             "type": "achievement"
           },
@@ -261,6 +263,7 @@
             "id": 40227,
             "name": "Paragon of the Mists",
             "notObtainable": true,
+            "notReleased":true,
             "titleId": 552,
             "type": "achievement"
           },
@@ -269,6 +272,7 @@
             "id": 20007,
             "name": "Claw of Eternus",
             "notObtainable": true,
+            "notReleased":true,
             "titleId": 553,
             "type": "achievement"
           }
@@ -572,6 +576,7 @@
             "id": 787,
             "name": "Honorary Historian",
             "notObtainable": true,
+            "notReleased":true,
             "titleId": 518,
             "type": "title"
           }
@@ -2742,14 +2747,6 @@
       {
         "items": [
           {
-            "icon": "inv_misc_questionmark",
-            "id": 742,
-            "name": "The Elite Evoker",
-            "notObtainable": true,
-            "titleId": 481,
-            "type": "title"
-          },
-          {
             "icon": "achievement_featsofstrength_gladiator_07",
             "id": 15951,
             "name": "Crimson Gladiator",
@@ -2914,6 +2911,7 @@
             "id": 815,
             "name": "Swabbie",
             "notObtainable": true,
+            "notReleased":true,
             "titleId": 542,
             "type": "title"
           },
@@ -2922,6 +2920,7 @@
             "id": 816,
             "name": "Deck Hand",
             "notObtainable": true,
+            "notReleased":true,
             "titleId": 543,
             "type": "title"
           },
@@ -2930,6 +2929,7 @@
             "id": 817,
             "name": "Swashbuckler",
             "notObtainable": true,
+            "notReleased":true,
             "titleId": 544,
             "type": "title"
           },
@@ -2938,6 +2938,7 @@
             "id": 818,
             "name": "Buccaneer",
             "notObtainable": true,
+            "notReleased":true,
             "titleId": 545,
             "type": "title"
           },
@@ -2946,6 +2947,7 @@
             "id": 819,
             "name": "First Mate",
             "notObtainable": true,
+            "notReleased":true,
             "titleId": 546,
             "type": "title"
           }
@@ -2962,7 +2964,7 @@
       {
         "items": [
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_zone_silithus_01",
             "id": 46,
             "name": "Scarab Lord",
             "notObtainable": true,
@@ -3103,7 +3105,7 @@
             "type": "achievement"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_gateofthesettingsun_platinum",
             "id": 366,
             "name": "Defender of the Wall",
             "notObtainable": true,
@@ -3111,7 +3113,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_mogushanpalace_platinum",
             "id": 367,
             "name": "Mogu-Slayer",
             "notObtainable": true,
@@ -3119,7 +3121,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_helmet_52",
+            "icon": "achievement_challengemode_scarlethalls_platinum",
             "id": 6760,
             "name": "Flameweaver",
             "notObtainable": true,
@@ -3127,7 +3129,7 @@
             "type": "achievement"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_scarletmonastery_platinum",
             "id": 369,
             "name": "Scarlet Commander",
             "notObtainable": true,
@@ -3135,7 +3137,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_scholomance_platinum",
             "id": 370,
             "name": "Darkmaster",
             "notObtainable": true,
@@ -3143,7 +3145,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_shadopanmonastery_platinum",
             "id": 371,
             "name": "Purified Defender",
             "notObtainable": true,
@@ -3151,7 +3153,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_seigeofniuzaotemple_platinum",
             "id": 372,
             "name": "Siegebreaker",
             "notObtainable": true,
@@ -3159,7 +3161,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_stormstoutbrewery_platinum",
             "id": 373,
             "name": "Stormbrewer",
             "notObtainable": true,
@@ -3167,7 +3169,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_templeofthejadeserpent_platinum",
             "id": 374,
             "name": "Jade Protector",
             "notObtainable": true,
@@ -3191,7 +3193,7 @@
             "type": "achievement"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_ogreslagmines_gold",
             "id": 429,
             "name": "The Mine Master",
             "notObtainable": true,
@@ -3199,7 +3201,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_blackrockdocks_gold",
             "id": 430,
             "name": "Dockmaster",
             "notObtainable": true,
@@ -3207,7 +3209,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_auchindoun_gold",
             "id": 431,
             "name": "The Soul Preserver",
             "notObtainable": true,
@@ -3215,7 +3217,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_arakkoaspires_gold",
             "id": 432,
             "name": "Scion of Rukhmar",
             "notObtainable": true,
@@ -3223,7 +3225,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_shadowmoonhideout_gold",
             "id": 433,
             "name": "Spiritwalker",
             "notObtainable": true,
@@ -3231,7 +3233,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_upperbrspire_gold",
             "id": 434,
             "name": "Lord of Blackrock",
             "notObtainable": true,
@@ -3239,7 +3241,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_upperbrspire_gold",
             "id": 435,
             "name": "Lady of Blackrock",
             "notObtainable": true,
@@ -3247,7 +3249,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_everbloom_gold",
             "id": 436,
             "name": "The Violet Guardian",
             "notObtainable": true,
@@ -3255,7 +3257,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_challengemode_blackrockdepot_gold",
             "id": 437,
             "name": "The Grimrail Suplexer",
             "notObtainable": true,

--- a/static/data/toys.json
+++ b/static/data/toys.json
@@ -135,42 +135,48 @@
             "icon": "monk_stance_redcrane",
             "itemId": 217724,
             "name": "Kindness of Chi-ji",
-            "notObtainable": true
+            "notObtainable": true,
+            "notReleased":true
           },
           {
             "ID": 1468,
             "icon": "monk_stance_drunkenox",
             "itemId": 217726,
             "name": "Fortitude of Niuzao",
-            "notObtainable": true
+            "notObtainable": true,
+            "notReleased":true
           },
           {
             "ID": 1469,
             "icon": "monk_stance_whitetiger",
             "itemId": 217723,
             "name": "Fury of Xuen",
-            "notObtainable": true
+            "notObtainable": true,
+            "notReleased":true
           },
           {
             "ID": 1470,
             "icon": "monk_stance_wiseserpent",
             "itemId": 217725,
             "name": "Essence of Yu'lon",
-            "notObtainable": true
+            "notObtainable": true,
+            "notReleased":true
           },
           {
             "ID": 1476,
             "icon": "inv_misc_herb_talandrasrose",
             "itemId": 220777,
             "name": "Cherry Blossom Trail",
-            "notObtainable": true
+            "notObtainable": true,
+            "notReleased":true
           },
           {
             "ID": 1479,
             "icon": "inv_misc_bag_herbpouch",
             "itemId": 223146,
             "name": "Satchel of Stormborn Seeds",
-            "notObtainable": true
+            "notObtainable": true,
+            "notReleased":true
           }
         ],
         "name": "Limited Time: Timerunning Pandamonium"
@@ -6632,28 +6638,32 @@
             "icon": "inv_misc_1h_umbrella_b_01",
             "itemId": 212524,
             "name": "Delicate Crimson Parasol",
-            "notObtainable": true
+            "notObtainable": true,
+            "notReleased":true
           },
           {
             "ID": 1455,
             "icon": "inv_misc_1h_umbrella_b_01",
             "itemId": 212525,
             "name": "Delicate Ebony Parasol",
-            "notObtainable": true
+            "notObtainable": true,
+            "notReleased":true
           },
           {
             "ID": 1471,
             "icon": "inv_fishingchair",
             "itemId": 218112,
             "name": "Colorful Beach Chair",
-            "notObtainable": true
+            "notObtainable": true,
+            "notReleased":true
           },
           {
             "ID": 1475,
             "icon": "inv_firearm_2h_waterblaster_c_01",
             "itemId": 220692,
             "name": "X-treme Water Blaster Display",
-            "notObtainable": true
+            "notObtainable": true,
+            "notReleased":true
           }
         ],
         "name": "Trading Post"


### PR DESCRIPTION
Applied corrections based on #610 and added a setting that lets you show any unobtainable items, it currently affects mounts, pets, toys and titles. (can be toggled from setting menu). The setting is off by default.

I also added a new attribute 'notReleased' for items that are in the game but were never released. These will not be shown with the above setting enabled.

I also corrected a bunch of titles that didn't have their corresponding achievement icon linked, I plan to fix a whole bunch more of the question mark icons next. I would also like to make this toggle affect FoS as well as legacy achievements, so will work on that as well.