### PR TITLE
PTR Item Links and Tooltips

### DIFF
--- a/src/components/Category/Item.svelte
+++ b/src/components/Category/Item.svelte
@@ -5,8 +5,8 @@
   export let item;
   export let getItemPath = (item) => item.link;
 
-  $: href = "//" + settings.WowHeadUrl + "/" + getItemPath(item);
-  $: src = getImageSrc(item, true)
+  $: href = item.new ? "//" + settings.WowHeadUrl + "/ptr-2/" + getItemPath(item) : "//" + settings.WowHeadUrl + "/" + getItemPath(item);
+  $: src = getImageSrc(item, true);
 </script>
 
 <a


### PR DESCRIPTION
Added a check if an item is marked as new it will link to & use the tooltip from the PTR version of the item/achievement