### PR TITLE
Trading Post June + Limited Time Overhaul

### DIFF
--- a/static/data/heirlooms.json
+++ b/static/data/heirlooms.json
@@ -1,5 +1,82 @@
 [
   {
+    "name": "Limited Time",
+    "subcats": [
+      {
+        "id": "269bd4eb",
+        "items": [
+          {
+            "ID": 724,
+            "icon": "inv_bow_1h_pvphorde_a_01_upres",
+            "itemId": 104399,
+            "name": "Hellscream's Warbow"
+          },
+          {
+            "ID": 725,
+            "icon": "inv_knife_1h_pvphorde_a_01",
+            "itemId": 104400,
+            "name": "Hellscream's Razor"
+          },
+          {
+            "ID": 726,
+            "icon": "inv_sword_1h_pvphorde_a_01_upres",
+            "itemId": 104401,
+            "name": "Hellscream's Doomblade"
+          },
+          {
+            "ID": 727,
+            "icon": "inv_hammer_1h_pvphorde_a_01red_upres",
+            "itemId": 104402,
+            "name": "Hellscream's Warmace"
+          },
+          {
+            "ID": 728,
+            "icon": "inv_polearm_2h_pvphorde_a_01_upres",
+            "itemId": 104403,
+            "name": "Hellscream's Pig Sticker"
+          },
+          {
+            "ID": 729,
+            "icon": "inv_axe_1h_pvphorde_d_01_upres",
+            "itemId": 104404,
+            "name": "Hellscream's Cleaver"
+          },
+          {
+            "ID": 730,
+            "icon": "inv_axe_2h_pvphorde_a_01blackhigh",
+            "itemId": 104405,
+            "name": "Hellscream's Decapitator"
+          },
+          {
+            "ID": 731,
+            "icon": "inv_stave_2h_pvphorde_a_01_upres",
+            "itemId": 104406,
+            "name": "Hellscream's War Staff"
+          },
+          {
+            "ID": 732,
+            "icon": "inv_shield_pvphorde_a_01_upres",
+            "itemId": 104407,
+            "name": "Hellscream's Shield Wall"
+          },
+          {
+            "ID": 733,
+            "icon": "inv_misc_1h_book_c_02red_upres",
+            "itemId": 104408,
+            "name": "Hellscream's Tome of Destruction"
+          },
+          {
+            "ID": 734,
+            "icon": "inv_shield_pvphorde_a_01_upres",
+            "itemId": 104409,
+            "name": "Hellscream's Barrier"
+          }
+        ],
+        "name": "Remix: Pandaria Vendor"
+      }
+    ]
+  },
+  {
     "id": "e2a50a64",
     "name": "Dragonflight",
     "subcats": [
@@ -282,78 +359,6 @@
           }
         ],
         "name": "Siege of Orgrimmar: Normal"
-      },
-      {
-        "id": "269bd4eb",
-        "items": [
-          {
-            "ID": 724,
-            "icon": "inv_bow_1h_pvphorde_a_01_upres",
-            "itemId": 104399,
-            "name": "Hellscream's Warbow"
-          },
-          {
-            "ID": 725,
-            "icon": "inv_knife_1h_pvphorde_a_01",
-            "itemId": 104400,
-            "name": "Hellscream's Razor"
-          },
-          {
-            "ID": 726,
-            "icon": "inv_sword_1h_pvphorde_a_01_upres",
-            "itemId": 104401,
-            "name": "Hellscream's Doomblade"
-          },
-          {
-            "ID": 727,
-            "icon": "inv_hammer_1h_pvphorde_a_01red_upres",
-            "itemId": 104402,
-            "name": "Hellscream's Warmace"
-          },
-          {
-            "ID": 728,
-            "icon": "inv_polearm_2h_pvphorde_a_01_upres",
-            "itemId": 104403,
-            "name": "Hellscream's Pig Sticker"
-          },
-          {
-            "ID": 729,
-            "icon": "inv_axe_1h_pvphorde_d_01_upres",
-            "itemId": 104404,
-            "name": "Hellscream's Cleaver"
-          },
-          {
-            "ID": 730,
-            "icon": "inv_axe_2h_pvphorde_a_01blackhigh",
-            "itemId": 104405,
-            "name": "Hellscream's Decapitator"
-          },
-          {
-            "ID": 731,
-            "icon": "inv_stave_2h_pvphorde_a_01_upres",
-            "itemId": 104406,
-            "name": "Hellscream's War Staff"
-          },
-          {
-            "ID": 732,
-            "icon": "inv_shield_pvphorde_a_01_upres",
-            "itemId": 104407,
-            "name": "Hellscream's Shield Wall"
-          },
-          {
-            "ID": 733,
-            "icon": "inv_misc_1h_book_c_02red_upres",
-            "itemId": 104408,
-            "name": "Hellscream's Tome of Destruction"
-          },
-          {
-            "ID": 734,
-            "icon": "inv_shield_pvphorde_a_01_upres",
-            "itemId": 104409,
-            "name": "Hellscream's Barrier"
-          }
-        ],
-        "name": "Siege of Orgrimmar: Heroic"
       },
       {
         "id": "79e350a8",

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -9045,6 +9045,20 @@
             "spellid": 46197
           },
           {
+            "ID": 372,
+            "icon": "ability_hunter_pet_rhino",
+            "itemId": 54068,
+            "name": "Wooly White Rhino",
+            "spellid": 74918
+          },
+          {
+            "ID": 212,
+            "icon": "inv_misc_missilesmall_red",
+            "itemId": 49286,
+            "name": "X-51 Nether-Rocket X-TREME",
+            "spellid": 46199
+          },
+          {
             "ID": 230,
             "icon": "ability_druid_challangingroar",
             "itemId": 49282,
@@ -9115,7 +9129,7 @@
             "spellid": 136505
           }
         ],
-        "name": "Trading Card Game"
+        "name": "Trading Card Game / Auction House"
       },
       {
         "items": [
@@ -9669,20 +9683,6 @@
             "itemId": 19902,
             "name": "Swift Zulian Tiger",
             "spellid": 24252
-          },
-          {
-            "ID": 372,
-            "icon": "ability_hunter_pet_rhino",
-            "itemId": 54068,
-            "name": "Wooly White Rhino",
-            "spellid": 74918
-          },
-          {
-            "ID": 212,
-            "icon": "inv_misc_missilesmall_red",
-            "itemId": 49286,
-            "name": "X-51 Nether-Rocket X-TREME",
-            "spellid": 46199
           },
           {
             "ID": 266,

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -1,150 +1,7 @@
 [
   {
-    "id": "40fa67ae",
-    "name": "Mounts",
+    "name": "Limited Time",
     "subcats": [
-      {
-        "id": "d0982483",
-        "items": [
-          {
-            "ID": 268,
-            "icon": "ability_mount_drake_blue",
-            "itemId": 44178,
-            "name": "Albino Drake",
-            "spellid": 60025
-          },
-          {
-            "ID": 292,
-            "icon": "ability_hunter_pet_dragonhawk",
-            "itemId": 44842,
-            "name": "Red Dragonhawk",
-            "side": "H",
-            "spellid": 61997
-          },
-          {
-            "ID": 291,
-            "icon": "ability_hunter_pet_dragonhawk",
-            "itemId": 44843,
-            "name": "Blue Dragonhawk",
-            "side": "A",
-            "spellid": 61996
-          },
-          {
-            "ID": 521,
-            "icon": "ability_mount_pandarenkitemount_blue",
-            "itemId": 91802,
-            "name": "Jade Pandaren Kite",
-            "spellid": 133023
-          },
-          {
-            "ID": 549,
-            "icon": "ability_mount_dragonhawkarmorallliance",
-            "itemId": 98259,
-            "name": "Armored Blue Dragonhawk",
-            "side": "A",
-            "spellid": 142478
-          },
-          {
-            "ID": 548,
-            "icon": "ability_mount_dragonhawkarmorhorde",
-            "itemId": 98104,
-            "name": "Armored Red Dragonhawk",
-            "side": "H",
-            "spellid": 142266
-          },
-          {
-            "ID": 416,
-            "icon": "inv_misc_summerfest_braziergreen",
-            "itemId": 69226,
-            "name": "Felfire Hawk",
-            "spellid": 97501
-          },
-          {
-            "ID": 477,
-            "icon": "inv_bluegodcloudserpent",
-            "itemId": 87776,
-            "name": "Heavenly Azure Cloud Serpent",
-            "spellid": 127169
-          },
-          {
-            "ID": 1167,
-            "icon": "inv_infernalmounice",
-            "itemId": 137614,
-            "name": "Frostshard Infernal",
-            "spellid": 213350
-          },
-          {
-            "ID": 1191,
-            "icon": "ability_mount_fireravengodmountgreen",
-            "itemId": 163981,
-            "name": "Frenzied Feltalon",
-            "spellid": 280729
-          },
-          {
-            "ID": 1654,
-            "icon": "inv_riverotterlargemount02_white",
-            "itemId": 198654,
-            "name": "Otterworldly Ottuk Carrier",
-            "spellid": 376912
-          },
-          {
-            "ID": 664,
-            "icon": "ability_mount_drake_blue",
-            "itemId": 118676,
-            "name": "Emerald Drake",
-            "spellid": 175700
-          }
-        ],
-        "name": "Collect"
-      },
-      {
-        "id": "5f70e5b4",
-        "items": [
-          {
-            "ID": 1190,
-            "icon": "inv_horse2white",
-            "itemId": 163982,
-            "name": "Pureheart Courser",
-            "spellid": 280730
-          }
-        ],
-        "name": "Reputations"
-      },
-      {
-        "id": "e2d7702d",
-        "items": [
-          {
-            "ID": 845,
-            "icon": "ability_mount_shreddermount",
-            "itemId": 140500,
-            "name": "Mechanized Lumber Extractor",
-            "spellid": 223814
-          }
-        ],
-        "name": "Toys"
-      },
-      {
-        "id": "91888e4b",
-        "items": [
-          {
-            "ID": 679,
-            "icon": "inv_misc_key_06",
-            "itemId": 120968,
-            "name": "Chauffeured Mekgineer's Chopper",
-            "side": "A",
-            "spellid": 179245
-          },
-          {
-            "ID": 678,
-            "icon": "inv_misc_key_06",
-            "itemId": 122703,
-            "name": "Chauffeured Mechano-Hog",
-            "side": "H",
-            "spellid": 179244
-          }
-        ],
-        "name": "Heirlooms"
-      },
       {
         "items": [
           {
@@ -372,7 +229,174 @@
             "spellid": 446022
           }
         ],
-        "name": "Limited Time: Remix: Pandaria"
+        "name": "Remix: Pandaria"
+      },
+      {
+        "items": [
+          {
+            "ID": 125,
+            "icon": "ability_hunter_pet_turtle",
+            "itemId": 23720,
+            "name": "Riding Turtle",
+            "spellid": 30174
+          },
+          {
+            "ID": 2152,
+            "icon": "inv_goblinsurfboardmount_white",
+            "itemId": 221814,
+            "name": "Pearlescent Goblin Wave Shredder",
+            "spellid": 447413
+          }
+        ],
+        "name": "Trading Post: June"
+      }
+    ]
+  },
+  {
+    "id": "40fa67ae",
+    "name": "Mounts",
+    "subcats": [
+      {
+        "id": "d0982483",
+        "items": [
+          {
+            "ID": 268,
+            "icon": "ability_mount_drake_blue",
+            "itemId": 44178,
+            "name": "Albino Drake",
+            "spellid": 60025
+          },
+          {
+            "ID": 292,
+            "icon": "ability_hunter_pet_dragonhawk",
+            "itemId": 44842,
+            "name": "Red Dragonhawk",
+            "side": "H",
+            "spellid": 61997
+          },
+          {
+            "ID": 291,
+            "icon": "ability_hunter_pet_dragonhawk",
+            "itemId": 44843,
+            "name": "Blue Dragonhawk",
+            "side": "A",
+            "spellid": 61996
+          },
+          {
+            "ID": 521,
+            "icon": "ability_mount_pandarenkitemount_blue",
+            "itemId": 91802,
+            "name": "Jade Pandaren Kite",
+            "spellid": 133023
+          },
+          {
+            "ID": 549,
+            "icon": "ability_mount_dragonhawkarmorallliance",
+            "itemId": 98259,
+            "name": "Armored Blue Dragonhawk",
+            "side": "A",
+            "spellid": 142478
+          },
+          {
+            "ID": 548,
+            "icon": "ability_mount_dragonhawkarmorhorde",
+            "itemId": 98104,
+            "name": "Armored Red Dragonhawk",
+            "side": "H",
+            "spellid": 142266
+          },
+          {
+            "ID": 416,
+            "icon": "inv_misc_summerfest_braziergreen",
+            "itemId": 69226,
+            "name": "Felfire Hawk",
+            "spellid": 97501
+          },
+          {
+            "ID": 477,
+            "icon": "inv_bluegodcloudserpent",
+            "itemId": 87776,
+            "name": "Heavenly Azure Cloud Serpent",
+            "spellid": 127169
+          },
+          {
+            "ID": 1167,
+            "icon": "inv_infernalmounice",
+            "itemId": 137614,
+            "name": "Frostshard Infernal",
+            "spellid": 213350
+          },
+          {
+            "ID": 1191,
+            "icon": "ability_mount_fireravengodmountgreen",
+            "itemId": 163981,
+            "name": "Frenzied Feltalon",
+            "spellid": 280729
+          },
+          {
+            "ID": 1654,
+            "icon": "inv_riverotterlargemount02_white",
+            "itemId": 198654,
+            "name": "Otterworldly Ottuk Carrier",
+            "spellid": 376912
+          },
+          {
+            "ID": 664,
+            "icon": "ability_mount_drake_blue",
+            "itemId": 118676,
+            "name": "Emerald Drake",
+            "spellid": 175700
+          }
+        ],
+        "name": "Collect"
+      },
+      {
+        "id": "5f70e5b4",
+        "items": [
+          {
+            "ID": 1190,
+            "icon": "inv_horse2white",
+            "itemId": 163982,
+            "name": "Pureheart Courser",
+            "spellid": 280730
+          }
+        ],
+        "name": "Reputations"
+      },
+      {
+        "id": "e2d7702d",
+        "items": [
+          {
+            "ID": 845,
+            "icon": "ability_mount_shreddermount",
+            "itemId": 140500,
+            "name": "Mechanized Lumber Extractor",
+            "spellid": 223814
+          }
+        ],
+        "name": "Toys"
+      },
+      {
+        "id": "91888e4b",
+        "items": [
+          {
+            "ID": 679,
+            "icon": "inv_misc_key_06",
+            "itemId": 120968,
+            "name": "Chauffeured Mekgineer's Chopper",
+            "side": "A",
+            "spellid": 179245
+          },
+          {
+            "ID": 678,
+            "icon": "inv_misc_key_06",
+            "itemId": 122703,
+            "name": "Chauffeured Mechano-Hog",
+            "side": "H",
+            "spellid": 179244
+          }
+        ],
+        "name": "Heirlooms"
       }
     ]
   },
@@ -7088,13 +7112,6 @@
             "spellid": 64731
           },
           {
-            "ID": 125,
-            "icon": "ability_hunter_pet_turtle",
-            "itemId": 23720,
-            "name": "Riding Turtle",
-            "spellid": 30174
-          },
-          {
             "ID": 982,
             "icon": "inv_ammo_bullet_07",
             "itemId": 152912,
@@ -8388,7 +8405,6 @@
           {
             "ID": 1737,
             "icon": "inv_sporebatrock_stoneorange",
-            "itemId": "205208",
             "name": "Sandy Shalewing",
             "notObtainable": true,
             "spellid": 408654
@@ -8422,6 +8438,41 @@
           }
         ],
         "name": "Secrets of Azeroth"
+      },
+      {
+        "items": [
+          {
+            "ID": 1292,
+            "icon": "inv_stormpikebattlecharger",
+            "itemId": 172022,
+            "name": "Stormpike Battle Ram",
+            "side": "A",
+            "spellid": 308250
+          },
+          {
+            "ID": 1285,
+            "icon": "inv_frostwolfhowler",
+            "itemId": 172023,
+            "name": "Frostwolf Snarler",
+            "side": "H",
+            "spellid": 306421
+          },
+          {
+            "ID": 293,
+            "icon": "ability_hunter_pet_dragonhawk",
+            "itemId": 186469,
+            "name": "Illidari Doomhawk",
+            "spellid": 62048
+          },
+          {
+            "ID": 1798,
+            "icon": "5260432",
+            "itemId": 208572,
+            "name": "Azure Worldchiller",
+            "spellid": 420097
+          }
+        ],
+        "name": "Anniversary"
       }
     ]
   },
@@ -8436,12 +8487,14 @@
             "ID": 1312,
             "icon": "inv_murlocmount",
             "name": "Gargantuan Grrloc",
+            "notObtainable": true,
             "spellid": 315132
           },
           {
             "ID": 1662,
             "icon": "inv_beetleprimalmount",
             "name": "Telix the Stormhorn",
+            "notObtainable": true,
             "spellid": 381529
           },
           {
@@ -8706,13 +8759,6 @@
             "spellid": 245725
           },
           {
-            "ID": 1458,
-            "icon": "3939983",
-            "name": "Wandering Ancient",
-            "notObtainable": true,
-            "spellid": 348162
-          },
-          {
             "ID": 1517,
             "icon": "4054329",
             "name": "Bound Blizzard",
@@ -8720,6 +8766,18 @@
           }
         ],
         "name": "Blizzcon"
+      },
+      {
+        "items": [
+          {
+            "ID": 1458,
+            "icon": "3939983",
+            "name": "Wandering Ancient",
+            "notObtainable": true,
+            "spellid": 348162
+          }
+        ],
+        "name": "Player Vote"
       },
       {
         "id": "259f733d",
@@ -8788,44 +8846,14 @@
         "id": "435bf98f",
         "items": [
           {
-            "ID": 1292,
-            "icon": "inv_stormpikebattlecharger",
-            "itemId": 172022,
-            "name": "Stormpike Battle Ram",
-            "side": "A",
-            "spellid": 308250
-          },
-          {
-            "ID": 1285,
-            "icon": "inv_frostwolfhowler",
-            "itemId": 172023,
-            "name": "Frostwolf Snarler",
-            "side": "H",
-            "spellid": 306421
-          },
-          {
-            "ID": 293,
-            "icon": "ability_hunter_pet_dragonhawk",
-            "itemId": 186469,
-            "name": "Illidari Doomhawk",
-            "spellid": 62048
-          },
-          {
             "ID": 1424,
             "icon": "3753812",
             "name": "Snowstorm",
             "notObtainable": true,
             "spellid": 341821
-          },
-          {
-            "ID": 1798,
-            "icon": "5260432",
-            "itemId": 208572,
-            "name": "Azure Worldchiller",
-            "spellid": 420097
           }
         ],
-        "name": "Anniversaries"
+        "name": "Blizzard Anniversary"
       },
       {
         "items": [
@@ -9323,15 +9351,6 @@
             "notObtainable": true,
             "notReleased": true,
             "spellid": 446352
-          },
-          {
-            "ID": 2152,
-            "icon": "inv_goblinsurfboardmount_white",
-            "itemId": 221814,
-            "name": "Pearlescent Goblin Wave Shredder",
-            "notObtainable": true,
-            "notReleased": true,
-            "spellid": 447413
           },
           {
             "ID": 2186,

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -1,5 +1,44 @@
 [
   {
+    "name": "Limited Time",
+    "subcats": [
+      {
+        "items": [
+          {
+            "ID": 4579,
+            "creatureId": 223785,
+            "icon": "inv_yakpet",
+            "itemId": 221817,
+            "name": "Muskpaw Calf",
+            "spellid": 449550
+          },
+          {
+            "ID": 4580,
+            "creatureId": 223810,
+            "icon": "inv_celestialpandarenserpentpet_gold",
+            "itemId": 221818,
+            "name": "Astral Emperor's Serpentling",
+            "spellid": 449626
+          }
+        ],
+        "name": "Remix: Pandaria"
+      },
+      {
+        "items": [
+          {
+            "ID": 4548,
+            "creatureId": 223316,
+            "icon": "inv_ogrepet",
+            "itemId": 223145,
+            "name": "Marrlok",
+            "spellid": 448355
+          }
+        ],
+        "name": "Trading Post: June"
+      }
+    ]
+  },
+  {
     "name": "",
     "subcats": [
       {
@@ -235,27 +274,6 @@
           }
         ],
         "name": "Achievement"
-      },
-      {
-        "items": [
-          {
-            "ID": 4579,
-            "creatureId": 223785,
-            "icon": "inv_yakpet",
-            "itemId": 221817,
-            "name": "Muskpaw Calf",
-            "spellid": 449550
-          },
-          {
-            "ID": 4580,
-            "creatureId": 223810,
-            "icon": "inv_celestialpandarenserpentpet_gold",
-            "itemId": 221818,
-            "name": "Astral Emperor's Serpentling",
-            "spellid": 449626
-          }
-        ],
-        "name": "Limited Time: Remix: Pandaria"
       }
     ]
   },
@@ -11177,16 +11195,6 @@
             "notObtainable": true,
             "notReleased": true,
             "spellid": 433098
-          },
-          {
-            "ID": 4548,
-            "creatureId": 223316,
-            "icon": "inv_ogrepet",
-            "itemId": 223145,
-            "name": "Marrlok",
-            "notObtainable": true,
-            "notReleased": true,
-            "spellid": 448355
           },
           {
             "ID": 4565,

--- a/static/data/titles.json
+++ b/static/data/titles.json
@@ -1,5 +1,36 @@
 [
   {
+    "name": "Limited Time",
+    "subcats": [
+      {
+        "items": [
+          {
+            "icon": "ability_evoker_timedilation",
+            "id": 40223,
+            "name": "Timerunner",
+            "titleId": 551,
+            "type": "achievement"
+          },
+          {
+            "icon": "achievement_boss_garrosh",
+            "id": 19961,
+            "name": "Paragon of the Mists",
+            "titleId": 552,
+            "type": "achievement"
+          },
+          {
+            "icon": "achievement_raid_terraceofendlessspring04",
+            "id": 20007,
+            "name": "Claw of Eternus",
+            "titleId": 553,
+            "type": "achievement"
+          }
+        ],
+        "name": "Remix: Pandaria"
+      }
+    ]
+  },
+  {
     "id": "fffffffe",
     "name": "Titles",
     "subcats": [
@@ -239,39 +270,6 @@
           }
         ],
         "name": "Brawler's Guild"
-      },
-      {
-        "items": [
-          {
-            "icon": "inv_celestialpandarenserpentpet_gold",
-            "id": 40226,
-            "name": "Mistrunner",
-            "titleId": 539,
-            "type": "achievement"
-          },
-          {
-            "icon": "achievement_scenario_greenstone",
-            "id": 20004,
-            "name": "Timerunner",
-            "titleId": 551,
-            "type": "achievement"
-          },
-          {
-            "icon": "achievement_boss_garrosh",
-            "id": 40227,
-            "name": "Paragon of the Mists",
-            "titleId": 552,
-            "type": "achievement"
-          },
-          {
-            "icon": "achievement_raid_terraceofendlessspring04",
-            "id": 20007,
-            "name": "Claw of Eternus",
-            "titleId": 553,
-            "type": "achievement"
-          }
-        ],
-        "name": "Limited Time: Remix: Pandaria"
       }
     ]
   },
@@ -1646,7 +1644,12 @@
             "side": "H",
             "titleId": 206,
             "type": "achievement"
-          },
+          }
+        ],
+        "name": "Scenarios"
+      },
+      {
+        "items": [
           {
             "icon": "achievement_challengemode_platinum",
             "id": 9589,
@@ -1669,7 +1672,7 @@
             "type": "achievement"
           }
         ],
-        "name": "Scenarios"
+        "name": "Proving Grounds"
       }
     ]
   },

--- a/static/data/toys.json
+++ b/static/data/toys.json
@@ -1,5 +1,75 @@
 [
   {
+    "name": "Limited Time",
+    "subcats": [
+      {
+        "id": "6edf78f8",
+        "items": [
+          {
+            "ID": 1467,
+            "icon": "monk_stance_redcrane",
+            "itemId": 217724,
+            "name": "Kindness of Chi-ji"
+          },
+          {
+            "ID": 1468,
+            "icon": "monk_stance_drunkenox",
+            "itemId": 217726,
+            "name": "Fortitude of Niuzao"
+          },
+          {
+            "ID": 1469,
+            "icon": "monk_stance_whitetiger",
+            "itemId": 217723,
+            "name": "Fury of Xuen"
+          },
+          {
+            "ID": 1470,
+            "icon": "monk_stance_wiseserpent",
+            "itemId": 217725,
+            "name": "Essence of Yu'lon"
+          },
+          {
+            "ID": 1476,
+            "icon": "inv_misc_herb_talandrasrose",
+            "itemId": 220777,
+            "name": "Cherry Blossom Trail"
+          },
+          {
+            "ID": 359,
+            "icon": "inv_misc_orb_03",
+            "itemId": 89205,
+            "name": "Mini Mana Bomb"
+          }
+        ],
+        "name": "Remix: Pandaria"
+      },
+      {
+        "items": [
+          {
+            "ID": 1454,
+            "icon": "inv_misc_1h_umbrella_b_01",
+            "itemId": 212524,
+            "name": "Delicate Crimson Parasol"
+          },
+          {
+            "ID": 1471,
+            "icon": "inv_fishingchair",
+            "itemId": 218112,
+            "name": "Colorful Beach Chair"
+          },
+          {
+            "ID": 1475,
+            "icon": "inv_firearm_2h_waterblaster_c_01",
+            "itemId": 220692,
+            "name": "X-treme Water Blaster Display"
+          }
+        ],
+        "name": "Trading Post: June"
+      }
+    ]
+  },
+  {
     "id": "8610320b",
     "items": [],
     "name": "Toys",
@@ -121,42 +191,6 @@
           }
         ],
         "name": "Racial"
-      },
-      {
-        "id": "6edf78f8",
-        "items": [
-          {
-            "ID": 1467,
-            "icon": "monk_stance_redcrane",
-            "itemId": 217724,
-            "name": "Kindness of Chi-ji"
-          },
-          {
-            "ID": 1468,
-            "icon": "monk_stance_drunkenox",
-            "itemId": 217726,
-            "name": "Fortitude of Niuzao"
-          },
-          {
-            "ID": 1469,
-            "icon": "monk_stance_whitetiger",
-            "itemId": 217723,
-            "name": "Fury of Xuen"
-          },
-          {
-            "ID": 1470,
-            "icon": "monk_stance_wiseserpent",
-            "itemId": 217725,
-            "name": "Essence of Yu'lon"
-          },
-          {
-            "ID": 1476,
-            "icon": "inv_misc_herb_talandrasrose",
-            "itemId": 220777,
-            "name": "Cherry Blossom Trail"
-          }
-        ],
-        "name": "Limited Time: Remix: Pandaria"
       }
     ]
   },
@@ -4016,19 +4050,6 @@
           }
         ],
         "name": "Treasure"
-      },
-      {
-        "id": "3c01691b",
-        "items": [
-          {
-            "ID": 359,
-            "icon": "inv_misc_orb_03",
-            "itemId": 89205,
-            "name": "Mini Mana Bomb",
-            "notObtainable": true
-          }
-        ],
-        "name": "Pre-launch Event"
       }
     ]
   },
@@ -6605,7 +6626,7 @@
             "name": "Foam Sword Rack"
           }
         ],
-        "name": "Trading Post Re-releases"
+        "name": "Trading Post Re-Releases"
       },
       {
         "id": "c1d734dd",
@@ -6635,34 +6656,10 @@
             "name": "Delicate Jade Parasol"
           },
           {
-            "ID": 1454,
-            "icon": "inv_misc_1h_umbrella_b_01",
-            "itemId": 212524,
-            "name": "Delicate Crimson Parasol",
-            "notObtainable": true,
-            "notReleased": true
-          },
-          {
             "ID": 1455,
             "icon": "inv_misc_1h_umbrella_b_01",
             "itemId": 212525,
             "name": "Delicate Ebony Parasol",
-            "notObtainable": true,
-            "notReleased": true
-          },
-          {
-            "ID": 1471,
-            "icon": "inv_fishingchair",
-            "itemId": 218112,
-            "name": "Colorful Beach Chair",
-            "notObtainable": true,
-            "notReleased": true
-          },
-          {
-            "ID": 1475,
-            "icon": "inv_firearm_2h_waterblaster_c_01",
-            "itemId": 220692,
-            "name": "X-treme Water Blaster Display",
             "notObtainable": true,
             "notReleased": true
           }


### PR DESCRIPTION
- Marked all content for June Trading Post as obtainable.
- Overhauled Limited Time system:
    - Every section with limited time content now has its own category for this limited time stuff, rather than it just being tossed under general. I hope this new way of doing it will make it more clear what players might want to act upon asap, it should be fairly easy to maintain.
    - Expanded Limited Time section to also include Trading Post items for better clarity.
    
![image](https://github.com/kevinclement/SimpleArmory/assets/150586735/bbe95d1c-9b4f-4312-b372-a0ceba4f36fd)

- Re-categorized and moved a few mounts
    - WoW Anniversary mounts are now under 'World Events' rather than 'Promotion' as they are mounts returning every year just like other world events.
    - Moved Wandering Ancient from 'Blizzcon' to 'Player Vote' as it had nothing to do with blizzcon but didn't fit into any other category.
    - Moved Snowstorm from 'Anniversary' to 'Blizzard Anniversary' as it was only ever available through a store bundle (unlike the other anniversary mounts).
    - Moved the 2 BMAH TCG mounts back to TCG and renamed 'Trading Card Game' to 'Trading Card Game / Auction House' to reflect that they can be sold on the AH (as that's also where the majority of TCG items are primarily sold).
    
    
 - Fixed a few issues
   - Removed 'Mistrunner' title as it was never made obtainable.
   - Corrected achievement listed for 'Timerunner' title.
   - Removed the item ID from the 'Sandy Shalewing' mount as the item to learn it was never released (displays the spell now)