### PR TITLE
Title icons and misc. fixes

### DIFF
--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -285,12 +285,14 @@
           {
             "ID": 2525,
             "icon": "inv_ravenmount_black",
+            "itemId": 238943,
             "name": "Prophet's Great Raven",
             "spellid": 1226760
           },
           {
             "ID": 2529,
             "icon": "inv_ravenmount_white",
+            "itemId": 238994,
             "name": "Archmage's Great Raven",
             "spellid": 1226983
           }
@@ -898,7 +900,7 @@
             "spellid": 441325
           }
         ],
-        "name": "Pre-Patch Event"
+        "name": "Pre-launch Event"
       }
     ]
   },

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -277,19 +277,6 @@
           }
         ],
         "name": "Promotions"
-      },
-      {
-        "items": [
-          {
-            "ID": 4791,
-            "creatureId": 198989,
-            "icon": "inv_babymurloc3bronze",
-            "itemId": 238796,
-            "name": "Thrrrdgl",
-            "spellid": 1226305
-          }
-        ],
-        "name": "Blizzard Gear Store"
       }
     ]
   },
@@ -1037,7 +1024,7 @@
             "spellid": 442327
           }
         ],
-        "name": "Pre-Patch Event"
+        "name": "Pre-launch Event"
       },
       {
         "id": "fad5d824",
@@ -1206,16 +1193,6 @@
             "notObtainable": true,
             "notReleased": true,
             "spellid": 471903
-          },
-          {
-            "ID": 4635,
-            "creatureId": 231466,
-            "icon": "inv_babyhyena_red",
-            "itemId": 232857,
-            "name": "Goggles",
-            "notObtainable": true,
-            "notReleased": true,
-            "spellid": 471900
           }
         ],
         "name": "Unknown"
@@ -2373,20 +2350,6 @@
         "name": "Emerald Bounty"
       },
       {
-        "id": "ccca067e",
-        "items": [
-          {
-            "ID": 3348,
-            "creatureId": 191387,
-            "icon": "inv_10_elementalspiritfoozles_air",
-            "itemId": 199109,
-            "name": "Primal Stormling",
-            "spellid": 375713
-          }
-        ],
-        "name": "Pre-launch Event"
-      },
-      {
         "id": "ccda057e",
         "items": [
           {
@@ -2407,6 +2370,20 @@
           }
         ],
         "name": "Archives"
+      },
+      {
+        "id": "ccca067e",
+        "items": [
+          {
+            "ID": 3348,
+            "creatureId": 191387,
+            "icon": "inv_10_elementalspiritfoozles_air",
+            "itemId": 199109,
+            "name": "Primal Stormling",
+            "spellid": 375713
+          }
+        ],
+        "name": "Pre-launch Event"
       },
       {
         "id": "332ea2f0",
@@ -8824,6 +8801,15 @@
             "name": "Helpful Workshop Bot",
             "new": true,
             "spellid": 367189
+          },
+          {
+            "ID": 4635,
+            "creatureId": 231466,
+            "icon": "inv_babyhyena_red",
+            "itemId": 232857,
+            "name": "Goggles",
+            "new": true,
+            "spellid": 471900
           }
         ],
         "name": "Children's Week"
@@ -12497,6 +12483,14 @@
             "itemId": 229366,
             "name": "Brrrgl",
             "spellid": 464798
+          },
+          {
+            "ID": 4791,
+            "creatureId": 198989,
+            "icon": "inv_babymurloc3bronze",
+            "itemId": 238796,
+            "name": "Thrrrdgl",
+            "spellid": 1226305
           }
         ],
         "name": "Blizzard Gear Store"

--- a/static/data/titles.json
+++ b/static/data/titles.json
@@ -18,7 +18,7 @@
       {
         "items": [
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_character_human_male",
             "id": 760,
             "name": "Lionguard",
             "side": "A",
@@ -26,7 +26,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_character_nightelf_female",
             "id": 778,
             "name": "Ama'shan",
             "side": "A",
@@ -398,28 +398,28 @@
       {
         "items": [
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "ui_majorfactions_candle",
             "id": 839,
             "name": "Machine Whisperer",
             "titleId": 564,
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "ui_majorfactions_storm",
             "id": 840,
             "name": "Honorary Councilmember",
             "titleId": 565,
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "ui_majorfactions_flame",
             "id": 841,
             "name": "Lamplighter",
             "titleId": 566,
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "ui_majorfactions_web_256",
             "id": 842,
             "name": "Thread-Spinner",
             "titleId": 567,
@@ -431,6 +431,20 @@
             "name": "The Explosive",
             "titleId": 603,
             "type": "achievement"
+          },
+          {
+            "icon": "ui_majorfactions_-nightfall",
+            "id": 899,
+            "name": "Sentry",
+            "titleId": 622,
+            "type": "title"
+          },
+          {
+            "icon": "ui_majorfactions_-nightfall",
+            "id": 905,
+            "name": "Sacred Templar",
+            "titleId": 628,
+            "type": "title"
           }
         ],
         "name": "Renown"
@@ -438,7 +452,7 @@
       {
         "items": [
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "ui_majorfactions_stars",
             "id": 878,
             "name": "High Roller",
             "titleId": 602,
@@ -603,6 +617,8 @@
             "icon": "ability_mount_charger",
             "id": 1436,
             "name": "Recruit",
+            "notObtainable": true,
+            "notReleased": true,
             "titleId": 619,
             "type": "achievement"
           },
@@ -610,6 +626,8 @@
             "icon": "inv_misc_questionmark",
             "id": 897,
             "name": "Reservist",
+            "notObtainable": true,
+            "notReleased": true,
             "titleId": 620,
             "type": "title"
           },
@@ -617,20 +635,17 @@
             "icon": "inv_misc_questionmark",
             "id": 898,
             "name": "Field Sacredite",
+            "notObtainable": true,
+            "notReleased": true,
             "titleId": 621,
-            "type": "title"
-          },
-          {
-            "icon": "inv_misc_questionmark",
-            "id": 899,
-            "name": "Sentry",
-            "titleId": 622,
             "type": "title"
           },
           {
             "icon": "inv_misc_questionmark",
             "id": 900,
             "name": "Stalwart",
+            "notObtainable": true,
+            "notReleased": true,
             "titleId": 623,
             "type": "title"
           },
@@ -638,6 +653,8 @@
             "icon": "inv_misc_questionmark",
             "id": 901,
             "name": "Ardent",
+            "notObtainable": true,
+            "notReleased": true,
             "titleId": 624,
             "type": "title"
           },
@@ -645,6 +662,8 @@
             "icon": "inv_misc_questionmark",
             "id": 902,
             "name": "Aeroknight",
+            "notObtainable": true,
+            "notReleased": true,
             "titleId": 625,
             "type": "title"
           },
@@ -652,6 +671,8 @@
             "icon": "inv_misc_questionmark",
             "id": 903,
             "name": "Flame Guard",
+            "notObtainable": true,
+            "notReleased": true,
             "titleId": 626,
             "type": "title"
           },
@@ -659,14 +680,9 @@
             "icon": "inv_misc_questionmark",
             "id": 904,
             "name": "Radiant Officer",
+            "notObtainable": true,
+            "notReleased": true,
             "titleId": 627,
-            "type": "title"
-          },
-          {
-            "icon": "inv_misc_questionmark",
-            "id": 905,
-            "name": "Sacred Templar",
-            "titleId": 628,
             "type": "title"
           }
         ],
@@ -1148,28 +1164,28 @@
             "type": "achievement"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "ui_sigil_nightfae",
             "id": 699,
             "name": "Protector of the Weald",
             "titleId": 442,
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "ui_sigil_necrolord",
             "id": 700,
             "name": "Sword of the Primus",
             "titleId": 443,
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "ui_sigil_venthyr",
             "id": 701,
             "name": "Sin Eater",
             "titleId": 444,
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "ui_sigil_kyrian",
             "id": 702,
             "name": "Disciple of Devotion",
             "titleId": 445,
@@ -3304,7 +3320,7 @@
         "id": "d470f041",
         "items": [
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_zone_grizzlyhills_04",
             "id": 852,
             "name": "Grizzly Hills Hiker",
             "notObtainable": true,
@@ -3312,7 +3328,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_zone_westernplaguelands_01",
             "id": 853,
             "name": "Plaguelands Survivor",
             "notObtainable": true,
@@ -3320,7 +3336,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "inv_misc_head_murloc_01",
             "id": 856,
             "name": "Classic Enthusiast",
             "notObtainable": true,
@@ -3328,7 +3344,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_zone_outland_01",
             "id": 857,
             "name": "Outland Enthusiast",
             "notObtainable": true,
@@ -3336,7 +3352,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_zone_northrend_01",
             "id": 858,
             "name": "Northrend Enthusiast",
             "notObtainable": true,
@@ -3344,7 +3360,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "spell_shaman_stormearthfire",
             "id": 859,
             "name": "Cataclysm Enthusiast",
             "notObtainable": true,
@@ -3352,7 +3368,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "expansionicon_mistsofpandaria",
             "id": 860,
             "name": "Pandaria Enthusiast",
             "notObtainable": true,
@@ -3360,7 +3376,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_zone_draenor_01",
             "id": 861,
             "name": "Draenor Enthusiast",
             "notObtainable": true,
@@ -3368,7 +3384,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievements_zone_brokenshore",
             "id": 862,
             "name": "Broken Isles Enthusiast",
             "notObtainable": true,
@@ -3376,7 +3392,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "inv_zuldazar",
             "id": 863,
             "name": "Zandalar Enthusiast",
             "notObtainable": true,
@@ -3384,7 +3400,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "inv_trinket_80_kultiras01b",
             "id": 864,
             "name": "Kul Tiras Enthusiast",
             "notObtainable": true,
@@ -3392,7 +3408,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "inv_torghast",
             "id": 865,
             "name": "Shadowlands Enthusiast",
             "notObtainable": true,
@@ -3400,7 +3416,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_zone_thaldraszus",
             "id": 866,
             "name": "Dragon Isles Enthusiast",
             "notObtainable": true,
@@ -3408,7 +3424,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_boss_ragnaros",
             "id": 870,
             "name": "Molten Core Prospector",
             "notObtainable": true,
@@ -3416,7 +3432,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "achievement_raid_karazhan",
             "id": 871,
             "name": "Karazhan Graduate",
             "notObtainable": true,
@@ -3447,7 +3463,7 @@
       {
         "items": [
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "inv_cape_special_treasure_c_01",
             "id": 875,
             "name": "Landlubber",
             "notObtainable": true,
@@ -3455,7 +3471,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "inv_cape_special_treasure_c_01",
             "id": 815,
             "name": "Swabbie",
             "notObtainable": true,
@@ -3463,7 +3479,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "inv_cape_special_treasure_c_01",
             "id": 816,
             "name": "Deck Hand",
             "notObtainable": true,
@@ -3471,7 +3487,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "inv_cape_special_treasure_c_01",
             "id": 817,
             "name": "Swashbuckler",
             "notObtainable": true,
@@ -3479,7 +3495,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "inv_cape_special_treasure_c_01",
             "id": 818,
             "name": "Buccaneer",
             "notObtainable": true,
@@ -3487,7 +3503,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "inv_cape_special_treasure_c_01",
             "id": 819,
             "name": "First Mate",
             "notObtainable": true,
@@ -3495,7 +3511,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "inv_cape_special_treasure_c_01",
             "id": 810,
             "name": "Plunderlord",
             "notObtainable": true,
@@ -3503,7 +3519,7 @@
             "type": "title"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "inv_cape_special_treasure_c_01",
             "id": 876,
             "name": "The Treasured",
             "notObtainable": true,
@@ -4189,7 +4205,7 @@
             "type": "achievement"
           },
           {
-            "icon": "inv_misc_questionmark",
+            "icon": "spell_fire_fire",
             "id": 128,
             "name": "The Flawless Victor",
             "notObtainable": true,
@@ -4574,12 +4590,12 @@
             "type": "achievement"
           },
           {
-            "icon": "inv_misc_questionmark",
-            "id": 469,
+            "icon": "garrison_building_sparringarena",
+            "id": 10537,
             "name": "Patron of War",
             "notObtainable": true,
             "titleId": 326,
-            "type": "title"
+            "type": "achievement"
           },
           {
             "icon": "achievement_bg_trueavshutout",


### PR DESCRIPTION
- Gave all titles that were missing an icon an icon that fit with the title of method of obtaining said title.
- All pre-launch event pets/mounts sections are now consistently named 'Pre-launch event'
- Removed Flame Radiance titles that never made it to live and moved the ones that did to the correct section.

