### PR TITLE
11.0.7 collectibles and achievements

### DIFF
--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -569,9 +569,7 @@
                   "icon": "achievement_reputation_kirintor",
                   "id": 40791,
                   "points": 0,
-                  "title": "Fate of the Kirin Tor",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Fate of the Kirin Tor"
                 }
               ],
               "name": "Campaign"
@@ -710,33 +708,25 @@
                   "icon": "inv_misc_map08",
                   "id": 41042,
                   "points": 10,
-                  "title": "Siren-ity Now!",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Siren-ity Now!"
                 },
                 {
                   "icon": "icon_treasuremap",
                   "id": 41043,
                   "points": 5,
-                  "title": "Excavation Projects",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Excavation Projects"
                 },
                 {
                   "icon": "inv_misc_book_09",
                   "id": 41045,
                   "points": 10,
-                  "title": "A Song of Secrets",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "A Song of Secrets"
                 },
                 {
                   "icon": "spell_shaman_thunderstorm",
                   "id": 41185,
                   "points": 5,
-                  "title": "Siren's Squall",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Siren's Squall"
                 }
               ],
               "name": "Siren Isle"
@@ -1520,17 +1510,13 @@
                   "icon": "vas_guildfactionchange",
                   "id": 40955,
                   "points": 20,
-                  "title": "War Stories",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "War Stories"
                 },
                 {
                   "icon": "inv_helm_plate_nzothraidmythic_d_01",
                   "id": 40959,
                   "points": 30,
-                  "title": "Black Empire State of Mind",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Black Empire State of Mind"
                 }
               ],
               "name": "Meta"
@@ -4573,57 +4559,43 @@
                   "icon": "inv_professions_inscription_scribesmagnifyingglass_gold",
                   "id": 40762,
                   "points": 10,
-                  "title": "Khaz Algar Lore Hunter",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Khaz Algar Lore Hunter"
                 },
                 {
                   "icon": "inv_cosmicvoid_buff",
                   "id": 41201,
                   "points": 40,
-                  "title": "You Xal Not Pass",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "You Xal Not Pass"
                 },
                 {
                   "icon": "achievement_zone_isleofdorn",
                   "id": 41186,
                   "points": 20,
-                  "title": "Slate of the Union",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Slate of the Union"
                 },
                 {
                   "icon": "achievement_zone_theringingdeeps",
                   "id": 41187,
                   "points": 20,
-                  "title": "Rage Aside the Machine",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Rage Aside the Machine"
                 },
                 {
                   "icon": "achievement_zone_hallowfall",
                   "id": 41188,
                   "points": 20,
-                  "title": "Crystal Chronicled",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Crystal Chronicled"
                 },
                 {
                   "icon": "achievement_zone_azjkahet",
                   "id": 41189,
                   "points": 20,
-                  "title": "Azj the World Turns",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Azj the World Turns"
                 },
                 {
                   "icon": "inv_siren_isle_singing_fragments",
                   "id": 41133,
                   "points": 15,
-                  "title": "Isle Remember You",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Isle Remember You"
                 }
               ],
               "name": "Meta"
@@ -4687,9 +4659,7 @@
                   "icon": "inv_misc_treasurechest04b",
                   "id": 41131,
                   "points": 5,
-                  "title": "Treasures of the Storm",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Treasures of the Storm"
                 }
               ],
               "name": "Treasure"
@@ -4724,9 +4694,7 @@
                   "icon": "ability_dualwield",
                   "id": 41046,
                   "points": 15,
-                  "title": "Clean Up on Isle Siren",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Clean Up on Isle Siren"
                 }
               ],
               "name": "Encounter"
@@ -4946,9 +4914,7 @@
                   "icon": "inv_siren_isle_stormcharged_citrine_turquoise",
                   "id": 41050,
                   "points": 10,
-                  "title": "A Choir of Citrines",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "A Choir of Citrines"
                 }
               ],
               "name": "Siren Isle"
@@ -6487,57 +6453,43 @@
                   "icon": "achievement_zone_sholazar_01",
                   "id": 40956,
                   "points": 40,
-                  "title": "I'm On Island Time",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "I'm On Island Time"
                 },
                 {
                   "icon": "inv_zuldazar",
                   "id": 41202,
                   "points": 20,
-                  "title": "Hot Tropic",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Hot Tropic"
                 },
                 {
                   "icon": "inv_nazmir",
                   "id": 41203,
                   "points": 20,
-                  "title": "Bwon Voyage",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Bwon Voyage"
                 },
                 {
                   "icon": "inv_voldun",
                   "id": 41204,
                   "points": 20,
-                  "title": "Dune Squad",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Dune Squad"
                 },
                 {
                   "icon": "inv_tiragardesound",
                   "id": 41205,
                   "points": 20,
-                  "title": "Sound Off",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Sound Off"
                 },
                 {
                   "icon": "inv_stormsongvalley",
                   "id": 41206,
                   "points": 20,
-                  "title": "Songs of Storms",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Songs of Storms"
                 },
                 {
                   "icon": "inv_tourofdutydrustvar",
                   "id": 41207,
                   "points": 20,
-                  "title": "When the Drust Settles",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "When the Drust Settles"
                 }
               ],
               "name": "Meta"
@@ -14898,9 +14850,7 @@
                   "icon": "achievement_nazmir_zone",
                   "id": 40960,
                   "points": 10,
-                  "title": "Uldir",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Uldir"
                 },
                 {
                   "icon": "inv_gizmo_goblinboombox_01",
@@ -15050,9 +15000,7 @@
                   "icon": "inv_zuldazar",
                   "id": 40961,
                   "points": 10,
-                  "title": "Battle of Dazar'alor",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Battle of Dazar'alor"
                 },
                 {
                   "icon": "inv_compy_purple",
@@ -15234,9 +15182,7 @@
                   "icon": "achievement_boss_nagazone",
                   "id": 40962,
                   "points": 10,
-                  "title": "The Eternal Palace",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "The Eternal Palace"
                 },
                 {
                   "icon": "achievement_boss_warlord_kalithresh",
@@ -15380,9 +15326,7 @@
                   "icon": "achievement_nzothraid_nyalothaguildrun",
                   "id": 40963,
                   "points": 10,
-                  "title": "Ny'alotha, the Waking City",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Ny'alotha, the Waking City"
                 },
                 {
                   "icon": "ability_rogue_smoke",
@@ -25578,59 +25522,59 @@
           "name": "War Within",
           "subcats": [
             {
-              "id": "79d5a865",
+              "id": "360bbc0b",
               "items": [
                 {
                   "icon": "achievement_reputation_02",
-                  "id": 40591,
+                  "id": 41169,
                   "points": 10,
                   "title": "Khaz Algar Diplomat"
                 },
                 {
                   "icon": "ui_majorfactions_candle",
-                  "id": 40836,
+                  "id": 41165,
                   "points": 10,
                   "title": "Assembly of the Deeps"
                 },
                 {
                   "icon": "ui_majorfactions_candle",
-                  "id": 40905,
+                  "id": 41166,
                   "points": 10,
                   "title": "From Many, One"
                 },
                 {
                   "icon": "ui_notoriety_theweaver",
-                  "id": 40838,
+                  "id": 41149,
                   "points": 10,
                   "title": "The Severed Threads"
                 },
                 {
                   "icon": "ui_notoriety_theweaver",
-                  "id": 40907,
+                  "id": 41164,
                   "points": 10,
                   "title": "We Rise Anew"
                 },
                 {
                   "icon": "ui_majorfactions_flame",
-                  "id": 40845,
+                  "id": 41167,
                   "points": 10,
                   "title": "Hallowfall Arathi"
                 },
                 {
                   "icon": "ui_majorfactions_flame",
-                  "id": 40906,
+                  "id": 41168,
                   "points": 10,
                   "title": "The Flame Burns Within"
                 },
                 {
                   "icon": "ui_majorfactions_storm",
-                  "id": 40856,
+                  "id": 41161,
                   "points": 10,
                   "title": "Council of Dornogal"
                 },
                 {
                   "icon": "ui_majorfactions_storm",
-                  "id": 40904,
+                  "id": 41162,
                   "points": 10,
                   "title": "Cornerstone of Dornogal"
                 }
@@ -25678,89 +25622,89 @@
               "name": "Meta"
             },
             {
-              "id": "285f7bcd",
+              "id": "1a8be24b",
               "items": [
                 {
                   "icon": "inv_dragonwhelp3_purple",
-                  "id": 19308,
+                  "id": 41184,
                   "points": 25,
                   "title": "Freshscales Fifteen"
                 },
                 {
                   "icon": "spell_warrior_dragoncharge",
-                  "id": 16549,
+                  "id": 41179,
                   "points": 40,
                   "title": "Popular Around the Isles"
                 },
                 {
                   "icon": "ui_majorfaction_expedition",
-                  "id": 16884,
+                  "id": 41172,
                   "points": 5,
                   "title": "Friends in the Field"
                 },
                 {
                   "icon": "ui_majorfaction_expedition",
-                  "id": 16522,
+                  "id": 41174,
                   "points": 5,
                   "title": "A True Explorer"
                 },
                 {
                   "icon": "ui_majorfaction_centaur",
-                  "id": 17064,
+                  "id": 41170,
                   "points": 5,
                   "title": "Friends in the Plains"
                 },
                 {
                   "icon": "ui_majorfaction_centaur",
-                  "id": 16528,
+                  "id": 41180,
                   "points": 5,
                   "title": "Joining the Khansguard"
                 },
                 {
                   "icon": "ui_majorfaction_tuskarr",
-                  "id": 16944,
+                  "id": 41173,
                   "points": 5,
                   "title": "Friend of the Family"
                 },
                 {
                   "icon": "ui_majorfaction_tuskarr",
-                  "id": 16529,
+                  "id": 41181,
                   "points": 5,
                   "title": "Joining the Community"
                 },
                 {
                   "icon": "ui_majorfaction_valdrakken",
-                  "id": 16994,
+                  "id": 41171,
                   "points": 5,
                   "title": "Friends in the Accord"
                 },
                 {
                   "icon": "ui_majorfaction_valdrakken",
-                  "id": 16530,
+                  "id": 41182,
                   "points": 5,
                   "title": "Ally of the Flights"
                 },
                 {
                   "icon": "ui_majorfaction_niffen",
-                  "id": 17756,
+                  "id": 41175,
                   "points": 5,
                   "title": "Friends in Loamm Places"
                 },
                 {
                   "icon": "ui_majorfaction_niffen",
-                  "id": 17763,
+                  "id": 41183,
                   "points": 5,
                   "title": "There's No Place Like Loamm"
                 },
                 {
                   "icon": "ui_majorfaction_denizens",
-                  "id": 19230,
+                  "id": 41176,
                   "points": 5,
                   "title": "Friends in the Dream"
                 },
                 {
                   "icon": "ui_majorfaction_denizens",
-                  "id": 19235,
+                  "id": 41177,
                   "points": 5,
                   "title": "Warden of the Dream"
                 }
@@ -27073,10 +27017,10 @@
                 {
                   "icon": "spell_holy_symbolofhope",
                   "id": 41130,
-                  "points": 10,
-                  "title": "Elders of Khaz Algar",
                   "notObtainable": true,
-                  "notReleased": true
+                  "notReleased": true,
+                  "points": 10,
+                  "title": "Elders of Khaz Algar"
                 }
               ],
               "name": "Elders"
@@ -28305,8 +28249,6 @@
                 {
                   "icon": "ability_kick",
                   "id": 20511,
-                  "notObtainable": true,
-                  "notReleased": true,
                   "points": 10,
                   "title": "Gotta Punt em' All"
                 }
@@ -31427,9 +31369,7 @@
                   "icon": "inv_misc_tabard_explorersguild",
                   "id": 41209,
                   "points": 20,
-                  "title": "Dressed to Kill: Battle for Azeroth",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Dressed to Kill: Battle for Azeroth"
                 },
                 {
                   "icon": "achievement_nazmir_zone",
@@ -31920,9 +31860,7 @@
                   "icon": "inv_radientazeriteheart",
                   "id": 40953,
                   "points": 100,
-                  "title": "A Farewell to Arms",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "A Farewell to Arms"
                 }
               ],
               "name": "Battle for Azeroth"
@@ -34420,9 +34358,7 @@
                   "icon": "inv_radientazeritematrix",
                   "id": 40958,
                   "points": 30,
-                  "title": "Full Heart, Can't Lose",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Full Heart, Can't Lose"
                 }
               ],
               "name": "Meta"
@@ -34511,9 +34447,7 @@
                   "icon": "vas_factionchange",
                   "id": 40957,
                   "points": 30,
-                  "title": "Maximum Effort",
-                  "notObtainable": true,
-                  "notReleased": true
+                  "title": "Maximum Effort"
                 }
               ],
               "name": "Meta"
@@ -38587,12 +38521,11 @@
                 {
                   "icon": "inv_motorcyclefelreavermount_fel",
                   "id": 40967,
-                  "notObtainable": true,
                   "points": 0,
                   "title": "Ratts' Revenge"
                 }
               ],
-              "name": "Anniversary"
+              "name": "Riddle"
             },
             {
               "id": "df3372f6",
@@ -43906,8 +43839,6 @@
                 {
                   "icon": "inv_holiday_christmas_present_01",
                   "id": 20510,
-                  "notObtainable": true,
-                  "notReleased": true,
                   "points": 0,
                   "title": "What Could it be?"
                 }

--- a/static/data/battlepets.json
+++ b/static/data/battlepets.json
@@ -677,81 +677,61 @@
             "icon": "inv_arfuspet_brown",
             "itemId": 233056,
             "name": "Marmaduke",
-            "notObtainable": true,
-            "notReleased": true,
             "spellid": 472536
           },
           {
             "ID": 4724,
             "creatureId": 234734,
             "icon": "ability_hunter_pet_boar",
-            "name": "Battleboar Piglet",
-            "notObtainable": true,
-            "notReleased": true
+            "name": "Battleboar Piglet"
           },
           {
             "ID": 4628,
             "creatureId": 230394,
             "icon": "inv_trilobitemount_green",
-            "name": "Tidal Kroling",
-            "notObtainable": true,
-            "notReleased": true
+            "name": "Tidal Kroling"
           },
           {
             "ID": 4702,
             "creatureId": 234097,
             "icon": "inv_trilobitemount_red",
-            "name": "Rusty Kroling",
-            "notObtainable": true,
-            "notReleased": true
+            "name": "Rusty Kroling"
           },
           {
             "ID": 4703,
             "creatureId": 234101,
             "icon": "inv_trilobitemount_sandy",
-            "name": "Cave Kroling",
-            "notObtainable": true,
-            "notReleased": true
+            "name": "Cave Kroling"
           },
           {
             "ID": 4710,
             "creatureId": 234367,
             "icon": "inv_parrotmount_red",
-            "name": "Pillaged Parrot",
-            "notObtainable": true,
-            "notReleased": true
+            "name": "Pillaged Parrot"
           },
           {
             "ID": 4711,
             "creatureId": 234369,
             "icon": "inv_snapdragonmount02",
-            "name": "Snapdragon Pup",
-            "notObtainable": true,
-            "notReleased": true
+            "name": "Snapdragon Pup"
           },
           {
             "ID": 4723,
             "creatureId": 234710,
             "icon": "ability_mount_tawnywindrider",
-            "name": "Cliffreach Cub",
-            "notObtainable": true,
-            "notReleased": true
+            "name": "Cliffreach Cub"
           },
           {
             "ID": 4731,
             "creatureId": 236040,
             "icon": "inv_snapdragonmount01",
-            "name": "Storm-Infused Snapdragon",
-            "notObtainable": true,
-            "notReleased": true
+            "name": "Storm-Infused Snapdragon"
           },
           {
             "ID": 4732,
             "creatureId": 236041,
             "icon": "inv_snapdragonmount03",
-            "name": "Scavenging Snapdragon",
-            "notObtainable": true,
-            "notReleased": true
+            "name": "Scavenging Snapdragon"
           }
         ],
         "name": "Siren Isle"

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -333,8 +333,6 @@
             "icon": "inv_shipmount",
             "itemId": 232991,
             "name": "The Breaker's Song",
-            "notObtainable": true,
-            "notReleased": true,
             "spellid": 472752
           },
           {
@@ -342,8 +340,6 @@
             "icon": "inv_shadowelementalmount_black",
             "itemId": 223313,
             "name": "Shadow of Doubt",
-            "notObtainable": true,
-            "notReleased": true,
             "spellid": 448934
           },
           {
@@ -494,6 +490,7 @@
           {
             "ID": 1943,
             "icon": "inv_motorcyclefelreavermount_fel",
+            "itemId": "229348",
             "name": "Incognitro, the Indecipherable Felcycle",
             "spellid": 428013
           }
@@ -584,19 +581,12 @@
             "itemId": 223153,
             "name": "Soaring Meaderbee",
             "spellid": 447151
-          }
-        ],
-        "name": "Zone"
-      },
-      {
-        "items": [
+          },
           {
             "ID": 2322,
             "icon": "ability_mount_stormcrowmount",
             "itemId": 232639,
             "name": "Thrayir, Eyes of the Siren",
-            "notObtainable": true,
-            "notReleased": true,
             "spellid": 471562
           },
           {
@@ -604,21 +594,22 @@
             "icon": "inv_goblinsurfboardmount_red",
             "itemId": 233058,
             "name": "Soweezi's Vintage Waveshredder",
-            "notObtainable": true,
-            "notReleased": true,
             "spellid": 473137
-          },
+          }
+        ],
+        "name": "Zone"
+      },
+      {
+        "items": [
           {
             "ID": 2469,
             "icon": "inv_seaeel_teal",
             "itemId": 233489,
             "name": "Prismatic Snapdragon",
-            "notObtainable": true,
-            "notReleased": true,
             "spellid": 474086
           }
         ],
-        "name": "Siren Isle"
+        "name": "Daily Activities"
       },
       {
         "items": [
@@ -2750,8 +2741,6 @@
             "icon": "inv_compy_purple",
             "itemId": 235515,
             "name": "Jani's Trashpile",
-            "notObtainable": true,
-            "notReleased": true,
             "spellid": 473472
           },
           {
@@ -2759,8 +2748,6 @@
             "icon": "inv_bee_black",
             "itemId": 170070,
             "name": "Honeyback Hivemother",
-            "notObtainable": true,
-            "notReleased": true,
             "spellid": 303767
           },
           {
@@ -8612,7 +8599,8 @@
             "icon": "inv_lunarrocketmount",
             "itemId": 232901,
             "name": "Lunar Launcher",
-            "notObtainable":true,
+            "notObtainable": true,
+            "notReleased": true,
             "spellid": 472253
           }
         ],
@@ -8725,8 +8713,6 @@
             "icon": "ability_mount_drake_twilight",
             "itemId": 234730,
             "name": "Broodling of Sinestra",
-            "notObtainable": true,
-            "notReleased": true,
             "spellid": 1214946
           },
           {
@@ -8741,8 +8727,6 @@
             "icon": "ability_mount_quilenflyingmount",
             "itemId": 234740,
             "name": "Copper-Maned Quilen",
-            "notObtainable": true,
-            "notReleased": true,
             "spellid": 1214974
           },
           {
@@ -8764,8 +8748,6 @@
             "icon": "ability_mount_ironchimera",
             "itemId": 234716,
             "name": "Nightfall Skyreaver",
-            "notObtainable": true,
-            "notReleased": true,
             "spellid": 1214920
           },
           {
@@ -8780,14 +8762,12 @@
             "icon": "inv_soulhoundmount_red",
             "itemId": 234721,
             "name": "Ur'zul Fleshripper",
-            "notObtainable": true,
-            "notReleased": true,
             "spellid": 1214940
           },
           {
             "ID": 1737,
             "icon": "inv_sporebatrock_stoneorange",
-            "itemId": "205208",
+            "itemId": 205208,
             "name": "Sandy Shalewing",
             "spellid": 408654
           },
@@ -8796,8 +8776,6 @@
             "icon": "inv_sandbeemount",
             "itemId": 232624,
             "name": "Timely Buzzbee",
-            "notObtainable": true,
-            "notReleased": true,
             "spellid": 471538
           },
           {
@@ -9234,7 +9212,7 @@
           {
             "ID": 1259,
             "icon": "inv_hippocampusmount_white",
-            "itemId": "233243",
+            "itemId": 233243,
             "name": "Silver Tidestallion",
             "notObtainable": true,
             "spellid": 300154
@@ -9242,7 +9220,7 @@
           {
             "ID": 994,
             "icon": "inv_parrotmount_blue",
-            "itemId": "233242",
+            "itemId": 233242,
             "name": "Royal Seafeather",
             "notObtainable": true,
             "spellid": 254812
@@ -9250,7 +9228,7 @@
           {
             "ID": 2090,
             "icon": "inv_parrotpiratemount_blue",
-            "itemId": "233240",
+            "itemId": 233240,
             "name": "Polly Roger",
             "notObtainable": true,
             "spellid": 437162

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -267,7 +267,7 @@
           {
             "ID": 4682,
             "creatureId": 232502,
-            "icon": "6075526",
+            "icon": "inv_foxpetdetective",
             "itemId": 231294,
             "name": "Reven",
             "spellid": 468186
@@ -587,8 +587,6 @@
             "icon": "ability_mount_bluewindrider",
             "itemId": 234379,
             "name": "Crackleroar",
-            "notObtainable": true,
-            "notReleased": true,
             "spellid": 1213821
           }
         ],
@@ -740,8 +738,6 @@
             "icon": "achievement_dungeon_thesandqueen",
             "itemId": 234395,
             "name": "Skitterbite",
-            "notObtainable": true,
-            "notReleased": true,
             "spellid": 1213831
           }
         ],
@@ -1227,7 +1223,7 @@
           {
             "ID": 4297,
             "creatureId": 212399,
-            "icon": "3071791",
+            "icon": "inv_shoulders_armor_faeriedragon_d_01",
             "itemId": 210633,
             "name": "Kal'andu",
             "spellid": 426319

--- a/static/data/toys.json
+++ b/static/data/toys.json
@@ -363,49 +363,37 @@
             "ID": 1537,
             "icon": "inv_siren_isle_ring",
             "itemId": 235041,
-            "name": "Cyrce's Circlet",
-            "notObtainable": true,
-            "notReleased": true
+            "name": "Cyrce's Circlet"
           },
           {
             "ID": 1538,
             "icon": "inv_10_all_memorycrystal_color2",
             "itemId": 235017,
-            "name": "Glittering Vault Shard",
-            "notObtainable": true,
-            "notReleased": true
+            "name": "Glittering Vault Shard"
           },
           {
             "ID": 1539,
             "icon": "inv_bfa_paragoncache_orderofembers",
             "itemId": 233486,
-            "name": "Hallowfall Supply Cache",
-            "notObtainable": true,
-            "notReleased": true
+            "name": "Hallowfall Supply Cache"
           },
           {
             "ID": 1541,
             "icon": "inv_legion_cache_hightmountaintribes",
             "itemId": 235015,
-            "name": "Awakened Supply Crate",
-            "notObtainable": true,
-            "notReleased": true
+            "name": "Awakened Supply Crate"
           },
           {
             "ID": 1543,
             "icon": "inv_leatherworking_70_loveseat",
             "itemId": 234473,
-            "name": "Soweezi's Comfy Lawn Chair",
-            "notObtainable": true,
-            "notReleased": true
+            "name": "Soweezi's Comfy Lawn Chair"
           },
           {
             "ID": 1545,
             "icon": "inv_10_blacksmithing_craftedoptional_engineering_uprez",
             "itemId": 235016,
-            "name": "Redeployment Module",
-            "notObtainable": true,
-            "notReleased": true
+            "name": "Redeployment Module"
           }
         ],
         "name": "Unknown"


### PR DESCRIPTION
Updated with all 11.0.7 things, plunderstorm things will be enabled when it goes live.

Couple of toys still unknown, so will update those as they get figured out.