### PR TITLE
11.1 Content Available

### DIFF
--- a/src/components/Category/Item.svelte
+++ b/src/components/Category/Item.svelte
@@ -5,7 +5,7 @@
   export let item;
   export let getItemPath = (item) => item.link;
 
-  $: href = item.new ? "//" + settings.WowHeadUrl + "/ptr-2/" + getItemPath(item) : "//" + settings.WowHeadUrl + "/" + getItemPath(item);
+  $: href = item.new || item.ptr ? "//" + settings.WowHeadUrl + "/ptr-2/" + getItemPath(item) : "//" + settings.WowHeadUrl + "/" + getItemPath(item);
   $: src = getImageSrc(item, true);
 </script>
 

--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -40704,6 +40704,7 @@
                   "icon": "achievement_challengemode_platinum",
                   "id": 20589,
                   "points": 0,
+                  "notObtainable": true,
                   "title": "Tempered Hero: The War Within Season 1"
                 },
                 {
@@ -42995,6 +42996,7 @@
                   "icon": "achievement_featsofstrength_gladiator_07",
                   "id": 40380,
                   "points": 0,
+                  "notObtainable": true,
                   "title": "Forged Gladiator: The War Within Season 1"
                 },
                 {
@@ -44045,6 +44047,7 @@
                 {
                   "icon": "achievement_pvp_a_a",
                   "id": 40383,
+                  "notObtainable": true,
                   "points": 0,
                   "side": "A",
                   "title": "Hero of the Alliance: Forged"
@@ -44052,6 +44055,7 @@
                 {
                   "icon": "achievement_pvp_h_h",
                   "id": 40384,
+                  "notObtainable": true,
                   "points": 0,
                   "side": "H",
                   "title": "Hero of the Horde: Forged"
@@ -44160,6 +44164,7 @@
                 {
                   "icon": "achievement_featsofstrength_gladiator_07",
                   "id": 40381,
+                  "notObtainable": true,
                   "points": 0,
                   "title": "Forged Legend: The War Within Season 1"
                 },
@@ -44207,6 +44212,7 @@
                 {
                   "icon": "achievement_featsofstrength_gladiator_07",
                   "id": 40234,
+                  "notObtainable": true,
                   "points": 0,
                   "side": "H",
                   "title": "Forged Warlord: The War Within Season 1"
@@ -44214,6 +44220,7 @@
                 {
                   "icon": "achievement_featsofstrength_gladiator_07",
                   "id": 40235,
+                  "notObtainable": true,
                   "points": 0,
                   "side": "A",
                   "title": "Forged Marshal: The War Within Season 1"

--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -247,14 +247,12 @@
                   "icon": "inv_misc_treasurechest04b",
                   "id": 40142,
                   "points": 10,
-                  "new": true,
                   "title": "Learning to Share"
                 },
                 {
                   "icon": "inv_cape_special_treasure_c_01",
                   "id": 40145,
                   "points": 20,
-                  "new": true,
                   "title": "So Much Sharing"
                 }
               ],
@@ -548,7 +546,6 @@
                   "icon": "inv_achievement_zone_undermine",
                   "id": 40900,
                   "points": 10,
-                  "new": true,
                   "title": "Undermined"
                 },
                 {
@@ -579,7 +576,6 @@
                   "icon": "achievement_goblinhead",
                   "id": 40894,
                   "points": 10,
-                  "new": true,
                   "title": "Sojourner of Undermine"
                 },
                 {
@@ -4641,14 +4637,12 @@
                   "icon": "inv_spell_arcane_telepotdornogal",
                   "id": 41555,
                   "points": 40,
-                  "new": true,
                   "title": "All That Khaz"
                 },
                 {
                   "icon": "inv_achievement_zone_undermine",
                   "id": 41586,
                   "points": 20,
-                  "new": true,
                   "title": "Going Goblin Mode"
                 }
               ],
@@ -4684,7 +4678,6 @@
                   "icon": "inv_achievement_zone_undermine",
                   "id": 41587,
                   "points": 10,
-                  "new": true,
                   "title": "Explore Undermine"
                 }
               ],
@@ -4726,7 +4719,6 @@
                   "icon": "inv_misc_lockchest02",
                   "id": 41217,
                   "points": 10,
-                  "new": true,
                   "title": "Treasures of Undermine"
                 }
               ],
@@ -4768,7 +4760,6 @@
                   "icon": "inv_axe_1h_outdoorundermine_c_01",
                   "id": 41216,
                   "points": 5,
-                  "new": true,
                   "title": "Adventurer of Undermine"
                 }
               ],
@@ -4821,14 +4812,12 @@
                   "icon": "spell_azerite_essence06",
                   "id": 41214,
                   "points": 5,
-                  "new": true,
                   "title": "Under the Echoes"
                 },
                 {
                   "icon": "achievement_dungeon_gloryofthehero",
                   "id": 41215,
                   "points": 10,
-                  "new": true,
                   "title": "Echoes of Deeper Dangers"
                 }
               ],
@@ -4851,35 +4840,30 @@
                   "icon": "inv_misc_1h_kobold_shovel_a_01",
                   "id": 41590,
                   "points": 5,
-                  "new": true,
                   "title": "No Littering"
                 },
                 {
                   "icon": "inv_misc_1h_kobold_shovel_a_01",
                   "id": 41591,
                   "points": 10,
-                  "new": true,
                   "title": "Really No Littering"
                 },
                 {
                   "icon": "inv_misc_1h_kobold_shovel_a_01",
                   "id": 41592,
                   "points": 25,
-                  "new": true,
                   "title": "Absolutely Zero Littering"
                 },
                 {
                   "icon": "inv_misc_2h_arathor_gardenshovel_b_01",
                   "id": 41593,
                   "points": 10,
-                  "new": true,
                   "title": "Cleanin' the Streets"
                 },
                 {
                   "icon": "achievement_boss_zuldazar_treasuregolem",
                   "id": 41594,
                   "points": 10,
-                  "new": true,
                   "title": "Can You Believe What People Throw Away?"
                 }
               ],
@@ -4891,21 +4875,18 @@
                   "icon": "inv_misc_punchcards_white",
                   "id": 41626,
                   "points": 5,
-                  "new": true,
                   "title": "C.H.E.T.T. a Look"
                 },
                 {
                   "icon": "inv_misc_punchcards_blue",
                   "id": 41627,
                   "points": 10,
-                  "new": true,
                   "title": "C.H.E.T.T.ing it Twice"
                 },
                 {
                   "icon": "inv_misc_punchcards_prismatic",
                   "id": 41629,
                   "points": 10,
-                  "new": true,
                   "title": "C.H.E.T.T.mate"
                 }
               ],
@@ -5081,31 +5062,26 @@
                   "icon": "inv_misc_chest_azerite",
                   "id": 40948,
                   "points": 10,
-                  "new": true,
                   "title": "Nine-Tenths of the Law"
                 },
                 {
                   "icon": "inv_10_inscription2_book1_color4",
                   "id": 41588,
                   "points": 5,
-                  "new": true,
                   "title": "Read Between the Lines"
                 },
                 {
                   "icon": "inv_crate_09",
                   "id": 41589,
                   "points": 10,
-                  "new": true,
                   "title": "That Can-Do Attitude"
                 },
                 {
                   "icon": "inv_rat2undermine_redpatchy",
                   "id": 41708,
                   "points": 5,
-                  "new": true,
                   "title": "You're My Friend Now"
                 }
-                
               ],
               "name": "Undermine"
             }
@@ -8824,15 +8800,13 @@
                 {
                   "icon": "achievement_scenario_500",
                   "id": 41095,
-                  "points": 10,                
-                  "new": true,
+                  "points": 10,
                   "title": "Delve Beyond"
                 },
                 {
                   "icon": "achievement_scenario_1000",
                   "id": 41096,
-                  "points": 10,               
-                  "new": true,
+                  "points": 10,
                   "title": "Delve Infinite"
                 }
               ],
@@ -8879,15 +8853,13 @@
                 {
                   "icon": "achievement_level_70",
                   "id": 41537,
-                  "points": 10,               
-                  "new": true,
+                  "points": 10,
                   "title": "Buddy System VII"
                 },
                 {
                   "icon": "achievement_level_80",
                   "id": 41723,
-                  "points": 10,               
-                  "new": true,
+                  "points": 10,
                   "title": "Buddy System VIII"
                 }
               ],
@@ -8904,8 +8876,7 @@
                 {
                   "icon": "ability_druid_cower",
                   "id": 41097,
-                  "points": 10,               
-                  "new": true,
+                  "points": 10,
                   "title": "Curiosity Never Killed the Looter"
                 },
                 {
@@ -8964,8 +8935,7 @@
                 {
                   "icon": "inv_prg_icon_puzzle13",
                   "id": 41105,
-                  "points": 10,               
-                  "new": true,
+                  "points": 10,
                   "title": "Prodigious Plentiful Perplexing Puzzles"
                 }
               ],
@@ -9050,77 +9020,66 @@
                   "icon": "inv_blacksmithing_815_khazgorianhammer",
                   "id": 41115,
                   "points": 30,
-                  "new": true,
                   "title": "Algari Delver"
                 },
                 {
                   "icon": "inv_mace_1h_khazgorianhammer_b_01",
                   "id": 41116,
                   "points": 30,
-                  "new": true,
                   "title": "Algari Delver II"
                 },
                 {
                   "icon": "spell_ice_magicdamage",
                   "id": 41106,
                   "points": 10,
-                  "new": true,
                   "title": "Algari Delver Damage Dealer"
                 },
                 {
                   "icon": "spell_frost_frostbolt02",
                   "id": 41109,
                   "points": 10,
-                  "new": true,
                   "title": "Algari Delver Damage Dealer II"
                 },
                 {
                   "icon": "spell_frost_frostbolt",
                   "id": 41110,
                   "points": 25,
-                  "new": true,
                   "title": "Algari Delver Damage Dealer III"
                 },
                 {
                   "icon": "spell_nature_unyeildingstamina",
                   "id": 41108,
                   "points": 10,
-                  "new": true,
                   "title": "Algari Delver Tank"
                 },
                 {
                   "icon": "spell_holy_blessingofstamina",
                   "id": 41113,
                   "points": 10,
-                  "new": true,
                   "title": "Algari Delver Tank II"
                 },
                 {
                   "icon": "inv_inscription_trinket_tank",
                   "id": 41114,
                   "points": 25,
-                  "new": true,
                   "title": "Algari Delver Tank III"
                 },
                 {
                   "icon": "spell_holy_heal",
                   "id": 41107,
                   "points": 10,
-                  "new": true,
                   "title": "Algari Delver Healer"
                 },
                 {
                   "icon": "spell_holy_heal02",
                   "id": 41111,
                   "points": 10,
-                  "new": true,
                   "title": "Algari Delver Healer II"
                 },
                 {
                   "icon": "spell_holy_healingaura",
                   "id": 41112,
                   "points": 25,
-                  "new": true,
                   "title": "Algari Delver Healer III"
                 }
               ],
@@ -9144,14 +9103,12 @@
                   "icon": "inv_airshipmountgoblin",
                   "id": 41532,
                   "points": 10,
-                  "new": true,
                   "title": "I've Got a Flying Machine?"
                 },
                 {
                   "icon": "ability_mount_gyrocoptorelite",
                   "id": 41714,
                   "points": 10,
-                  "new": true,
                   "title": "From Trash to Treasure"
                 }
               ],
@@ -9258,14 +9215,12 @@
                   "icon": "inv_stave_2h_430oldgod_c_01",
                   "id": 41098,
                   "points": 5,
-                  "new": true,
                   "title": "Excavation Site 9 Stories"
                 },
                 {
                   "icon": "inv_mace_2h_goblinraid_d_01",
                   "id": 41099,
                   "points": 5,
-                  "new": true,
                   "title": "Sidestreet Sluice Stories"
                 }
               ],
@@ -9384,14 +9339,12 @@
                   "icon": "inv_cape_special_treasure_c_01",
                   "id": 41100,
                   "points": 5,
-                  "new": true,
                   "title": "Excavation Site 9 Discoveries"
                 },
                 {
                   "icon": "inv_cape_special_treasure_c_01",
                   "id": 41101,
                   "points": 5,
-                  "new": true,
                   "title": "Sidestreet Sluice Discoveries"
                 }
               ],
@@ -12459,7 +12412,6 @@
                   "icon": "achievement_zone_azjkahet",
                   "id": 41522,
                   "points": 10,
-                  "new": true,
                   "title": "Tour of Duty: Undermine"
                 },
                 {
@@ -12615,7 +12567,6 @@
                   "icon": "inv_111_raid_achievement_chromekinggallywix",
                   "id": 41286,
                   "points": 10,
-                  "new": true,
                   "title": "Glory of the Liberation of Undermine Raider"
                 }
               ],
@@ -13144,203 +13095,174 @@
                   "icon": "spell_shaman_crashlightning",
                   "id": 41225,
                   "points": 10,
-                  "new": true,
                   "title": "Shock and Awesome"
                 },
                 {
                   "icon": "ability_siege_engineer_overload",
                   "id": 41226,
                   "points": 10,
-                  "new": true,
                   "title": "Maniacal Machinist"
                 },
                 {
                   "icon": "inv_misc_dice_02",
                   "id": 41227,
                   "points": 10,
-                  "new": true,
                   "title": "Beating the Odds"
                 },
                 {
                   "icon": "inv_111_raid_achievement_chromekinggallywix",
                   "id": 41228,
                   "points": 10,
-                  "new": true,
                   "title": "Fall of the Chrome King"
                 },
                 {
                   "icon": "inv_achievement_zone_undermine",
                   "id": 41222,
                   "points": 10,
-                  "new": true,
                   "title": "Liberation of Undermine"
                 },
                 {
                   "icon": "inv_achievement_zone_undermine",
                   "id": 41223,
                   "points": 10,
-                  "new": true,
                   "title": "Heroic: Liberation of Undermine"
                 },
                 {
                   "icon": "inv_achievement_zone_undermine",
                   "id": 41224,
                   "points": 10,
-                  "new": true,
                   "title": "Mythic: Liberation of Undermine"
                 },
                 {
                   "icon": "inv_viciousgoblintrike",
                   "id": 41208,
                   "points": 10,
-                  "new": true,
                   "title": "Hold My Gear!"
                 },
                 {
                   "icon": "spell_nature_sicklypolymorph",
                   "id": 41554,
                   "points": 10,
-                  "new": true,
                   "title": "The Splash Zone"
                 },
                 {
                   "icon": "inv_mechadevilsaurmount_yellow",
                   "id": 41694,
                   "points": 10,
-                  "new": true,
                   "title": "Flarendo's Biggest Fan"
                 },
                 {
                   "icon": "inv_misc_food_23",
                   "id": 41695,
                   "points": 10,
-                  "new": true,
                   "title": "Torq's Biggest Fan"
                 },
                 {
                   "icon": "inv_misc_discoball_01",
                   "id": 41338,
                   "points": 10,
-                  "new": true,
                   "title": "Just /Dance"
                 },
                 {
                   "icon": "ability_vehicle_plaguebarrel",
                   "id": 41596,
                   "points": 10,
-                  "new": true,
                   "title": "Garbage In, Garbage Out"
                 },
                 {
                   "icon": "inv_gizmo_02",
                   "id": 41711,
                   "points": 10,
-                  "new": true,
                   "title": "Conveyor Slayer"
                 },
                 {
                   "icon": "inv_misc_coinbag_special",
                   "id": 41119,
                   "points": 10,
-                  "new": true,
                   "title": "One Rank Higher"
                 },
                 {
                   "icon": "inv_misc_coinbag_special",
                   "id": 41120,
                   "points": 10,
-                  "new": true,
                   "title": "Two Ranks Higher"
                 },
                 {
                   "icon": "inv_misc_coinbag_special",
                   "id": 41121,
                   "points": 10,
-                  "new": true,
                   "title": "Three Ranks Higher"
                 },
                 {
                   "icon": "inv_misc_coinbag_special",
                   "id": 41122,
                   "points": 10,
-                  "new": true,
                   "title": "Best In Class"
                 },
                 {
                   "icon": "inv_misc_head_murloc_01",
                   "id": 41337,
                   "points": 10,
-                  "new": true,
                   "title": "Sleep with the Fishes"
                 },
                 {
                   "icon": "ability_ironmaidens_sorkasprey",
                   "id": 41211,
                   "points": 10,
-                  "new": true,
                   "title": "A Good Day to Dye Hard"
                 },
                 {
                   "icon": "ability_vehicle_electrocharge",
                   "id": 41347,
                   "points": 10,
-                  "new": true,
                   "title": "Scheming on a Thing"
                 },
                 {
                   "icon": "inv_111_raid_achievement_vexieandthegeargrinders",
                   "id": 41229,
                   "points": 10,
-                  "new": true,
                   "title": "Mythic: Vexie and the Geargrinders"
                 },
                 {
                   "icon": "inv_11_arenaboss_colossalclash",
                   "id": 41230,
                   "points": 10,
-                  "new": true,
                   "title": "Mythic: Cauldron of Carnage"
                 },
                 {
                   "icon": "inv_111_raid_achievement_rikreverb",
                   "id": 41231,
                   "points": 10,
-                  "new": true,
                   "title": "Mythic: Rik Reverb"
                 },
                 {
                   "icon": "inv_111_raid_achievement_stixbunkjunker",
                   "id": 41232,
                   "points": 10,
-                  "new": true,
                   "title": "Mythic: Stix Bunkjunker"
                 },
                 {
                   "icon": "inv_111_raid_achievement_sprocketmongerlocknstock",
                   "id": 41233,
                   "points": 10,
-                  "new": true,
                   "title": "Mythic: Sprocketmonger Lockenstock"
                 },
                 {
                   "icon": "inv_111_raid_achievement_onearmedbandit",
                   "id": 41234,
                   "points": 10,
-                  "new": true,
                   "title": "Mythic: The One-Armed Bandit"
                 },
                 {
                   "icon": "inv_111_raid_achievement_mugzeeheadsofsecurity",
                   "id": 41235,
                   "points": 10,
-                  "new": true,
                   "title": "Mythic: Mug'Zee, Heads of Security"
                 },
                 {
                   "icon": "inv_111_raid_achievement_chromekinggallywix",
                   "id": 41236,
                   "points": 10,
-                  "new": true,
                   "title": "Mythic: Chrome King Gallywix"
                 }
               ],
@@ -13572,21 +13494,18 @@
                   "icon": "inv_achievement_dungeon_waterworks",
                   "id": 41339,
                   "points": 10,
-                  "new": true,
                   "title": "Operation: Floodgate"
                 },
                 {
                   "icon": "inv_achievement_dungeon_waterworks",
                   "id": 41340,
                   "points": 10,
-                  "new": true,
                   "title": "Heroic: Operation: Floodgate"
                 },
                 {
                   "icon": "inv_achievement_dungeon_waterworks",
                   "id": 41341,
                   "points": 10,
-                  "new": true,
                   "title": "Mythic: Operation: Floodgate"
                 }
               ],
@@ -26136,7 +26055,6 @@
                   "icon": "ui_majorfactions_rocket",
                   "id": 41086,
                   "points": 10,
-                  "new": true,
                   "title": "Ally of Undermine"
                 }
               ],
@@ -26166,28 +26084,24 @@
                   "icon": "inv_chicken2_mechanical",
                   "id": 41349,
                   "points": 10,
-                  "new": true,
                   "title": "In with the Cartels"
                 },
                 {
                   "icon": "inv_tabard_black_armor_goblinbruiser_d_01",
                   "id": 41351,
                   "points": 10,
-                  "new": true,
                   "title": "Cartels Bestie"
                 },
                 {
                   "icon": "achievement_femalegoblinhead",
                   "id": 41352,
                   "points": 10,
-                  "new": true,
                   "title": "Trade-Duke"
                 },
                 {
                   "icon": "inv_misc_bomb_06",
                   "id": 41350,
                   "points": 10,
-                  "new": true,
                   "title": "A Long Fuse"
                 }
               ],
@@ -29988,7 +29902,6 @@
                   "icon": "inv_crabbomb_red",
                   "id": 41092,
                   "points": 5,
-                  "new": true,
                   "title": "Undermine Safari"
                 }
               ],
@@ -30999,77 +30912,66 @@
                   "icon": "icon_petfamily_critter",
                   "id": 41541,
                   "points": 5,
-                  "new": true,
                   "title": "Critter Battler of Undermine"
                 },
                 {
                   "icon": "icon_petfamily_water",
                   "id": 41542,
                   "points": 5,
-                  "new": true,
                   "title": "Aquatic Battler of Undermine"
                 },
                 {
                   "icon": "icon_petfamily_beast",
                   "id": 41543,
                   "points": 5,
-                  "new": true,
                   "title": "Beast Battler of Undermine"
                 },
                 {
                   "icon": "icon_petfamily_dragon",
                   "id": 41544,
                   "points": 5,
-                  "new": true,
                   "title": "Dragonkin Battler of Undermine"
                 },
                 {
                   "icon": "icon_petfamily_elemental",
                   "id": 41545,
                   "points": 5,
-                  "new": true,
                   "title": "Elemental Battler of Undermine"
                 },
                 {
                   "icon": "icon_petfamily_flying",
                   "id": 41546,
                   "points": 5,
-                  "new": true,
                   "title": "Flying Battler of Undermine"
                 },
                 {
                   "icon": "icon_petfamily_humanoid",
                   "id": 41547,
                   "points": 5,
-                  "new": true,
                   "title": "Humanoid Battler of Undermine"
                 },
                 {
                   "icon": "icon_petfamily_magical",
                   "id": 41548,
                   "points": 5,
-                  "new": true,
                   "title": "Magic Battler of Undermine"
                 },
                 {
                   "icon": "icon_petfamily_mechanical",
                   "id": 41549,
                   "points": 5,
-                  "new": true,
                   "title": "Mechanical Battler of Undermine"
                 },
                 {
                   "icon": "icon_petfamily_undead",
                   "id": 41550,
                   "points": 5,
-                  "new": true,
                   "title": "Undead Battler of Undermine"
                 },
                 {
                   "icon": "inv_babyhyena_yellow",
                   "id": 41551,
                   "points": 10,
-                  "new": true,
                   "title": "Family Battler of Undermine"
                 }
               ],
@@ -32141,14 +32043,12 @@
                   "icon": "inv_achievement_zone_undermine",
                   "id": 41525,
                   "points": 10,
-                  "new": true,
                   "title": "Can You Please Spell \"Gobanna?\""
                 },
                 {
                   "icon": "inv_achievement_zone_undermine",
                   "id": 41665,
                   "points": 10,
-                  "new": true,
                   "title": "Dressed to the Mines"
                 }
               ],
@@ -32353,7 +32253,6 @@
                   "icon": "inv_chest_cloth_raidpriestgoblin_d_01",
                   "id": 41595,
                   "points": 10,
-                  "new": true,
                   "title": "Prized Guise"
                 }
               ],
@@ -32555,7 +32454,7 @@
         },
         {
           "id": "794879ae",
-          "name": "Racing",
+          "name": "Skyriding",
           "subcats": [
             {
               "id": "8a17da43",
@@ -33935,42 +33834,36 @@
                   "icon": "achievement_challengemode_arakkoaspires_bronze",
                   "id": 40936,
                   "points": 10,
-                  "new": true,
                   "title": "Undermine Skyrocketing: Bronze"
                 },
                 {
                   "icon": "achievement_challengemode_arakkoaspires_silver",
                   "id": 40937,
                   "points": 10,
-                  "new": true,
                   "title": "Undermine Skyrocketing: Silver"
                 },
                 {
                   "icon": "achievement_challengemode_arakkoaspires_gold",
                   "id": 40938,
                   "points": 10,
-                  "new": true,
                   "title": "Undermine Skyrocketing: Gold"
                 },
                 {
                   "icon": "achievement_challengemode_arakkoaspires_bronze",
                   "id": 41081,
                   "points": 10,
-                  "new": true,
                   "title": "Undermine Breaknecking: Bronze"
                 },
                 {
                   "icon": "achievement_challengemode_arakkoaspires_silver",
                   "id": 41083,
                   "points": 10,
-                  "new": true,
                   "title": "Undermine Breaknecking: Silver"
                 },
                 {
                   "icon": "achievement_challengemode_arakkoaspires_gold",
                   "id": 41084,
                   "points": 10,
-                  "new": true,
                   "title": "Undermine Breaknecking: Gold"
                 }
               ],
@@ -38966,7 +38859,6 @@
                   "icon": "inv_misc_punchcards_prismatic",
                   "id": 41630,
                   "points": 0,
-                  "new": true,
                   "title": "\"Employee\" of the Month"
                 }
               ],
@@ -39065,35 +38957,30 @@
                   "icon": "inv_achievement_zone_undermine",
                   "id": 40911,
                   "points": 0,
-                  "new": true,
                   "title": "The War Within Season 2: Master Blaster"
                 },
                 {
                   "icon": "inv_crestupgrade_undermine_weathered",
                   "id": 40942,
                   "points": 0,
-                  "new": true,
                   "title": "Weathered of the Undermine"
                 },
                 {
                   "icon": "inv_crestupgrade_undermine_carved",
                   "id": 40943,
                   "points": 0,
-                  "new": true,
                   "title": "Carved of the Undermine"
                 },
                 {
                   "icon": "inv_crestupgrade_undermine_runed",
                   "id": 40944,
                   "points": 0,
-                  "new": true,
                   "title": "Runed of the Undermine"
                 },
                 {
                   "icon": "inv_crestupgrade_undermine_gilded",
                   "id": 40945,
                   "points": 0,
-                  "new": true,
                   "title": "Gilded of the Undermine"
                 }
               ],
@@ -39765,7 +39652,6 @@
                   "icon": "inv_felbatgladiatormount_copper",
                   "id": 41362,
                   "points": 0,
-                  "new": true,
                   "title": "Prized Gladiator's Fel Bat"
                 }
               ],
@@ -39871,35 +39757,30 @@
                   "icon": "inv_cape_special_goblin_d_01",
                   "id": 41530,
                   "points": 0,
-                  "new": true,
                   "title": "My New Nemesis"
                 },
                 {
                   "icon": "inv_goblinshreddermech_black",
                   "id": 41529,
                   "points": 0,
-                  "new": true,
                   "title": "Breaking the Bank"
                 },
                 {
                   "icon": "inv_airshipmountgold",
                   "id": 41210,
                   "points": 0,
-                  "new": true,
                   "title": "Let Me Solo Him: The Underpin"
                 },
                 {
                   "icon": "inv_helm_armor_buckledhat_b_01_darkbrown",
                   "id": 41531,
                   "points": 0,
-                  "new": true,
                   "title": "The Hataclysm"
                 },
                 {
                   "icon": "ui_delves",
                   "id": 41709,
                   "points": 0,
-                  "new": true,
                   "title": "Journey's End (Season 2)"
                 }
               ],
@@ -39960,56 +39841,48 @@
                   "icon": "ui_delves",
                   "id": 41191,
                   "points": 0,
-                  "new": true,
                   "title": "War Within Delves: Tier 4 (Season 2)"
                 },
                 {
                   "icon": "ui_delves",
                   "id": 41192,
                   "points": 0,
-                  "new": true,
                   "title": "War Within Delves: Tier 5 (Season 2)"
                 },
                 {
                   "icon": "ui_delves",
                   "id": 41198,
                   "points": 0,
-                  "new": true,
                   "title": "War Within Delves: Tier 6 (Season 2)"
                 },
                 {
                   "icon": "ui_delves",
                   "id": 41193,
                   "points": 0,
-                  "new": true,
                   "title": "War Within Delves: Tier 7 (Season 2)"
                 },
                 {
                   "icon": "ui_delves",
                   "id": 41194,
                   "points": 0,
-                  "new": true,
                   "title": "War Within Delves: Tier 8 (Season 2)"
                 },
                 {
                   "icon": "ui_delves",
                   "id": 41195,
                   "points": 0,
-                  "new": true,
                   "title": "War Within Delves: Tier 9 (Season 2)"
                 },
                 {
                   "icon": "ui_delves",
                   "id": 41196,
                   "points": 0,
-                  "new": true,
                   "title": "War Within Delves: Tier 10 (Season 2)"
                 },
                 {
                   "icon": "ui_delves",
                   "id": 41197,
                   "points": 0,
-                  "new": true,
                   "title": "War Within Delves: Tier 11 (Season 2)"
                 }
               ],
@@ -40385,14 +40258,12 @@
                   "icon": "achievement_dungeon_kezan",
                   "id": 40965,
                   "points": 0,
-                  "new": true,
                   "title": "Keystone Hero: The MOTHERLODE!!"
                 },
                 {
                   "icon": "achievement_boss_mechagon",
                   "id": 40966,
                   "points": 0,
-                  "new": true,
                   "title": "Keystone Hero: Operation: Mechagon - Workshop"
                 }
               ],
@@ -40839,42 +40710,36 @@
                   "icon": "achievement_challengemode_silver",
                   "id": 40949,
                   "points": 0,
-                  "new": true,
                   "title": "The War Within Keystone Explorer: Season Two"
                 },
                 {
                   "icon": "achievement_challengemode_silver",
                   "id": 40950,
                   "points": 0,
-                  "new": true,
                   "title": "The War Within Keystone Conqueror: Season Two"
                 },
                 {
                   "icon": "achievement_challengemode_platinum",
                   "id": 41533,
                   "points": 0,
-                  "new": true,
                   "title": "The War Within Keystone Master: Season Two"
                 },
                 {
                   "icon": "achievement_challengemode_scholomance_platinum",
                   "id": 40952,
                   "points": 0,
-                  "new": true,
                   "title": "The War Within Keystone Hero: Season Two"
                 },
                 {
                   "icon": "achievement_challengemode_scholomance_gold",
                   "id": 40951,
                   "points": 0,
-                  "new": true,
                   "title": "The War Within Keystone Legend: Season Two"
                 },
                 {
                   "icon": "achievement_challengemode_platinum",
                   "id": 40954,
                   "points": 0,
-                  "new": true,
                   "title": "Enterprising Hero: The War Within Season Two"
                 }
               ],
@@ -40938,7 +40803,6 @@
                   "icon": "inv_achievement_dungeon_waterworks",
                   "id": 41348,
                   "points": 0,
-                  "new": true,
                   "title": "Keystone Hero: Operation: Floodgate"
                 }
               ],
@@ -41422,14 +41286,12 @@
                   "icon": "inv_111_raid_achievement_chromekinggallywix",
                   "id": 41298,
                   "points": 0,
-                  "new": true,
                   "title": "Ahead of the Curve: Chrome King Gallywix"
                 },
                 {
                   "icon": "inv_111_raid_achievement_chromekinggallywix",
                   "id": 41297,
                   "points": 0,
-                  "new": true,
                   "title": "Cutting Edge: Chrome King Gallywix"
                 }
               ],
@@ -43139,70 +43001,60 @@
                   "icon": "achievement_featsofstrength_gladiator_10",
                   "id": 41020,
                   "points": 0,
-                  "new": true,
                   "title": "Combatant I: The War Within Season 2"
                 },
                 {
                   "icon": "achievement_featsofstrength_gladiator_10",
                   "id": 41021,
                   "points": 0,
-                  "new": true,
                   "title": "Combatant II: The War Within Season 2"
                 },
                 {
                   "icon": "achievement_featsofstrength_gladiator_09",
                   "id": 41022,
                   "points": 0,
-                  "new": true,
                   "title": "Challenger I: The War Within Season 2"
                 },
                 {
                   "icon": "achievement_featsofstrength_gladiator_09",
                   "id": 41023,
                   "points": 0,
-                  "new": true,
                   "title": "Challenger II: The War Within Season 2"
                 },
                 {
                   "icon": "achievement_featsofstrength_gladiator_09",
                   "id": 41016,
                   "points": 0,
-                  "new": true,
                   "title": "Rival I: The War Within Season 2"
                 },
                 {
                   "icon": "achievement_featsofstrength_gladiator_09",
                   "id": 41017,
                   "points": 0,
-                  "new": true,
                   "title": "Rival II: The War Within Season 2"
                 },
                 {
                   "icon": "achievement_featsofstrength_gladiator_09",
                   "id": 41018,
                   "points": 0,
-                  "new": true,
                   "title": "Duelist: The War Within Season 2"
                 },
                 {
                   "icon": "achievement_featsofstrength_gladiator_09",
                   "id": 41019,
                   "points": 0,
-                  "new": true,
                   "title": "Elite: The War Within Season 2"
                 },
                 {
                   "icon": "achievement_featsofstrength_gladiator_09",
                   "id": 41032,
                   "points": 0,
-                  "new": true,
                   "title": "Gladiator: The War Within Season 2"
                 },
                 {
                   "icon": "achievement_featsofstrength_gladiator_07",
                   "id": 41354,
                   "points": 0,
-                  "new": true,
                   "title": "Prized Gladiator: The War Within Season 2"
                 }
               ],
@@ -44208,16 +44060,14 @@
                   "icon": "achievement_pvp_h_h",
                   "id": 41360,
                   "points": 0,
-                  "side": "H",                
-                  "new": true,
+                  "side": "H",
                   "title": "Hero of the Horde: Prized"
                 },
                 {
                   "icon": "achievement_pvp_a_a",
                   "id": 41361,
                   "points": 0,
-                  "side": "A",                
-                  "new": true,
+                  "side": "A",
                   "title": "Hero of the Alliance: Prized"
                 }
               ],
@@ -44323,21 +44173,18 @@
                   "icon": "achievement_featsofstrength_gladiator_04",
                   "id": 41358,
                   "points": 0,
-                  "new": true,
                   "title": "Legend: The War Within Season 2"
                 },
                 {
                   "icon": "achievement_featsofstrength_gladiator_07",
                   "id": 41355,
                   "points": 0,
-                  "new": true,
                   "title": "Prized Legend: The War Within Season 2"
                 },
                 {
                   "icon": "ability_paladin_blessedmending",
                   "id": 41359,
                   "points": 0,
-                  "new": true,
                   "title": "Battle Mender: The War Within Season 2"
                 },
                 {
@@ -44374,8 +44221,7 @@
                 {
                   "icon": "achievement_featsofstrength_gladiator_04",
                   "id": 41363,
-                  "points": 0,                
-                  "new": true,
+                  "points": 0,
                   "title": "Strategist: The War Within Season 2"
                 },
                 {
@@ -44383,7 +44229,6 @@
                   "id": 41356,
                   "points": 0,
                   "side": "H",
-                  "new": true,
                   "title": "Prized Warlord: The War Within Season 2"
                 },
                 {
@@ -44391,7 +44236,6 @@
                   "id": 41357,
                   "points": 0,
                   "side": "A",
-                  "new": true,
                   "title": "Prized Marshal: The War Within Season 2"
                 },
                 {
@@ -44482,7 +44326,6 @@
                   "icon": "inv_misc_token_pvp02",
                   "id": 41047,
                   "points": 0,
-                  "new": true,
                   "title": "Prized Weapons of Conquest"
                 }
               ],
@@ -45613,15 +45456,15 @@
                 {
                   "icon": "inv_11xp_wow20year_balloonchest01",
                   "id": 40976,
-                  "points": 0,
                   "notObtainable": true,
+                  "points": 0,
                   "title": "A Cool Twenty Years"
                 },
                 {
                   "icon": "inv_10_dungeonjewelry_dragon_necklace_1_bronze",
                   "id": 41038,
-                  "points": 0,
                   "notObtainable": true,
+                  "points": 0,
                   "title": "Token Collector"
                 }
               ],

--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -40703,8 +40703,8 @@
                 {
                   "icon": "achievement_challengemode_platinum",
                   "id": 20589,
-                  "points": 0,
                   "notObtainable": true,
+                  "points": 0,
                   "title": "Tempered Hero: The War Within Season 1"
                 },
                 {
@@ -42995,8 +42995,8 @@
                 {
                   "icon": "achievement_featsofstrength_gladiator_07",
                   "id": 40380,
-                  "points": 0,
                   "notObtainable": true,
+                  "points": 0,
                   "title": "Forged Gladiator: The War Within Season 1"
                 },
                 {

--- a/static/data/battlepets.json
+++ b/static/data/battlepets.json
@@ -613,7 +613,6 @@
             "creatureId": 222592,
             "icon": "inv_grey_sporecreature2",
             "name": "Hemospore",
-            "new": true,
             "spellid": 446500
           }
         ],
@@ -759,7 +758,6 @@
             "creatureId": 231477,
             "icon": "inv_111_rat_brown",
             "name": "Wily Rat",
-            "new": true,
             "spellid": 471893
           },
           {
@@ -767,7 +765,6 @@
             "creatureId": 231470,
             "icon": "inv_111_rat_radioactive",
             "name": "Acid-Drenched Rat",
-            "new": true,
             "spellid": 471896
           },
           {
@@ -775,7 +772,6 @@
             "creatureId": 231481,
             "icon": "inv_cockroach2_brown",
             "name": "Underroach",
-            "new": true,
             "spellid": 471897
           },
           {
@@ -783,7 +779,6 @@
             "creatureId": 231550,
             "icon": "inv_crabbomb_blue",
             "name": "Bombshell Crab",
-            "new": true,
             "spellid": 471909
           },
           {
@@ -791,7 +786,6 @@
             "creatureId": 231567,
             "icon": "inv_crabbomb_yellow",
             "name": "Venture Bombshell",
-            "new": true,
             "spellid": 471908
           },
           {
@@ -799,7 +793,6 @@
             "creatureId": 231570,
             "icon": "inv_crabcave_blue",
             "name": "Cave Crab",
-            "new": true,
             "spellid": 471910
           },
           {
@@ -807,7 +800,6 @@
             "creatureId": 231574,
             "icon": "inv_crabcave_white",
             "name": "Paleshell Crab",
-            "new": true,
             "spellid": 471917
           },
           {
@@ -815,7 +807,6 @@
             "creatureId": 231577,
             "icon": "inv_mechanicalprairiedog_green",
             "name": "Varmint MK II",
-            "new": true,
             "spellid": 471932
           },
           {
@@ -823,7 +814,6 @@
             "creatureId": 231579,
             "icon": "inv_chicken2_mechanical",
             "name": "Lime Roboclucker",
-            "new": true,
             "spellid": 471934
           },
           {
@@ -831,7 +821,6 @@
             "creatureId": 231684,
             "icon": "inv_frog2_mechanical_yellow",
             "name": "Spring-Loaded Ribbitron",
-            "new": true,
             "spellid": 471943
           },
           {
@@ -839,7 +828,6 @@
             "creatureId": 231686,
             "icon": "inv_frog2_mechanical_black",
             "name": "Ultrahopper EX",
-            "new": true,
             "spellid": 471937
           },
           {
@@ -847,7 +835,6 @@
             "creatureId": 231728,
             "icon": "inv_maldraxxusslime_purple",
             "name": "Alchemical Runoff",
-            "new": true,
             "spellid": 471898
           }
         ],
@@ -860,7 +847,6 @@
             "creatureId": 231572,
             "icon": "inv_crabcave_green",
             "name": "Kaja Crab",
-            "new": true,
             "spellid": 471911
           },
           {
@@ -868,7 +854,6 @@
             "creatureId": 231616,
             "icon": "inv_frog2_black",
             "name": "Tropical Frog",
-            "new": true,
             "spellid": 471912
           }
         ],

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -358,7 +358,6 @@
             "icon": "inv_goblinspidertank",
             "itemId": 235549,
             "name": "Crimson Shreddertank",
-            "new": true,
             "spellid": 1217235
           },
           {
@@ -366,7 +365,6 @@
             "icon": "inv_goblinspidertank",
             "itemId": 237141,
             "name": "Enterprising Shreddertank",
-            "new": true,
             "spellid": 1221694
           },
           {
@@ -374,7 +372,6 @@
             "icon": "inv_felbatgladiatormount_copper",
             "itemId": 229987,
             "name": "Prized Gladiator's Fel Bat",
-            "new": true,
             "spellid": 466144
           }
         ],
@@ -453,7 +450,6 @@
             "icon": "inv_goblinshreddermechboss",
             "itemId": 231173,
             "name": "Junkmaestro's Magnetomech",
-            "new": true,
             "spellid": 468068
           }
         ],
@@ -480,7 +476,6 @@
             "icon": "inv_goblinflyingmachine",
             "itemId": 236960,
             "name": "Prototype A.S.M.R.",
-            "new": true,
             "spellid": 1221155
           },
           {
@@ -488,7 +483,6 @@
             "icon": "inv_gallywixmechmount",
             "itemId": 235626,
             "name": "The Big G",
-            "new": true,
             "spellid": 1217760
           }
         ],
@@ -501,7 +495,6 @@
             "icon": "inv_molemount_brown",
             "itemId": 225548,
             "name": "Wick",
-            "new": true,
             "spellid": 449264
           },
           {
@@ -542,7 +535,6 @@
             "icon": "inv_red_hyena2goblinmount",
             "itemId": 229935,
             "name": "Crimson Armored Growler",
-            "new": true,
             "spellid": 465999
           },
           {
@@ -550,7 +542,6 @@
             "icon": "inv_goblinflyingmachine_green",
             "itemId": 229956,
             "name": "Mean Green Flying Machine",
-            "new": true,
             "spellid": 466028
           },
           {
@@ -558,7 +549,6 @@
             "icon": "inv_goblinshreddermech_blue",
             "itemId": 229948,
             "name": "Blackwater Shredder Deluxe Mk 2",
-            "new": true,
             "spellid": 466019
           },
           {
@@ -566,7 +556,6 @@
             "icon": "inv_yellow_rocketmount5",
             "itemId": 229946,
             "name": "Ocher Delivery Rocket",
-            "new": true,
             "spellid": 466013
           },
           {
@@ -574,7 +563,6 @@
             "icon": "inv_goblinshreddermech_black",
             "itemId": 229950,
             "name": "Darkfuse Demolisher",
-            "new": true,
             "spellid": 466018
           }
         ],
@@ -643,7 +631,6 @@
             "icon": "inv_purple_hyena2goblinmount",
             "itemId": 229936,
             "name": "Violet Armored Growler",
-            "new": true,
             "spellid": 466002
           },
           {
@@ -651,19 +638,18 @@
             "icon": "inv_purple_rocketmount5",
             "itemId": 229944,
             "name": "The Topskimmer Special",
-            "new": true,
             "spellid": 466016
           }
         ],
         "name": "Renown"
       },
       {
-        "items" : [
+        "items": [
           {
             "ID": 2274,
             "icon": "inv_blue_hyena2goblinmount",
+            "itemId": 229937,
             "name": "Blackwater Bonecrusher",
-            "new": true,
             "spellid": 466001
           },
           {
@@ -671,23 +657,13 @@
             "icon": "inv_green_rocketmount5",
             "itemId": 229943,
             "name": "Steamwheedle Supplier",
-            "new": true,
             "spellid": 466014
-          },
-          {
-            "ID": 2303,
-            "icon": "inv_goblinshreddermech_purple",
-            "itemId": 229947,
-            "name": "Violet Goblin Shredder",
-            "new": true,
-            "spellid": 466021
           },
           {
             "ID": 2295,
             "icon": "inv_goblinflyingmachine_red",
             "itemId": 229957,
             "name": "Bilgewater Bombardier",
-            "new": true,
             "spellid": 466024
           },
           {
@@ -695,7 +671,6 @@
             "icon": "inv_goblinshreddermech_yellow",
             "itemId": 229951,
             "name": "Venture Co-ordinator",
-            "new": true,
             "spellid": 466022
           },
           {
@@ -703,7 +678,6 @@
             "icon": "inv_goblinsurfboardmount_green",
             "itemId": 233064,
             "name": "Bronze Goblin Waveshredder",
-            "new": true,
             "spellid": 473188
           }
         ],
@@ -716,7 +690,6 @@
             "icon": "inv_red_rocketmount5",
             "itemId": 229945,
             "name": "Thunderdrum Misfire",
-            "new": true,
             "spellid": 466012
           },
           {
@@ -724,7 +697,6 @@
             "icon": "inv_black_hyena2goblinmount",
             "itemId": 229924,
             "name": "Darkfuse Chompactor",
-            "new": true,
             "spellid": 466000
           },
           {
@@ -732,7 +704,6 @@
             "icon": "inv_mechadevilsaurmount_yellow",
             "itemId": 229940,
             "name": "Flarendo the Furious",
-            "new": true,
             "spellid": 466011
           }
         ],
@@ -771,16 +742,7 @@
             "icon": "inv_airshipmountgoblin",
             "itemId": 229974,
             "name": "Delver's Gob-Trotter",
-            "new": true,
             "spellid": 466133
-          },
-          {
-            "ID": 2293,
-            "icon": "inv_goblinflyingmachine_black",
-            "itemId": 229955,
-            "name": "Darkfuse Spy-Eye",
-            "new": true,
-            "spellid": 466027
           }
         ],
         "name": "Quest"
@@ -800,6 +762,13 @@
             "itemId": 223269,
             "name": "Machine Defense Unit 1-11",
             "spellid": 448188
+          },
+          {
+            "ID": 2303,
+            "icon": "inv_goblinshreddermech_purple",
+            "itemId": 229947,
+            "name": "Violet Goblin Shredder",
+            "spellid": 466021
           }
         ],
         "name": "Zone Feature"
@@ -833,6 +802,20 @@
             "itemId": 224150,
             "name": "Siesbarg",
             "spellid": 451489
+          },
+          {
+            "ID": 2293,
+            "icon": "inv_goblinflyingmachine_black",
+            "itemId": 229955,
+            "name": "Darkfuse Spy-Eye",
+            "spellid": 466027
+          },
+          {
+            "ID": 2291,
+            "icon": "inv_goblinflyingmachine_yellow",
+            "itemId": 229953,
+            "name": "Salvaged Goblin Gazillionaire's Flying Machine",
+            "spellid": 466026
           }
         ],
         "name": "Rare Spawn"
@@ -870,7 +853,6 @@
             "icon": "inv_black_rocketmount5",
             "itemId": 229941,
             "name": "Innovation Investigator",
-            "new": true,
             "spellid": 466017
           },
           {
@@ -878,7 +860,6 @@
             "icon": "inv_goblinshreddermech",
             "itemId": 229952,
             "name": "Asset Advocator",
-            "new": true,
             "spellid": 466023
           },
           {
@@ -886,23 +867,14 @@
             "icon": "inv_goblinflyingmachine_blue",
             "itemId": 229954,
             "name": "Margin Manipulator",
-            "new": true,
             "spellid": 466025
           },
           {
             "ID": 2288,
             "icon": "inv_goblinshreddermech_green",
+            "itemId": 229949,
             "name": "Personalized Goblin S.C.R.A.Per",
-            "new": true,
             "spellid": 466020
-          },
-          {
-            "ID": 2291,
-            "icon": "inv_goblinflyingmachine_yellow",
-            "itemId": 229953,
-            "name": "Salvaged Goblin Gazillionaire's Flying Machine",
-            "new": true,
-            "spellid": 466026
           }
         ],
         "name": "Vendor"
@@ -8458,7 +8430,6 @@
             "itemId": 229988,
             "name": "Vicious Electro Eel",
             "side": "H",
-            "new": true,
             "spellid": 466145
           },
           {
@@ -8467,7 +8438,6 @@
             "itemId": 229989,
             "name": "Vicious Electro Eel",
             "side": "A",
-            "new": true,
             "spellid": 466146
           }
         ],
@@ -10053,7 +10023,7 @@
           },
           {
             "ID": 2315,
-            "icon": "6118902",
+            "icon": "inv_lunarsnakemount",
             "itemId": 231297,
             "name": "Timbered Sky Snake",
             "spellid": 468205
@@ -10173,7 +10143,7 @@
             "ID": 2477,
             "icon": "6243518",
             "itemId": 235287,
-            "name": "Sha-Warped Tiger",
+            "name": "Sha-Warped Riding Tiger",
             "spellid": 1216430
           },
           {

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -349,7 +349,6 @@
           {
             "ID": 2480,
             "icon": "inv_goblinspidertank",
-            "itemId": 235549,
             "name": "Crimson Shreddertank",
             "spellid": 1217235
           },
@@ -540,21 +539,18 @@
           {
             "ID": 2286,
             "icon": "inv_goblinshreddermech_blue",
-            "itemId": 229948,
             "name": "Blackwater Shredder Deluxe Mk 2",
             "spellid": 466019
           },
           {
             "ID": 2284,
             "icon": "inv_yellow_rocketmount5",
-            "itemId": 229946,
             "name": "Ocher Delivery Rocket",
             "spellid": 466013
           },
           {
             "ID": 2287,
             "icon": "inv_goblinshreddermech_black",
-            "itemId": 229950,
             "name": "Darkfuse Demolisher",
             "spellid": 466018
           }
@@ -622,14 +618,12 @@
           {
             "ID": 2277,
             "icon": "inv_purple_hyena2goblinmount",
-            "itemId": 229936,
             "name": "Violet Armored Growler",
             "spellid": 466002
           },
           {
             "ID": 2280,
             "icon": "inv_purple_rocketmount5",
-            "itemId": 229944,
             "name": "The Topskimmer Special",
             "spellid": 466016
           }
@@ -641,28 +635,24 @@
           {
             "ID": 2274,
             "icon": "inv_blue_hyena2goblinmount",
-            "itemId": 229937,
             "name": "Blackwater Bonecrusher",
             "spellid": 466001
           },
           {
             "ID": 2281,
             "icon": "inv_green_rocketmount5",
-            "itemId": 229943,
             "name": "Steamwheedle Supplier",
             "spellid": 466014
           },
           {
             "ID": 2295,
             "icon": "inv_goblinflyingmachine_red",
-            "itemId": 229957,
             "name": "Bilgewater Bombardier",
             "spellid": 466024
           },
           {
             "ID": 2289,
             "icon": "inv_goblinshreddermech_yellow",
-            "itemId": 229951,
             "name": "Venture Co-ordinator",
             "spellid": 466022
           },
@@ -760,6 +750,7 @@
             "ID": 2303,
             "icon": "inv_goblinshreddermech_purple",
             "itemId": 229947,
+            "ptr": true,
             "name": "Violet Goblin Shredder",
             "spellid": 466021
           }
@@ -844,28 +835,24 @@
           {
             "ID": 2283,
             "icon": "inv_black_rocketmount5",
-            "itemId": 229941,
             "name": "Innovation Investigator",
             "spellid": 466017
           },
           {
             "ID": 2290,
             "icon": "inv_goblinshreddermech",
-            "itemId": 229952,
             "name": "Asset Advocator",
             "spellid": 466023
           },
           {
             "ID": 2292,
             "icon": "inv_goblinflyingmachine_blue",
-            "itemId": 229954,
             "name": "Margin Manipulator",
             "spellid": 466025
           },
           {
             "ID": 2288,
             "icon": "inv_goblinshreddermech_green",
-            "itemId": 229949,
             "name": "Personalized Goblin S.C.R.A.Per",
             "spellid": 466020
           }

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -256,13 +256,6 @@
             "spellid": 453255
           },
           {
-            "ID": 1947,
-            "icon": "inv_motorcyclefelreavermount_fire",
-            "itemId": 211087,
-            "name": "Hateforged Blazecycle",
-            "spellid": 428067
-          },
-          {
             "ID": 571,
             "icon": "ability_mount_ironchimera",
             "itemId": 107951,
@@ -10244,6 +10237,18 @@
           }
         ],
         "name": "Diablo IV"
+      },
+      {
+        "items": [
+          {
+            "ID": 1947,
+            "icon": "inv_motorcyclefelreavermount_fire",
+            "itemId": 211087,
+            "name": "Hateforged Blazecycle",
+            "spellid": 428067
+          }
+        ],
+        "name": "Mountain Dew"
       },
       {
         "id": "ed0e4736",

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -449,7 +449,6 @@
             "icon": "inv_babyhyena_yellow",
             "itemId": 232855,
             "name": "Foreman",
-            "new": true,
             "spellid": 471902
           },
           {
@@ -458,7 +457,6 @@
             "icon": "inv_chicken2_mechanical",
             "itemId": 232807,
             "name": "Iron Chick",
-            "new": true,
             "spellid": 471946
           }
         ],
@@ -529,7 +527,6 @@
             "icon": "inv_toygorilla_blue",
             "itemId": 232843,
             "name": "Gorillion",
-            "new": true,
             "spellid": 471935
           }
         ],
@@ -713,7 +710,6 @@
             "icon": "inv_babydevilsaur_yellow",
             "itemId": 232844,
             "name": "Fun-Size Flarendo",
-            "new": true,
             "spellid": 471933
           },
           {
@@ -722,7 +718,6 @@
             "icon": "inv_toygorilla_red",
             "itemId": 232806,
             "name": "Tiny Torq",
-            "new": true,
             "spellid": 471945
           }
         ],
@@ -736,7 +731,6 @@
             "icon": "inv_111_sapper_bilgewater",
             "itemId": 232845,
             "name": "Bilgewater Junkhauler",
-            "new": true,
             "spellid": 471925
           },
           {
@@ -745,7 +739,6 @@
             "icon": "inv_babyhyena_green",
             "itemId": 232853,
             "name": "Eepy",
-            "new": true,
             "spellid": 471904
           },
           {
@@ -754,7 +747,6 @@
             "icon": "inv_babydevilsaur_blue",
             "itemId": 232839,
             "name": "Wavebreaker Mechasaur",
-            "new": true,
             "spellid": 471942
           },
           {
@@ -763,7 +755,6 @@
             "icon": "inv_toygorilla_yellow",
             "itemId": 232851,
             "name": "Rocketfist",
-            "new": true,
             "spellid": 471918
           }
         ],
@@ -825,7 +816,6 @@
             "icon": "inv_111_sapper_darkfuse",
             "itemId": 232848,
             "name": "Mr. DELVER",
-            "new": true,
             "spellid": 471922
           }
         ],
@@ -863,7 +853,6 @@
             "icon": "inv_mechanicalprairiedog_black",
             "itemId": 232840,
             "name": "Mechagopher",
-            "new": true,
             "spellid": 471941
           },
           {
@@ -872,7 +861,6 @@
             "icon": "inv_111_sapper_steamwheedle",
             "itemId": 232846,
             "name": "Steamwheedle Flunkie",
-            "new": true,
             "spellid": 471924
           },
           {
@@ -881,7 +869,6 @@
             "icon": "inv_111_sapper_blackwater",
             "itemId": 232850,
             "name": "Blackwater Kegmover",
-            "new": true,
             "spellid": 471920
           },
           {
@@ -890,7 +877,6 @@
             "icon": "inv_111_sapper_ventureco",
             "itemId": 232849,
             "name": "Venture Companyman",
-            "new": true,
             "spellid": 471921
           },
           {
@@ -899,7 +885,6 @@
             "icon": "inv_toygorilla_green",
             "itemId": 232841,
             "name": "Professor Punch",
-            "new": true,
             "spellid": 471940
           },
           {
@@ -908,7 +893,6 @@
             "icon": "inv_babydevilsaur_red",
             "itemId": 232842,
             "name": "Crimson Mechasaur",
-            "new": true,
             "spellid": 471939
           }
         ],
@@ -922,7 +906,6 @@
             "icon": "inv_111_rat_white",
             "itemId": 232859,
             "name": "Lab Rat",
-            "new": true,
             "spellid": 471895
           },
           {
@@ -931,7 +914,6 @@
             "icon": "inv_cockroach2_black",
             "itemId": 232858,
             "name": "Cruncher",
-            "new": true,
             "spellid": 471899
           },
           {
@@ -940,7 +922,6 @@
             "icon": "inv_babydevilsaur_green",
             "itemId": 232838,
             "name": "Viridian Mechasaur",
-            "new": true,
             "spellid": 471944
           }
         ],
@@ -1008,7 +989,6 @@
             "icon": "inv_crabbomb_black",
             "itemId": 236768,
             "name": "Craboom",
-            "new": true,
             "spellid": 1220834
           }
         ],
@@ -12115,6 +12095,14 @@
             "itemId": 210964,
             "name": "Lil' Wrathion",
             "spellid": 427682
+          },
+          {
+            "ID": 4733,
+            "creatureId": 236783,
+            "icon": "6243478",
+            "itemId": 235358,
+            "name": "Merriment",
+            "spellid": 1216564
           }
         ],
         "name": "WoW Classic"

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -243,6 +243,19 @@
       {
         "items": [
           {
+            "ID": 4762,
+            "creatureId": 240137,
+            "icon": "inv_clockworkbeagle_blue",
+            "itemId": 238261,
+            "name": "Tock the Clocker Spaniel",
+            "spellid": 1224569
+          }
+        ],
+        "name": "Twitch Drops"
+      },
+      {
+        "items": [
+          {
             "ID": 4729,
             "creatureId": 235159,
             "icon": "inv_redpandapet_orange",
@@ -331,22 +344,6 @@
             "itemId": 224576,
             "name": "Lil' Flameo",
             "spellid": 453266
-          },
-          {
-            "ID": 4617,
-            "creatureId": 229890,
-            "icon": "inv_pet_futurebotpet_orange",
-            "itemId": 228790,
-            "name": "Thrillbot 9000",
-            "spellid": 463242
-          },
-          {
-            "ID": 4618,
-            "creatureId": 229901,
-            "icon": "inv_pet_futurebotpet_purple",
-            "itemId": 228793,
-            "name": "Chillbot 9000",
-            "spellid": 463251
           },
           {
             "ID": 4690,
@@ -11615,16 +11612,6 @@
             "notObtainable": true,
             "notReleased": true,
             "spellid": 1215317
-          },
-          {
-            "ID": 4762,
-            "creatureId": 240137,
-            "icon": "inv_clockworkbeagle_blue",
-            "itemId": 238261,
-            "name": "Tock the Clocker Spaniel",
-            "notObtainable": true,
-            "notReleased": true,
-            "spellid": 1224569
           }
         ],
         "name": "Blizzard Store"
@@ -12118,6 +12105,27 @@
           }
         ],
         "name": "Warcraft Rumble"
+      },
+      {
+        "items": [
+          {
+            "ID": 4617,
+            "creatureId": 229890,
+            "icon": "inv_pet_futurebotpet_orange",
+            "itemId": 228790,
+            "name": "Thrillbot 9000",
+            "spellid": 463242
+          },
+          {
+            "ID": 4618,
+            "creatureId": 229901,
+            "icon": "inv_pet_futurebotpet_purple",
+            "itemId": 228793,
+            "name": "Chillbot 9000",
+            "spellid": 463251
+          }
+        ],
+        "name": "Mountain Dew"
       },
       {
         "items": [

--- a/static/data/titles.json
+++ b/static/data/titles.json
@@ -73,7 +73,6 @@
             "icon": "achievement_scenario_500",
             "id": 41095,
             "name": "Delver",
-            "new": true,
             "titleId": 598,
             "type": "achievement"
           },
@@ -81,7 +80,6 @@
             "icon": "achievement_scenario_1000",
             "id": 41096,
             "name": "Infinite Delver",
-            "new": true,
             "titleId": 599,
             "type": "achievement"
           }
@@ -299,7 +297,6 @@
             "icon": "achievement_challengemode_silver",
             "id": 40950,
             "name": "The Enterprising",
-            "new": true,
             "titleId": 592,
             "type": "achievement"
           },
@@ -307,7 +304,6 @@
             "icon": "achievement_challengemode_platinum",
             "id": 40954,
             "name": "The Enterprising Hero",
-            "new": true,
             "titleId": 593,
             "type": "achievement"
           },
@@ -315,7 +311,6 @@
             "icon": "inv_goblinshreddermech_black",
             "id": 41529,
             "name": "The Real Deal",
-            "new": true,
             "titleId": 612,
             "type": "achievement"
           }
@@ -340,7 +335,6 @@
             "icon": "inv_111_raid_achievement_chromekinggallywix",
             "id": 41236,
             "name": "Liberator of Undermine",
-            "new": true,
             "titleId": 605,
             "type": "achievement"
           }
@@ -353,7 +347,6 @@
             "icon": "ability_vehicle_plaguebarrel",
             "id": 41596,
             "name": "Junkmaestro",
-            "new": true,
             "titleId": 613,
             "type": "achievement"
           },
@@ -361,7 +354,6 @@
             "icon": "inv_misc_coinbag_special",
             "id": 41122,
             "name": "The Reel Deal",
-            "new": true,
             "titleId": 618,
             "type": "achievement"
           }
@@ -435,7 +427,6 @@
             "icon": "ui_majorfactions_rocket",
             "id": 41086,
             "name": "The Explosive",
-            "new": true,
             "titleId": 603,
             "type": "achievement"
           }
@@ -448,7 +439,6 @@
             "icon": "inv_misc_questionmark",
             "id": 878,
             "name": "High Roller",
-            "new": true,
             "titleId": 602,
             "type": "title"
           }
@@ -482,7 +472,6 @@
             "icon": "inv_misc_bomb_06",
             "id": 41350,
             "name": "Darkfuse Diplomat",
-            "new": true,
             "titleId": 606,
             "type": "achievement"
           },
@@ -490,7 +479,6 @@
             "icon": "achievement_femalegoblinhead",
             "id": 41352,
             "name": "Trade-Duke",
-            "new": true,
             "titleId": 607,
             "type": "achievement"
           }
@@ -545,7 +533,6 @@
             "icon": "achievement_challengemode_arakkoaspires_gold",
             "id": 40938,
             "name": "Skyrocketer",
-            "new": true,
             "titleId": 580,
             "type": "achievement"
           }
@@ -558,7 +545,6 @@
             "icon": "achievement_challengemode_arakkoaspires_gold",
             "id": 41084,
             "name": "Breaknecker",
-            "new": true,
             "titleId": 597,
             "type": "achievement"
           }
@@ -583,7 +569,6 @@
             "icon": "inv_misc_punchcards_prismatic",
             "id": 41629,
             "name": "Part-Timer",
-            "new": true,
             "titleId": 616,
             "type": "achievement"
           },
@@ -591,7 +576,6 @@
             "icon": "inv_misc_punchcards_prismatic",
             "id": 41629,
             "name": "\"Employee\" of the Month",
-            "new": true,
             "titleId": 617,
             "type": "achievement"
           }
@@ -3018,7 +3002,6 @@
             "icon": "achievement_featsofstrength_gladiator_07",
             "id": 41355,
             "name": "Prized Legend",
-            "new": true,
             "notObtainable": true,
             "titleId": 611,
             "type": "achievement"
@@ -3041,7 +3024,6 @@
             "id": 41354,
             "name": "Prized Gladiator",
             "notObtainable": true,
-            "new": true,
             "titleId": 608,
             "type": "achievement"
           }
@@ -3081,7 +3063,6 @@
             "id": 41356,
             "name": "Prized Warlord",
             "notObtainable": true,
-            "new": true,
             "side": "H",
             "titleId": 609,
             "type": "achievement"
@@ -3091,7 +3072,6 @@
             "id": 41357,
             "name": "Prized Marshal",
             "notObtainable": true,
-            "new": true,
             "side": "A",
             "titleId": 610,
             "type": "achievement"
@@ -4064,7 +4044,6 @@
             "id": 41296,
             "name": "Famed Slayer of The Chrome King",
             "nameF": "Famed Slayer of Gallywix",
-            "new": true,
             "notObtainable": true,
             "titleId": 604,
             "type": "achievement"

--- a/static/data/toys.json
+++ b/static/data/toys.json
@@ -167,8 +167,8 @@
             "ID": 1515,
             "icon": "inv_goblinsapperpet",
             "itemId": 230727,
-            "new": true,
-            "name": "Explosive Victory"
+            "name": "Explosive Victory",
+            "new": true
           },
           {
             "ID": 1483,
@@ -186,8 +186,8 @@
             "ID": 1560,
             "icon": "inv_hammer_2h_centaur_b_03",
             "itemId": 236769,
-            "new": true,
-            "name": "Gallagio Pipeline Rerouter"
+            "name": "Gallagio Pipeline Rerouter",
+            "new": true
           }
         ],
         "name": "Achievement"
@@ -240,8 +240,8 @@
             "ID": 1536,
             "icon": "inv_drink_21_color04",
             "itemId": 234951,
-            "new": true,
-            "name": "Uncracked Cold Ones"
+            "name": "Uncracked Cold Ones",
+            "new": true
           }
         ],
         "name": "Treasure"
@@ -282,22 +282,22 @@
             "ID": 1521,
             "icon": "inv_111_robocopter_robocopter",
             "itemId": 230850,
-            "new": true,
-            "name": "Delve-O-Bot 7001"
+            "name": "Delve-O-Bot 7001",
+            "new": true
           },
           {
             "ID": 1522,
             "icon": "ability_priest_flashoflight",
             "itemId": 230924,
-            "new": true,
-            "name": "Spotlight Materializer 1000"
+            "name": "Spotlight Materializer 1000",
+            "new": true
           },
           {
             "ID": 1523,
             "icon": "inv_111_underminegangsterdisguise",
             "itemId": 231064,
-            "new": true,
-            "name": "Throwaway Gangster Disguise"
+            "name": "Throwaway Gangster Disguise",
+            "new": true
           }
         ],
         "name": "Delves"
@@ -343,64 +343,64 @@
             "ID": 1548,
             "icon": "inv_111_goblincasinochips_bilgewater",
             "itemId": 235670,
-            "new": true,
-            "name": "Bilgewater Cartel Banner"
+            "name": "Bilgewater Cartel Banner",
+            "new": true
           },
           {
             "ID": 1556,
             "icon": "inv_10_engineering_device_gadget2_color3",
             "itemId": 235807,
-            "new": true,
-            "name": "Storefront-in-a-Box"
+            "name": "Storefront-in-a-Box",
+            "new": true
           },
           {
             "ID": 1550,
             "icon": "inv_111_goblincasinochips_steamwheedle",
             "itemId": 235669,
-            "new": true,
-            "name": "Steamwheedle Cartel Banner"
+            "name": "Steamwheedle Cartel Banner",
+            "new": true
           },
           {
             "ID": 1561,
             "icon": "inv_potion_83",
             "itemId": 226373,
-            "new": true,
-            "name": "Everlasting Noggenfogger Elixir"
+            "name": "Everlasting Noggenfogger Elixir",
+            "new": true
           },
           {
             "ID": 1549,
             "icon": "inv_111_goblincasinochips_blackwater",
             "itemId": 235671,
-            "new": true,
-            "name": "Blackwater Cartel Banner"
+            "name": "Blackwater Cartel Banner",
+            "new": true
           },
           {
             "ID": 1555,
             "icon": "inv_misc_8xp_balloon_horse01",
             "itemId": 235801,
-            "new": true,
-            "name": "Personal Fishing Barge"
+            "name": "Personal Fishing Barge",
+            "new": true
           },
           {
             "ID": 1551,
             "icon": "inv_111_goblincasinochips_ventureco",
             "itemId": 235672,
-            "new": true,
-            "name": "Venture Co. Banner"
+            "name": "Venture Co. Banner",
+            "new": true
           },
           {
             "ID": 1554,
             "icon": "inv_misc_sawblade_01",
             "itemId": 235799,
-            "new": true,
-            "name": "Throwin' Sawblade"
+            "name": "Throwin' Sawblade",
+            "new": true
           },
           {
             "ID": 1535,
             "icon": "inv_offhand_1h_goblinraid_d_02",
             "itemId": 234950,
-            "new": true,
-            "name": "Atomic Regoblinator"
+            "name": "Atomic Regoblinator",
+            "new": true
           }
         ],
         "name": "Renown"
@@ -481,22 +481,22 @@
             "ID": 1567,
             "icon": "inv_111_fishingbobber_meat",
             "itemId": 237347,
-            "new": true,
-            "name": "Organically-Sourced Wellington Bobber"
+            "name": "Organically-Sourced Wellington Bobber",
+            "new": true
           },
           {
             "ID": 1568,
             "icon": "inv_111_fishingbobber_can",
             "itemId": 237346,
-            "new": true,
-            "name": "Artisan Beverage Goblet Bobber"
+            "name": "Artisan Beverage Goblet Bobber",
+            "new": true
           },
           {
             "ID": 1569,
             "icon": "inv_111_fishingbobber_rocket",
             "itemId": 237345,
-            "new": true,
-            "name": "Limited Edition Rocket Bobber"
+            "name": "Limited Edition Rocket Bobber",
+            "new": true
           }
         ],
         "name": "Vendor"
@@ -550,8 +550,8 @@
             "ID": 1566,
             "icon": "inv_10_engineering2_boxofbombs_friendly_color2",
             "itemId": 237382,
-            "new": true,
-            "name": "Undermine Supply Crate"
+            "name": "Undermine Supply Crate",
+            "new": true
           }
         ],
         "name": "Zone"
@@ -562,8 +562,8 @@
             "ID": 1559,
             "icon": "inv_111_goldenbomb_goldblue",
             "itemId": 236687,
-            "new": true,
-            "name": "Explosive Hearthstone"
+            "name": "Explosive Hearthstone",
+            "new": true
           }
         ],
         "name": "Raid"
@@ -574,33 +574,33 @@
             "ID": 1557,
             "icon": "inv_misc_-selfiecamera_01",
             "itemId": 236751,
+            "name": "Take-Home Flarendo",
             "notObtainable": true,
-            "notReleased": true,
-            "name": "Take-Home Flarendo"
+            "notReleased": true
           },
           {
             "ID": 1558,
             "icon": "inv_misc_-selfiecamera_01",
             "itemId": 236749,
+            "name": "Take-Home Torq",
             "notObtainable": true,
-            "notReleased": true,
-            "name": "Take-Home Torq"
+            "notReleased": true
           },
           {
             "ID": 1540,
             "icon": "inv_helm_misc_fireworkpartyhat",
             "itemId": 235220,
+            "name": "Fireworks Hat",
             "notObtainable": true,
-            "notReleased": true,
-            "name": "Fireworks Hat"
+            "notReleased": true
           },
           {
             "ID": 1565,
             "icon": "inv_10_engineering2_boxofbombs_friendly_color1",
             "itemId": 235050,
+            "name": "Desk-in-a-Box",
             "notObtainable": true,
-            "notReleased": true,
-            "name": "Desk-in-a-Box"
+            "notReleased": true
           }
         ],
         "name": "Unknown"
@@ -5742,8 +5742,8 @@
             "ID": 1534,
             "icon": "inv_misc_enggizmos_33",
             "itemId": 233202,
-            "new": true,
-            "name": "G.O.L.E.M, Jr."
+            "name": "G.O.L.E.M, Jr.",
+            "new": true
           }
         ],
         "name": "Engineering"
@@ -7334,8 +7334,10 @@
         "name": "Hearthstone"
       },
       {
+        "id": "f9358031",
         "items": [
           {
+            "ID": 1542,
             "icon": "6246537",
             "itemId": 235288,
             "name": "Sha-Warped Tea Set"


### PR DESCRIPTION
all 11.1 content is no longer marked as new + some corrections missing MoP classic bundle pet and updated toy ID.

Mostly got everything now, wowhead still a bit behind on the items for mounts so I'm using spell ids for now. 
Added temporary extra function to display PTR tooltips for non-"upcoming" items. Will see if it has use in the future.