### PR TITLE
11.1.5 New Store Items & Misc fixes

### DIFF
--- a/static/data/factions.json
+++ b/static/data/factions.json
@@ -109,7 +109,11 @@
       },
       {
         "id": 2688,
-        "name": "Flame's Radiance"
+        "name": "Flame's Radiance",
+        "renown": {
+          "max": 10,
+          "step": 2500
+        }
       },
       {
         "id": 2683,

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -10194,13 +10194,13 @@
           },
           {
             "ID": 2525,
-            "icon": "6705369",
+            "icon": "inv_ravenmount_black",
             "name": "Prophet's Great Raven",
             "spellid": 1226760
           },
           {
             "ID": 2529,
-            "icon": "6705370",
+            "icon": "inv_ravenmount_white",
             "name": "Archmage's Great Raven",
             "spellid": 1226983
           }

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -538,6 +538,13 @@
             "itemId": 229944,
             "name": "The Topskimmer Special",
             "spellid": 466016
+          },
+          {
+            "ID": 2519,
+            "icon": "inv_arathilynxmount_nightfall",
+            "itemId": 238829,
+            "name": "Radiant Imperial Lynx",
+            "spellid": 1226421
           }
         ],
         "name": "Renown"
@@ -834,13 +841,6 @@
             "itemId": 229949,
             "name": "Personalized Goblin S.C.R.A.P.per",
             "spellid": 466020
-          },
-          {
-            "ID": 2519,
-            "icon": "inv_arathilynxmount_nightfall",
-            "itemId": 238829,
-            "name": "Radiant Imperial Lynx",
-            "spellid": 1226421
           },
           {
             "ID": 2501,
@@ -10191,6 +10191,18 @@
             "itemId": 233285,
             "name": "Meeksi Teatuft",
             "spellid": 473744
+          },
+          {
+            "ID": 2525,
+            "icon": "6705369",
+            "name": "Prophet's Great Raven",
+            "spellid": 1226760
+          },
+          {
+            "ID": 2529,
+            "icon": "6705370",
+            "name": "Archmage's Great Raven",
+            "spellid": 1226983
           }
         ],
         "name": "Blizzard Store"

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -2550,16 +2550,6 @@
             "notObtainable": true,
             "notReleased": true,
             "spellid": 408332
-          },
-          {
-            "ID": 4264,
-            "creatureId": 209163,
-            "icon": "inv_wooddragonpet",
-            "itemId": 208446,
-            "name": "Fyrn",
-            "notObtainable": true,
-            "notReleased": true,
-            "spellid": 419467
           }
         ],
         "name": "Unknown"
@@ -11706,9 +11696,15 @@
             "ID": 4568,
             "creatureId": 223691,
             "icon": "inv_snowowlpet_white",
-            "name": "Whoopy",
-            "notObtainable": true,
-            "notReleased": true
+            "name": "Whoopy"
+          },
+          {
+            "ID": 4264,
+            "creatureId": 209163,
+            "icon": "inv_wooddragonpet",
+            "itemId": 208446,
+            "name": "Fyrn",
+            "spellid": 419467
           },
           {
             "ID": 4730,


### PR DESCRIPTION
New Content: 
- Added new store content: two new mounts and two new pets

Fixes:
- Fixed Flame Radiance rep track to use renown
- Moved Flame Radiance renown vendor mount from Vendor to Renown