### PR TITLE
September Trading Post & TWW Corrections

### DIFF
--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -571,6 +571,46 @@
             {
               "items": [
                 {
+                  "icon": "spell_misc_emotionhappy",
+                  "id": 40524,
+                  "points": 5,
+                  "title": "Good Deed Delver"
+                }
+              ],
+              "name": "World"
+            },
+            {
+              "items": [
+                {
+                  "icon": "ability_warrior_titansgrip",
+                  "id": 40507,
+                  "points": 5,
+                  "title": "Hanging Tight"
+                },
+                {
+                  "icon": "ability_warrior_titansgrip",
+                  "id": 40623,
+                  "points": 5,
+                  "title": "I Only Need One Trip"
+                },
+                {
+                  "icon": "garrison_building_workshop",
+                  "id": 40630,
+                  "points": 10,
+                  "title": "For the Collective"
+                },
+                {
+                  "icon": "achievement_cooking_masterofthegrill",
+                  "id": 40731,
+                  "points": 5,
+                  "title": "Panhandled"
+                }
+              ],
+              "name": "Ringing Deeps"
+            },
+            {
+              "items": [
+                {
                   "icon": "inv_fishing_frenziedfangtooth",
                   "id": 40082,
                   "points": 5,
@@ -613,52 +653,27 @@
                   "title": "Life on the Farm"
                 },
                 {
-                  "icon": "ability_warrior_titansgrip",
-                  "id": 40507,
-                  "points": 5,
-                  "title": "Hanging Tight"
-                },
-                {
-                  "icon": "spell_misc_emotionhappy",
-                  "id": 40524,
-                  "points": 5,
-                  "title": "Good Deed Delver"
-                },
-                {
                   "icon": "inv_10_dungeonjewelry_explorer_trinket_1compass_color5",
                   "id": 40618,
                   "points": 5,
                   "title": "Lost and Found"
                 },
                 {
-                  "icon": "ability_warrior_titansgrip",
-                  "id": 40623,
-                  "points": 5,
-                  "title": "I Only Need One Trip"
-                },
-                {
-                  "icon": "garrison_building_workshop",
-                  "id": 40630,
+                  "icon": "spell_holy_weaponmastery",
+                  "id": 40729,
                   "points": 10,
-                  "title": "For the Collective"
-                },
+                  "title": "Light's Gambit Champion"
+                }
+              ],
+              "name": "Hallowfall"
+            },
+            {
+              "items": [
                 {
                   "icon": "inv_misc_noodle_cart_intermediate_level",
                   "id": 40727,
                   "points": 5,
                   "title": "Skittershaw Spin"
-                },
-                {
-                  "icon": "spell_holy_weaponmastery",
-                  "id": 40729,
-                  "points": 10,
-                  "title": "Light's Gambit Champion"
-                },
-                {
-                  "icon": "achievement_cooking_masterofthegrill",
-                  "id": 40731,
-                  "points": 5,
-                  "title": "Panhandled"
                 },
                 {
                   "icon": "ui_notoriety_thegeneral",
@@ -679,7 +694,7 @@
                   "title": "Leave it to Weaver"
                 }
               ],
-              "name": "World"
+              "name": "Azj-Kahet"
             },
             {
               "id": "8b73aed1",

--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -8538,6 +8538,12 @@
             {
               "items": [
                 {
+                  "icon": "achievement_level_10",
+                  "id": 40455,
+                  "points": 10,
+                  "title": "Buddy System"
+                },
+                {
                   "icon": "achievement_level_20",
                   "id": 40450,
                   "points": 10,
@@ -8548,12 +8554,6 @@
                   "id": 40451,
                   "points": 10,
                   "title": "Buddy System III"
-                },
-                {
-                  "icon": "achievement_level_10",
-                  "id": 40455,
-                  "points": 10,
-                  "title": "Buddy System"
                 },
                 {
                   "icon": "achievement_level_40",
@@ -46824,12 +46824,14 @@
                 {
                   "icon": "achievement_garrison_horde_pve",
                   "id": 11218,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "There's a Boss In There"
                 },
                 {
                   "icon": "inv_jewelry_ring_65",
                   "id": 9493,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "They Burn, Burn, Burn"
                 }
@@ -46842,12 +46844,14 @@
                 {
                   "icon": "inv_relics_hourglass",
                   "id": 11181,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Legion Keymaster"
                 },
                 {
                   "icon": "inv_relics_hourglass",
                   "id": 13075,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Battle for Azeroth Keymaster"
                 }
@@ -47146,216 +47150,252 @@
                 {
                   "icon": "achievement_challengemode_ogreslagmines_hourglass",
                   "id": 8875,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Bloodmaul Slag Mines Challenger"
                 },
                 {
                   "icon": "achievement_challengemode_ogreslagmines_bronze",
                   "id": 8876,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Bloodmaul Slag Mines: Bronze"
                 },
                 {
                   "icon": "achievement_challengemode_ogreslagmines_silver",
                   "id": 8877,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Bloodmaul Slag Mines: Silver"
                 },
                 {
                   "icon": "achievement_challengemode_ogreslagmines_gold",
                   "id": 8878,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Bloodmaul Slag Mines: Gold"
                 },
                 {
                   "icon": "achievement_challengemode_auchindoun_hourglass",
                   "id": 8879,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Auchindoun Challenger"
                 },
                 {
                   "icon": "achievement_challengemode_auchindoun_bronze",
                   "id": 8880,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Auchindoun: Bronze"
                 },
                 {
                   "icon": "achievement_challengemode_auchindoun_silver",
                   "id": 8881,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Auchindoun: Silver"
                 },
                 {
                   "icon": "achievement_challengemode_auchindoun_gold",
                   "id": 8882,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Auchindoun: Gold"
                 },
                 {
                   "icon": "achievement_challengemode_everbloom_hourglass",
                   "id": 9001,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "The Everbloom Challenger"
                 },
                 {
                   "icon": "achievement_challengemode_everbloom_bronze",
                   "id": 9002,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "The Everbloom: Bronze"
                 },
                 {
                   "icon": "achievement_challengemode_everbloom_silver",
                   "id": 9003,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "The Everbloom: Silver"
                 },
                 {
                   "icon": "achievement_challengemode_everbloom_gold",
                   "id": 9004,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "The Everbloom: Gold"
                 },
                 {
                   "icon": "achievement_challengemode_shadowmoonhideout_hourglass",
                   "id": 8883,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Shadowmoon Burial Grounds Challenger"
                 },
                 {
                   "icon": "achievement_challengemode_shadowmoonhideout_bronze",
                   "id": 8884,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Shadowmoon Burial Grounds: Bronze"
                 },
                 {
                   "icon": "achievement_challengemode_shadowmoonhideout_silver",
                   "id": 8885,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Shadowmoon Burial Grounds: Silver"
                 },
                 {
                   "icon": "achievement_challengemode_shadowmoonhideout_gold",
                   "id": 8886,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Shadowmoon Burial Grounds: Gold"
                 },
                 {
                   "icon": "achievement_challengemode_blackrockdocks_hourglass",
                   "id": 8997,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Iron Docks Challenger"
                 },
                 {
                   "icon": "achievement_challengemode_blackrockdocks_bronze",
                   "id": 8998,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Iron Docks: Bronze"
                 },
                 {
                   "icon": "achievement_challengemode_blackrockdocks_silver",
                   "id": 8999,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Iron Docks: Silver"
                 },
                 {
                   "icon": "achievement_challengemode_blackrockdocks_gold",
                   "id": 9000,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Iron Docks: Gold"
                 },
                 {
                   "icon": "achievement_challengemode_arakkoaspires_hourglass",
                   "id": 8871,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Skyreach Challenger"
                 },
                 {
                   "icon": "achievement_challengemode_arakkoaspires_bronze",
                   "id": 8872,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Skyreach: Bronze"
                 },
                 {
                   "icon": "achievement_challengemode_seigeofniuzaotemple_silver",
                   "id": 8873,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Skyreach: Silver"
                 },
                 {
                   "icon": "achievement_challengemode_seigeofniuzaotemple_gold",
                   "id": 8874,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Skyreach: Gold"
                 },
                 {
                   "icon": "achievement_challengemode_blackrockdepot_hourglass",
                   "id": 8887,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Grimrail Depot Challenger"
                 },
                 {
                   "icon": "achievement_challengemode_blackrockdepot_bronze",
                   "id": 8888,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Grimrail Depot: Bronze"
                 },
                 {
                   "icon": "achievement_challengemode_blackrockdepot_silver",
                   "id": 8889,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Grimrail Depot: Silver"
                 },
                 {
                   "icon": "achievement_challengemode_blackrockdepot_gold",
                   "id": 8890,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Grimrail Depot: Gold"
                 },
                 {
                   "icon": "achievement_challengemode_upperbrspire_hourglass",
                   "id": 8891,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Upper Blackrock Spire Challenger"
                 },
                 {
                   "icon": "achievement_challengemode_upperbrspire_bronze",
                   "id": 8892,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Upper Blackrock Spire: Bronze"
                 },
                 {
                   "icon": "achievement_challengemode_upperbrspire_silver",
                   "id": 8893,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Upper Blackrock Spire: Silver"
                 },
                 {
                   "icon": "achievement_challengemode_upperbrspire_gold",
                   "id": 8894,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Upper Blackrock Spire: Gold"
                 },
                 {
                   "icon": "achievement_guildperk_honorablemention",
                   "id": 8895,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Challenge Warlord"
                 },
                 {
                   "icon": "achievement_challengemode_bronze",
                   "id": 8897,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Challenge Warlord: Bronze"
                 },
                 {
                   "icon": "achievement_challengemode_silver",
                   "id": 8898,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Challenge Warlord: Silver"
                 },
                 {
                   "icon": "achievement_challengemode_gold",
                   "id": 8899,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Challenge Warlord: Gold"
                 }
@@ -47368,17 +47408,19 @@
                 {
                   "icon": "Achievement_Boss_LadyVashj",
                   "id": 5285,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Old Faithful"
                 },
                 {
                   "icon": "achievement_dungeon_throne-of-the-tides_ozumat",
                   "id": 5286,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Prince of Tides"
                 }
               ],
-              "name": "[R]Throne of the Tides"
+              "name": "Throne of the Tides"
             }
           ]
         },

--- a/static/data/factions.json
+++ b/static/data/factions.json
@@ -11,16 +11,28 @@
   {
     "factions": [
       {
-        "id": 2570,
-        "name": "Hallowfall Arathi"
+        "id": 2590,
+        "name": "Council of Dornogal",
+        "renown": {
+          "max": 25,
+          "step": 2500
+        }
       },
       {
-        "id": 2579,
-        "name": "zzOldDelves: Season 1"
+        "id": 2570,
+        "name": "Hallowfall Arathi",
+        "renown": {
+          "max": 25,
+          "step": 2500
+        }
       },
       {
         "id": 2594,
-        "name": "The Assembly of the Deeps"
+        "name": "The Assembly of the Deeps",
+        "renown": {
+          "max": 25,
+          "step": 2500
+        }
       },
       {
         "id": 2601,

--- a/static/data/heirlooms.json
+++ b/static/data/heirlooms.json
@@ -9,8 +9,8 @@
             "ID": 986,
             "icon": "inv_10_dungeonjewelry_primalist_ring_2_earth",
             "itemId": 219325,
-            "notObtainable": true,
-            "name": "Band of Radiant Echoes"
+            "name": "Band of Radiant Echoes",
+            "notObtainable": true
           }
         ],
         "name": "Pre-Patch Event"

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -153,35 +153,21 @@
       {
         "items": [
           {
-            "ID": 376,
-            "icon": "ability_mount_celestialhorse",
-            "itemId": 54811,
-            "name": "Celestial Steed",
-            "spellid": 75614
+            "ID": 2238,
+            "icon": "inv_treasurebasiliskmount_tan",
+            "itemId": 226040,
+            "name": "Plunderlord's Golden Crocolisk",
+            "spellid": 457650
           },
           {
-            "ID": 454,
-            "icon": "inv_lavahorse",
-            "itemId": 118515,
-            "name": "Cindermane Charger",
-            "spellid": 171847
-          },
-          {
-            "ID": 2201,
-            "icon": "inv_alliancewolfmount2_white",
-            "itemId": 223469,
-            "name": "Sentinel War Wolf",
-            "spellid": 449140
-          },
-          {
-            "ID": 2198,
-            "icon": "inv_nightsaberhordemount_red",
-            "itemId": 223449,
-            "name": "Kor'kron Warsaber",
-            "spellid": 449126
+            "ID": 2239,
+            "icon": "inv_treasurebasiliskmount_green",
+            "itemId": 226041,
+            "name": "Keg Leg's Radiant Crocolisk",
+            "spellid": 457654
           }
         ],
-        "name": "Trading Post: August"
+        "name": "Trading Post: September"
       },
       {
         "items": [
@@ -259,6 +245,7 @@
             "icon": "inv_molemount_brown",
             "itemId": 225548,
             "name": "Wick",
+            "notObtainable": true,
             "spellid": 449264
           },
           {
@@ -378,12 +365,7 @@
             "itemId": 223318,
             "name": "Dauntless Imperial Lynx",
             "spellid": 448979
-          }
-        ],
-        "name": "Zone Event"
-      },
-      {
-        "items": [
+          },
           {
             "ID": 2159,
             "icon": "inv_dwarvenmechboss_bronze",
@@ -392,7 +374,7 @@
             "spellid": 448188
           }
         ],
-        "name": "Awakening the Machine"
+        "name": "Zone Feature"
       },
       {
         "items": [
@@ -8614,6 +8596,13 @@
             "spellid": 49322
           },
           {
+            "ID": 376,
+            "icon": "ability_mount_celestialhorse",
+            "itemId": 54811,
+            "name": "Celestial Steed",
+            "spellid": 75614
+          },
+          {
             "ID": 382,
             "icon": "ability_mount_rocketmount2",
             "itemId": 54860,
@@ -8649,6 +8638,13 @@
             "itemId": 76755,
             "name": "Tyrael's Charger",
             "spellid": 107203
+          },
+          {
+            "ID": 454,
+            "icon": "inv_lavahorse",
+            "itemId": 118515,
+            "name": "Cindermane Charger",
+            "spellid": 171847
           },
           {
             "ID": 1051,
@@ -8813,6 +8809,20 @@
             "spellid": 448851
           },
           {
+            "ID": 2201,
+            "icon": "inv_alliancewolfmount2_white",
+            "itemId": 223469,
+            "name": "Sentinel War Wolf",
+            "spellid": 449140
+          },
+          {
+            "ID": 2198,
+            "icon": "inv_nightsaberhordemount_red",
+            "itemId": 223449,
+            "name": "Kor'kron Warsaber",
+            "spellid": 449126
+          },
+          {
             "ID": 799,
             "icon": "inv_infernalmountlava",
             "itemId": 137615,
@@ -8901,24 +8911,6 @@
             "notObtainable": true,
             "notReleased": true,
             "spellid": 359380
-          },
-          {
-            "ID": 2238,
-            "icon": "inv_treasurebasiliskmount_tan",
-            "itemId": 226040,
-            "name": "Plunderlord's Golden Crocolisk",
-            "notObtainable": true,
-            "notReleased": true,
-            "spellid": 457650
-          },
-          {
-            "ID": 2239,
-            "icon": "inv_treasurebasiliskmount_green",
-            "itemId": 226041,
-            "name": "Keg Leg's Radiant Crocolisk",
-            "notObtainable": true,
-            "notReleased": true,
-            "spellid": 457654
           },
           {
             "ID": 2240,

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -1242,18 +1242,18 @@
             "spellid": 354355
           },
           {
-            "ID": 1551,
-            "icon": "ability_mount_progenitorjellyfish_red",
-            "itemId": 187673,
-            "name": "Cryptic Aurelid",
-            "spellid": 359381
-          },
-          {
             "ID": 1446,
             "icon": "inv_brokermount_brass",
             "itemId": 186637,
             "name": "Tazavesh Gearglider",
             "spellid": 346554
+          },
+          {
+            "ID": 1551,
+            "icon": "ability_mount_progenitorjellyfish_red",
+            "itemId": 187673,
+            "name": "Cryptic Aurelid",
+            "spellid": 359381
           },
           {
             "ID": 1443,
@@ -1888,7 +1888,7 @@
             "spellid": 344575
           }
         ],
-        "name": "Oozing Necroray Egg"
+        "name": "Maldraxxus Callings"
       },
       {
         "items": [
@@ -2614,6 +2614,13 @@
             "spellid": 296788
           },
           {
+            "ID": 1282,
+            "icon": "inv_nzothserpentmount_black",
+            "itemId": 174654,
+            "name": "Black Serpent of N'Zoth",
+            "spellid": 305182
+          },
+          {
             "ID": 933,
             "icon": "inv_trilobitemount_black",
             "itemId": 161215,
@@ -2647,13 +2654,6 @@
             "itemId": 174861,
             "name": "Wriggling Parasite",
             "spellid": 316343
-          },
-          {
-            "ID": 1282,
-            "icon": "inv_nzothserpentmount_black",
-            "itemId": 174654,
-            "name": "Black Serpent of N'Zoth",
-            "spellid": 305182
           },
           {
             "ID": 1326,
@@ -3575,26 +3575,13 @@
       {
         "id": "13a5b522",
         "items": [
-          {
-            "ID": 773,
-            "icon": "inv_moosemount2nightmare",
-            "itemId": 141216,
-            "name": "Grove Defiler",
-            "spellid": 193007
-          },
+
           {
             "ID": 804,
             "icon": "inv_ratmount",
             "itemId": 138387,
             "name": "Ratstallion",
             "spellid": 215558
-          },
-          {
-            "ID": 846,
-            "icon": "inv_mount_hippogryph_arcane",
-            "itemId": 141217,
-            "name": "Leyfeather Hippogryph",
-            "spellid": 225765
           },
           {
             "ID": 775,
@@ -3613,18 +3600,32 @@
             "spellid": 204166
           },
           {
-            "ID": 972,
-            "icon": "inv_felhound3_shadow_mount",
-            "itemId": 152815,
-            "name": "Antoran Gloomhound",
-            "spellid": 253087
-          },
-          {
             "ID": 986,
             "icon": "inv_argustalbukmount_felred",
             "itemId": 153041,
             "name": "Bleakhoof Ruinstrider",
             "spellid": 254260
+          },
+          {
+            "ID": 846,
+            "icon": "inv_mount_hippogryph_arcane",
+            "itemId": 141217,
+            "name": "Leyfeather Hippogryph",
+            "spellid": 225765
+          },
+          {
+            "ID": 773,
+            "icon": "inv_moosemount2nightmare",
+            "itemId": 141216,
+            "name": "Grove Defiler",
+            "spellid": 193007
+          },
+          {
+            "ID": 972,
+            "icon": "inv_felhound3_shadow_mount",
+            "itemId": 152815,
+            "name": "Antoran Gloomhound",
+            "spellid": 253087
           }
         ],
         "name": "Achievement"
@@ -3900,6 +3901,13 @@
             "spellid": 213134
           },
           {
+            "ID": 633,
+            "icon": "inv_infernalmountred",
+            "itemId": 137575,
+            "name": "Hellfire Infernal",
+            "spellid": 171827
+          },
+          {
             "ID": 899,
             "icon": "inv_serpentmount_green",
             "itemId": 143643,
@@ -3912,13 +3920,6 @@
             "itemId": 152816,
             "name": "Antoran Charhound",
             "spellid": 253088
-          },
-          {
-            "ID": 633,
-            "icon": "inv_infernalmountred",
-            "itemId": 137575,
-            "name": "Hellfire Infernal",
-            "spellid": 171827
           },
           {
             "ID": 954,
@@ -4171,6 +4172,13 @@
         "id": "fe18d149",
         "items": [
           {
+            "ID": 772,
+            "icon": "spell_beastmaster_rylak",
+            "itemId": 128706,
+            "name": "Soaring Skyterror",
+            "spellid": 191633
+          },
+          {
             "ID": 623,
             "icon": "inv_giantboarmount_brown",
             "itemId": 116670,
@@ -4185,14 +4193,6 @@
             "spellid": 171436
           },
           {
-            "ID": 654,
-            "icon": "inv_misc_pet_pandaren_yeti",
-            "itemId": 116791,
-            "name": "Challenger's War Yeti",
-            "notObtainable": true,
-            "spellid": 171848
-          },
-          {
             "ID": 758,
             "icon": "inv_wolfdraenor_felmount",
             "itemId": 127140,
@@ -4200,11 +4200,12 @@
             "spellid": 186305
           },
           {
-            "ID": 772,
-            "icon": "spell_beastmaster_rylak",
-            "itemId": 128706,
-            "name": "Soaring Skyterror",
-            "spellid": 191633
+            "ID": 654,
+            "icon": "inv_misc_pet_pandaren_yeti",
+            "itemId": 116791,
+            "name": "Challenger's War Yeti",
+            "notObtainable": true,
+            "spellid": 171848
           }
         ],
         "name": "Achievement"
@@ -4594,20 +4595,6 @@
         "id": "cada0b8f",
         "items": [
           {
-            "ID": 472,
-            "icon": "inv_pandarenserpentmount",
-            "itemId": 87769,
-            "name": "Crimson Cloud Serpent",
-            "spellid": 127156
-          },
-          {
-            "ID": 474,
-            "icon": "inv_pandarenserpentgodmount_red",
-            "itemId": 87773,
-            "name": "Heavenly Crimson Cloud Serpent",
-            "spellid": 127161
-          },
-          {
             "ID": 450,
             "icon": "ability_mount_pandarenkitemount",
             "itemId": 81559,
@@ -4622,6 +4609,20 @@
             "name": "Pandaren Kite",
             "side": "A",
             "spellid": 130985
+          },
+          {
+            "ID": 472,
+            "icon": "inv_pandarenserpentmount",
+            "itemId": 87769,
+            "name": "Crimson Cloud Serpent",
+            "spellid": 127156
+          },
+          {
+            "ID": 474,
+            "icon": "inv_pandarenserpentgodmount_red",
+            "itemId": 87773,
+            "name": "Heavenly Crimson Cloud Serpent",
+            "spellid": 127161
           },
           {
             "ID": 530,
@@ -5076,6 +5077,13 @@
         "id": "127df01c",
         "items": [
           {
+            "ID": 413,
+            "icon": "ability_mount_warhippogryph",
+            "itemId": 69213,
+            "name": "Flameward Hippogryph",
+            "spellid": 97359
+          },
+          {
             "ID": 391,
             "icon": "inv_misc_stonedragonred",
             "itemId": 62900,
@@ -5088,13 +5096,6 @@
             "itemId": 62901,
             "name": "Drake of the East Wind",
             "spellid": 88335
-          },
-          {
-            "ID": 413,
-            "icon": "ability_mount_warhippogryph",
-            "itemId": 69213,
-            "name": "Flameward Hippogryph",
-            "spellid": 97359
           },
           {
             "ID": 417,
@@ -5175,13 +5176,6 @@
         "id": "22842c61",
         "items": [
           {
-            "ID": 419,
-            "icon": "ability_druid_challangingroar",
-            "itemId": 69747,
-            "name": "Amani Battle Bear",
-            "spellid": 98204
-          },
-          {
             "ID": 395,
             "icon": "inv_misc_stormdragonpale",
             "itemId": 63040,
@@ -5194,6 +5188,13 @@
             "itemId": 63043,
             "name": "Vitreous Stone Drake",
             "spellid": 88746
+          },
+          {
+            "ID": 419,
+            "icon": "ability_druid_challangingroar",
+            "itemId": 69747,
+            "name": "Amani Battle Bear",
+            "spellid": 98204
           },
           {
             "ID": 410,
@@ -5784,13 +5785,6 @@
             "spellid": 59650
           },
           {
-            "ID": 349,
-            "icon": "achievement_boss_onyxia",
-            "itemId": 49636,
-            "name": "Onyxian Drake",
-            "spellid": 69395
-          },
-          {
             "ID": 286,
             "icon": "ability_mount_mammoth_black_3seater",
             "itemId": 43959,
@@ -5812,6 +5806,13 @@
             "itemId": 45693,
             "name": "Mimiron's Head",
             "spellid": 63796
+          },
+          {
+            "ID": 349,
+            "icon": "achievement_boss_onyxia",
+            "itemId": 49636,
+            "name": "Onyxian Drake",
+            "spellid": 69395
           },
           {
             "ID": 363,

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -244,15 +244,15 @@
       {
         "items": [
           {
-            "ID": 4566,
-            "creatureId": 223645,
-            "icon": "inv_murlocsurrender",
-            "itemId": 223474,
-            "name": "Worgli the Apprehensive",
-            "spellid": 449173
+            "ID": 4602,
+            "creatureId": 227414,
+            "icon": "inv_treasurecrabpet_yellow",
+            "itemId": 226104,
+            "name": "Claudius",
+            "spellid": 457689
           }
         ],
-        "name": "Trading Post: August"
+        "name": "Trading Post: September"
       },
       {
         "items": [
@@ -10857,6 +10857,14 @@
             "spellid": 449046
           },
           {
+            "ID": 4566,
+            "creatureId": 223645,
+            "icon": "inv_murlocsurrender",
+            "itemId": 223474,
+            "name": "Worgli the Apprehensive",
+            "spellid": 449173
+          },
+          {
             "ID": 3242,
             "creatureId": 185322,
             "icon": "inv_brontosaurusmount",
@@ -10885,26 +10893,6 @@
             "notObtainable": true,
             "notReleased": true,
             "spellid": 449286
-          },
-          {
-            "ID": 4595,
-            "creatureId": 225354,
-            "icon": "inv_pitlordpet_fire",
-            "itemId": 224576,
-            "name": "Lil' Flameo",
-            "notObtainable": true,
-            "notReleased": true,
-            "spellid": 453266
-          },
-          {
-            "ID": 4602,
-            "creatureId": 227414,
-            "icon": "inv_treasurecrabpet_yellow",
-            "itemId": 226104,
-            "name": "Claudius",
-            "notObtainable": true,
-            "notReleased": true,
-            "spellid": 457689
           }
         ],
         "name": "Trading Post Originals"
@@ -11931,6 +11919,34 @@
       {
         "items": [
           {
+            "ID": 4616,
+            "creatureId": 229860,
+            "icon": "inv_brokerworm_pink",
+            "itemId": 228765,
+            "name": "Gummi",
+            "notObtainable": true,
+            "spellid": 463148
+          }
+        ],
+        "name": "Trolli"
+      },
+      {
+        "items": [
+          {
+            "ID": 4595,
+            "creatureId": 225354,
+            "icon": "inv_pitlordpet_fire",
+            "itemId": 224576,
+            "name": "Lil' Flameo",
+            "notObtainable": true,
+            "spellid": 453266
+          }
+        ],
+        "name": "Steelseries"
+      },
+      {
+        "items": [
+          {
             "ID": 192,
             "creatureId": 29726,
             "icon": "inv_misc_penguinpet",
@@ -11983,16 +11999,6 @@
             "name": "Murki",
             "notObtainable": true,
             "spellid": 25018
-          },
-          {
-            "ID": 4616,
-            "creatureId": 229860,
-            "icon": "inv_brokerworm_pink",
-            "itemId": 228765,
-            "name": "Gummi",
-            "notObtainable": true,
-            "notReleased": true,
-            "spellid": 463148
           }
         ],
         "name": "Other"

--- a/static/data/toys.json
+++ b/static/data/toys.json
@@ -128,8 +128,7 @@
     "name": "Limited Time",
     "subcats": [
       {
-        "items": [
-        ],
+        "items": [],
         "name": "Trading Post"
       }
     ]

--- a/static/data/toys.json
+++ b/static/data/toys.json
@@ -129,14 +129,8 @@
     "subcats": [
       {
         "items": [
-          {
-            "ID": 1345,
-            "icon": "ability_racial_etherealconnection",
-            "itemId": 206268,
-            "name": "Ethereal Transmogrifier"
-          }
         ],
-        "name": "Trading Post: August"
+        "name": "Trading Post"
       }
     ]
   },
@@ -6577,6 +6571,12 @@
       {
         "id": "c1d734dd",
         "items": [
+          {
+            "ID": 1345,
+            "icon": "ability_racial_etherealconnection",
+            "itemId": 206268,
+            "name": "Ethereal Transmogrifier"
+          },
           {
             "ID": 1334,
             "icon": "tradingpostcurrency",


### PR DESCRIPTION
- Added all items from September trading post
- Bunch of corrections to TWW content:
  - Mounts:
     - Combined 'Zone Event' and 'Awakening the Machine' section into 'Zone Feature'
     - Set 'Wick' mount to unobtainable since it will not be available to be earned until at the earliest season 2 of TWW.
  - Achievements -> Quests
    - Gave achievements proper zone sections rather than all being bunched up under 'World'
 - Bunch of misc. corrections
   - Mounts:
     - Made mount order consistent under all expacs, following these rules:
       - Raid Mounts: Sorted by order of release, then by difficulty.
       - Achievement Mounts: Follows a set in stone order; Meta Achievement > Zone Achievement >Misc Achievement > Dungeon/Delve Glory > Raid Glory > Seasonal Raid (fated mounts) > Seasonal Dungeon (m+)
     - Changed 'Oozing Necroray Egg' section to 'Maldraxxus Callings' to better represent source of the mount
 - Fixed Reputation page to properly include the new reputations
    - Still can't display Severed Threads but I believe it's due to an API issue, so may need to calculate it ourselves (since it's based off the other reps), but will wait a bit and see if blizz changes things on their end.