### PR TITLE
switch to alternative characterMedia given service errors

### DIFF
--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -1,7 +1,6 @@
 <script>
-	import { region, realm, character, page, category } from '$stores/user'
+	import { region, realm, character, avatar, page, category } from '$stores/user'
 	import { preferences } from '$stores/preferences'
-	import { getProfileMedia } from '$api/profile'
 	import { getUrl } from '$util/url'
 	import { getWowheadUrl } from '$util/utils'
 	import { onMount } from 'svelte'
@@ -58,7 +57,6 @@
 	    $realm && $realm !== '' && 
 	    $character && $character !== ''
 	$: armoryUrl = !$character ? '' : 'https://worldofwarcraft.com/character/' + $region + '/' + $realm + '/' + $character.toLowerCase();
-	$: imgUrl = getProfileMedia($region, $realm, $character)
 
 	const toggleCollapsed = (e) => {
 		menuCollapsed = !menuCollapsed;
@@ -197,9 +195,7 @@
 			<ul class="nav navbar-nav navbar-right">
 				<li class="dropdown" class:open={menuItems.Profile.isOpen}>
 					<a id="profileDrop" href="#/" aria-label="Profile" on:click="{(e) => toggleDropDown(e,menuItems.Profile)}" class="navbar-char-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-						{#await imgUrl then value}
-						<img width="32" height="32" class="navbar-char-image" src="{value}" alt="Profile"/>
-						{/await}
+						<img width="32" height="32" class="navbar-char-image" src="{$avatar}" alt="Profile"/>					
 						<b class="caret"></b>
 					</a>
 

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -3,6 +3,7 @@ import { writable } from "svelte/store"
 export const region = writable(undefined);
 export const realm = writable(undefined);
 export const character = writable(undefined);
+export const avatar = writable("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII="); // default to 1x1 for avatar
 export const page = writable(undefined);
 export const category = writable(undefined);
 export const subcat = writable(undefined);


### PR DESCRIPTION
The official character media api has been throwing errors for a week or so.  I haven't seen anything indicating a fix is coming soon.  However, I found an alternative way to get the avatar img we're using so I'm switching to using that method.  