### PR TITLE
Fix tooltip for Calescent Shalewing

### DIFF
--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -417,7 +417,6 @@
           {
             "ID": 1733,
             "icon": "inv_sporebatrock_yellow",
-            "itemId": 205206,
             "name": "Calescent Shalewing",
             "spellid": 408648
           },


### PR DESCRIPTION
Hi there, thanks for the excellent tool.  I resubbed late last year and I've been very happy using SA as a checklist for all the stuff I want to catch up on collecting.

I discovered this week that the tooltip for Calescent Shalewing wasn't working, a known previous issue originally mentioned in #610.  It looks like this was fixed shortly after (didn't see exactly where) and then broke again at some point.  Sandy Shalewing was re-fixed in #622 but it looks like Calescent was overlooked at that time; this PR resolves that.

This commit resolves the issue for me locally both with `npm run dev` and after building and previewing the build, but if I've overlooked anything that needs to be fixed, please let me know.  I copied the solution from #622 pretty naively without actually digging into any of the actually logic of the app.

Thanks again!