### PR TITLE
Razer Promotion and Show Unobtained Only setting

### DIFF
--- a/src/api/_collectables.js
+++ b/src/api/_collectables.js
@@ -1,4 +1,4 @@
-import { getShowHiddenSetting } from "../util/utils"
+import { getShowHiddenSetting, getShowUnobtainedSetting } from "../util/utils"
 
 function getHigherQualityBattlePet(currentPet, newPet) {
     function getPetsQuality(type) {
@@ -26,6 +26,7 @@ export async function parseCollectablesObject(categories, profile, collected_dat
     var totalPossible = 0;
 
     var showHiddenItems = getShowHiddenSetting();
+    var showUnobtainedOnly = getShowUnobtainedSetting();
 
     // Build up lookup for items that character has
     collected_data[collectedProperty].forEach((item) => {
@@ -147,6 +148,10 @@ export async function parseCollectablesObject(categories, profile, collected_dat
                     showthis = false;
                 }
 
+                if(hasthis && showUnobtainedOnly == "true") {
+                    showthis = false;
+                }
+
                 if (item.allowableRaces && item.allowableRaces.length > 0)
                 {
                     var foundRace = false;
@@ -180,9 +185,9 @@ export async function parseCollectablesObject(categories, profile, collected_dat
                     if (hasthis) {
                         totalCollected++;
                     }
-
                     totalPossible++;
                 }
+                
                 });
 
             if (subCat.items.length > 0) {

--- a/src/api/achievements.js
+++ b/src/api/achievements.js
@@ -3,7 +3,7 @@ import { getProfile } from '$api/profile'
 import { getJsonDb } from '$api/_db'
 import settings from '$util/settings'
 import Cache from '$api/_cache'
-import { getShowHiddenSetting, getShowHiddenFeatSetting } from '../util/utils'
+import { getShowHiddenSetting, getShowHiddenFeatSetting, getShowUnobtainedSetting } from '../util/utils'
 
 let _cache;
 export async function getAchievements(region, realm, character) {
@@ -40,6 +40,7 @@ function parseAchievementObject(db, earned, character, faction) {
     console.log(`Parsing achievements.json...`)
     var showHiddenItems = getShowHiddenSetting();
     var showHiddenFeats = getShowHiddenFeatSetting();
+    var showOnlyUnobtained = getShowUnobtainedSetting();
 
     let obj            = {}
      ,  completed      = {}
@@ -120,8 +121,10 @@ function parseAchievementObject(db, earned, character, faction) {
 
                     // Always add it if we've completed it, it should show up regardless if its available
                     if (myAchievement.completed) {
-                        added = true;
-                        mySubCat.achievements.push(myAchievement);    
+                        if(showOnlyUnobtained == "false") {
+                            added = true;
+                            mySubCat.achievements.push(myAchievement);  
+                        }
 
                         // if this is feats of strength then I want to keep a seperate count for that 
                         // since its not a percentage thing
@@ -163,7 +166,13 @@ function parseAchievementObject(db, earned, character, faction) {
                         // if we haven't already added it, then this is one that should show up in the page of achievements
                         // so add it
                         if (!added) {
-                            mySubCat.achievements.push(myAchievement);
+                            if(showOnlyUnobtained == "true") {
+                                if(!myAchievement.completed) {
+                                    mySubCat.achievements.push(myAchievement);                                
+                                }
+                            } else {
+                                mySubCat.achievements.push(myAchievement);
+                            }
                         }
                     }
                 })

--- a/src/api/titles.js
+++ b/src/api/titles.js
@@ -2,7 +2,7 @@ import { getData } from '$api/_blizzard'
 import { getProfile } from '$api/profile'
 import { getJsonDb } from '$api/_db'
 import Cache from '$api/_cache'
-import { getShowHiddenSetting } from '../util/utils'
+import { getShowHiddenSetting, getShowUnobtainedSetting } from '../util/utils'
 
 let _cache;
 export async function getTitles(region, realm, character) {   
@@ -45,6 +45,7 @@ function parseTitlesObject(db, profile, earned) {
     var totalPossible = 0;
 
     var showHiddenItems = getShowHiddenSetting();
+    var showUnobtainedOnly = getShowUnobtainedSetting();
 
     // Build up lookup for titles that character has
     earned.forEach((title) => {
@@ -77,6 +78,10 @@ function parseTitlesObject(db, profile, earned) {
                 var showthis = (hasthis || !item.notObtainable || (showHiddenItems == "shown" && !item.notReleased));
 
                 if (item.side && item.side !== profile.factionMapped) {
+                    showthis = false;
+                }
+
+                if(hasthis && showUnobtainedOnly == "true") {
                     showthis = false;
                 }
 

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -68,6 +68,14 @@
 		localStorage.setItem('showHiddenFeat', $preferences.showHiddenFeat);
 	}
 
+  const toggleShowUnobtained = (e) => {
+    e.preventDefault();
+		$preferences.showUnobtainedOnly = $preferences.showUnobtainedOnly == "false" ? "true" : "false";
+
+    localStorage.setItem('showHiddenUpdated',Date.now());
+		localStorage.setItem('showUnobtainedOnly', $preferences.showUnobtainedOnly);
+  }
+
   function setLocale(e, wowhead_url) {
     e.preventDefault();
 
@@ -117,6 +125,11 @@
     <div>
       <a href="#/" on:click={toggleHiddenFeat}
         >{$preferences.showHiddenFeat === "hidden" ? "Show Obtainable Feat of Strengths" : "Hide Obtainable Feat of Strengths"}
+    </div>
+
+    <div>
+      <a href="#/" on:click={toggleShowUnobtained}
+        >{$preferences.showUnobtainedOnly === "false" ? "Show Only Unobtained" : "Show Obtained and Unobtained"}
     </div>
 
     <div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -67,6 +67,7 @@
 		$preferences.itemSkin = localStorage.getItem('itemSkin') ?? 'new';
 		$preferences.showHidden = localStorage.getItem('showHidden') ?? "hidden";
 		$preferences.showHiddenFeat = localStorage.getItem('showHiddenFeat') ?? "hidden";
+		$preferences.showUnobtainedOnly = localStorage.getItem('showUnobtainedOnly') ?? "false";
 	})
 
     function getCharInfoFromURL() {

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -88,6 +88,10 @@ export function getShowHiddenFeatSetting() {
     return(localStorage.getItem("showHiddenFeat"));
 }
 
+export function getShowUnobtainedSetting() {
+    return(localStorage.getItem("showUnobtainedOnly"));
+}
+
 export function getShowHiddenUpdated() {
     return(localStorage.getItem("showHiddenUpdated"));
 }

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -210,6 +210,13 @@
             "itemId": 211087,
             "name": "Hateforged Blazecycle",
             "spellid": 428067
+          },
+          {
+            "ID": 1579,
+            "icon": "inv_sharkraymount_4",
+            "itemId": 190539,
+            "name": "Coral-Stalker Waveray",
+            "spellid": 367620
           }
         ],
         "name": "Promotions"
@@ -9128,15 +9135,6 @@
             "notObtainable": true,
             "notReleased": true,
             "spellid": 213349
-          },
-          {
-            "ID": 1579,
-            "icon": "inv_sharkraymount_4",
-            "itemId": 190539,
-            "name": "Coral-Stalker Waveray",
-            "notObtainable": true,
-            "notReleased": true,
-            "spellid": 367620
           },
           {
             "ID": 2145,

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -298,12 +298,7 @@
             "itemId": 228765,
             "name": "Gummi",
             "spellid": 463148
-          }
-        ],
-        "name": "Trolli Promotion"
-      },
-      {
-        "items": [
+          },
           {
             "ID": 4595,
             "creatureId": 225354,
@@ -311,12 +306,7 @@
             "itemId": 224576,
             "name": "Lil' Flameo",
             "spellid": 453266
-          }
-        ],
-        "name": "SteelSeries Promotion"
-      },
-      {
-        "items": [
+          },
           {
             "ID": 4617,
             "creatureId": 229890,
@@ -332,9 +322,17 @@
             "itemId": 228793,
             "name": "Chillbot 9000",
             "spellid": 463251
+          },
+          {
+            "ID": 4690,
+            "creatureId": 233481,
+            "icon": "inv_babynaga2_purple",
+            "itemId": 232519,
+            "name": "Razeshi B.",
+            "spellid": 470914
           }
         ],
-        "name": "Mountain Dew Promotion"
+        "name": "Promotions"
       },
       {
         "items": [
@@ -12313,21 +12311,6 @@
           }
         ],
         "name": "BMAH"
-      },
-      {
-        "items": [
-          {
-            "ID": 4690,
-            "creatureId": 233481,
-            "icon": "inv_babynaga2_purple",
-            "itemId": 232519,
-            "name": "Razeshi B.",
-            "notObtainable": true,
-            "notReleased": true,
-            "spellid": 470914
-          }
-        ],
-        "name": "Unknown"
       }
     ]
   }


### PR DESCRIPTION
Added Razer promotional pet and mount
Added new 'Show Unobtained Only' setting for #663, applies to all collectibles. (Note that having this setting enabled will break the calendar, will fix later since calendar still works when setting is disabled).