### PR TITLE
New Setting, Planner Availability attribute and Misc Fixes

### DIFF
--- a/src/api/_collectables.js
+++ b/src/api/_collectables.js
@@ -1,4 +1,4 @@
-import { getShowHiddenSetting, getShowUnobtainedSetting, getShowUpcomingSetting } from "../util/utils"
+import { getShowHiddenSetting, getShowUnobtainedSetting, getShowUpcomingSetting, getHideResaleSetting } from "../util/utils"
 
 function getHigherQualityBattlePet(currentPet, newPet) {
     function getPetsQuality(type) {
@@ -28,6 +28,7 @@ export async function parseCollectablesObject(categories, profile, collected_dat
     var showHiddenItems = getShowHiddenSetting();
     var showUnobtainedOnly = getShowUnobtainedSetting();
     var showUpcoming = getShowUpcomingSetting();
+    var hideResale = getHideResaleSetting();
 
     // Build up lookup for items that character has
     collected_data[collectedProperty].forEach((item) => {
@@ -154,6 +155,10 @@ export async function parseCollectablesObject(categories, profile, collected_dat
                 }
 
                 if(hasthis && showUnobtainedOnly == "true") {
+                    showthis = false;
+                }
+
+                if(!hasthis && item.resale && hideResale == "true") {
                     showthis = false;
                 }
 

--- a/src/api/planner.js
+++ b/src/api/planner.js
@@ -28,6 +28,7 @@ export async function getPlannerSteps(mountsPromise, region, realm, character) {
 function parseStepsObject(steps, items) {
     var neededSteps = [];
     steps.forEach((step) => {
+        if (step.unavailable) return;
         if (step.steps) {
             var neededChildSteps = parseStepsObject(step.steps, items);
 

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -95,6 +95,16 @@
 		localStorage.setItem('showUpcoming', $preferences.showUpcoming);
   }
 
+  let hideResale = $preferences.hideResale == "false" ? false : true;
+
+  const toggleHideResale = (e) => {
+    e.preventDefault();
+		$preferences.hideResale = hideResale == true ? "true" : "false";
+
+    localStorage.setItem('showHiddenUpdated',Date.now());
+		localStorage.setItem('hideResale', $preferences.hideResale);
+  }
+
   function setLocale(e, wowhead_url) {
     e.preventDefault();
 
@@ -146,6 +156,10 @@
 
     <div>
       <input type="checkbox" id="showUpcoming" bind:checked={showUpcoming} on:change={toggleShowUpcoming}><label for="showUpcoming">&nbsp Show Upcoming Content</label>
+    </div>
+
+    <div>
+      <input type="checkbox" id="hideResale" bind:checked={hideResale} on:change={toggleHideResale}><label for="hideResale">&nbsp Hide Resale Exclusive Content: TCG / Collector's Edition / Blizzcon / Promotion</label>
     </div>
 
     <div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -69,6 +69,7 @@
 		$preferences.showHiddenFeat = localStorage.getItem('showHiddenFeat') ?? "hidden";
 		$preferences.showUnobtainedOnly = localStorage.getItem('showUnobtainedOnly') ?? "false";
 		$preferences.showUpcoming = localStorage.getItem('showUpcoming') ?? "false";
+		$preferences.hideResale = localStorage.getItem('hideResale') ?? "false";
 	})
 
     function getCharInfoFromURL() {

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -96,6 +96,10 @@ export function getShowUpcomingSetting() {
     return(localStorage.getItem("showUpcoming"));
 }
 
+export function getHideResaleSetting() {
+    return(localStorage.getItem("hideResale"));
+}
+
 export function getShowHiddenUpdated() {
     return(localStorage.getItem("showHiddenUpdated"));
 }

--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -32681,18 +32681,6 @@
           "name": "Expansion Features",
           "subcats": [
             {
-              "items": [
-                {
-                  "icon": "inv_ability_felscarreddemonhunter_demonsurge",
-                  "id": 42028,
-                  "new": true,
-                  "points": 100,
-                  "title": "Ashes to Ashes"
-                }
-              ],
-              "name": "Legion"
-            },
-            {
               "id": "9a7c4830",
               "items": [
                 {
@@ -41306,28 +41294,24 @@
                 {
                   "icon": "achievement_dungeon_heroic_gloryoftheraider",
                   "id": 42148,
-                  "new": true,
                   "points": 0,
                   "title": "The Enterprising Dungeon Master"
                 },
                 {
                   "icon": "inv_shield_05",
                   "id": 42139,
-                  "new": true,
                   "points": 0,
                   "title": "The Enterprising Tank"
                 },
                 {
                   "icon": "petbattle_health",
                   "id": 42141,
-                  "new": true,
                   "points": 0,
                   "title": "The Enterprising Healer"
                 },
                 {
                   "icon": "ability_dualwield",
                   "id": 42144,
-                  "new": true,
                   "points": 0,
                   "title": "The Enterprising Damage Dealer"
                 }

--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -8929,7 +8929,12 @@
                   "id": 41097,
                   "points": 10,
                   "title": "Curiosity Never Killed the Looter"
-                },
+                }
+              ],
+              "name": "Mislaid Curiosities"
+            },
+            {
+              "items": [
                 {
                   "icon": "inv__blacksmithing_skeletonkey",
                   "id": 40819,
@@ -8955,7 +8960,7 @@
                   "title": "The Key to Madness"
                 }
               ],
-              "name": "Treasures"
+              "name": "Bountiful Coffers"
             },
             {
               "id": "ee78ad6d",
@@ -9399,7 +9404,7 @@
                   "title": "Sidestreet Sluice Discoveries"
                 }
               ],
-              "name": "Chests"
+              "name": "Sturdy Chests"
             },
             {
               "items": [
@@ -9933,6 +9938,12 @@
               "id": "79289469",
               "items": [
                 {
+                  "icon": "INV_Misc_Rune_07",
+                  "id": 1172,
+                  "points": 25,
+                  "title": "Master of Warsong Gulch"
+                },
+                {
                   "icon": "Ability_Racial_ShadowMeld",
                   "id": 713,
                   "points": 10,
@@ -10047,12 +10058,6 @@
                   "id": 168,
                   "points": 10,
                   "title": "Warsong Gulch Perfection"
-                },
-                {
-                  "icon": "INV_Misc_Rune_07",
-                  "id": 1172,
-                  "points": 25,
-                  "title": "Master of Warsong Gulch"
                 }
               ],
               "name": ""
@@ -10066,6 +10071,12 @@
             {
               "id": "a2b78bbf",
               "items": [
+                {
+                  "icon": "INV_Jewelry_Amulet_07",
+                  "id": 1169,
+                  "points": 25,
+                  "title": "Master of Arathi Basin"
+                },
                 {
                   "icon": "Ability_Warrior_RallyingCry",
                   "id": 711,
@@ -10157,12 +10168,6 @@
                   "id": 165,
                   "points": 20,
                   "title": "Arathi Basin Perfection"
-                },
-                {
-                  "icon": "INV_Jewelry_Amulet_07",
-                  "id": 1169,
-                  "points": 25,
-                  "title": "Master of Arathi Basin"
                 }
               ],
               "name": ""
@@ -10176,6 +10181,12 @@
             {
               "id": "19d39b7c",
               "items": [
+                {
+                  "icon": "Spell_Nature_EyeOfTheStorm",
+                  "id": 1171,
+                  "points": 25,
+                  "title": "Master of Eye of the Storm"
+                },
                 {
                   "icon": "Spell_Nature_BloodLust",
                   "id": 233,
@@ -10247,12 +10258,6 @@
                   "id": 783,
                   "points": 10,
                   "title": "The Perfect Storm"
-                },
-                {
-                  "icon": "Spell_Nature_EyeOfTheStorm",
-                  "id": 1171,
-                  "points": 25,
-                  "title": "Master of Eye of the Storm"
                 }
               ],
               "name": ""
@@ -10266,6 +10271,12 @@
             {
               "id": "524e28e4",
               "items": [
+                {
+                  "icon": "INV_Jewelry_Necklace_21",
+                  "id": 1167,
+                  "points": 25,
+                  "title": "Master of Alterac Valley"
+                },
                 {
                   "icon": "INV_Jewelry_FrostwolfTrinket_05",
                   "id": 708,
@@ -10383,12 +10394,6 @@
                   "points": 20,
                   "side": "A",
                   "title": "Stormpike Perfection"
-                },
-                {
-                  "icon": "INV_Jewelry_Necklace_21",
-                  "id": 1167,
-                  "points": 25,
-                  "title": "Master of Alterac Valley"
                 }
               ],
               "name": ""
@@ -10534,7 +10539,7 @@
                   "title": "Tour of Duty"
                 }
               ],
-              "name": "Ashran"
+              "name": ""
             },
             {
               "id": "9e539439",
@@ -10554,7 +10559,7 @@
                   "title": "Wrynn's Vanguard"
                 }
               ],
-              "name": "Ashran Reputation"
+              "name": "Reputation"
             },
             {
               "id": "cb24c606",
@@ -10585,6 +10590,20 @@
             {
               "id": "5f6d56ca",
               "items": [
+                {
+                  "icon": "Achievement_BG_winWSG",
+                  "id": 3957,
+                  "points": 25,
+                  "side": "H",
+                  "title": "Master of Isle of Conquest"
+                },
+                {
+                  "icon": "Achievement_BG_winWSG",
+                  "id": 3857,
+                  "points": 25,
+                  "side": "A",
+                  "title": "Master of Isle of Conquest"
+                },
                 {
                   "icon": "INV_Misc_Bomb_01",
                   "id": 3848,
@@ -10692,20 +10711,6 @@
                   "points": 10,
                   "side": "H",
                   "title": "Mine"
-                },
-                {
-                  "icon": "Achievement_BG_winWSG",
-                  "id": 3857,
-                  "points": 25,
-                  "side": "A",
-                  "title": "Master of Isle of Conquest"
-                },
-                {
-                  "icon": "Achievement_BG_winWSG",
-                  "id": 3957,
-                  "points": 25,
-                  "side": "H",
-                  "title": "Master of Isle of Conquest"
                 }
               ],
               "name": ""
@@ -10720,52 +10725,10 @@
               "id": "df9f6638",
               "items": [
                 {
-                  "icon": "inv_misc_statue_07",
-                  "id": 1722,
+                  "icon": "spell_frost_chillingblast",
+                  "id": 1752,
                   "points": 10,
-                  "title": "Archavon the Stone Watcher (10 player)"
-                },
-                {
-                  "icon": "inv_misc_statue_07",
-                  "id": 1721,
-                  "points": 10,
-                  "title": "Archavon the Stone Watcher (25 player)"
-                },
-                {
-                  "icon": "inv_misc_statue_10",
-                  "id": 3136,
-                  "points": 10,
-                  "title": "Emalon the Storm Watcher (10 player)"
-                },
-                {
-                  "icon": "inv_misc_statue_10",
-                  "id": 3137,
-                  "points": 10,
-                  "title": "Emalon the Storm Watcher (25 player)"
-                },
-                {
-                  "icon": "spell_fire_totemofwrath",
-                  "id": 3836,
-                  "points": 10,
-                  "title": "Koralon the Flame Watcher (10 player)"
-                },
-                {
-                  "icon": "spell_fire_totemofwrath",
-                  "id": 3837,
-                  "points": 10,
-                  "title": "Koralon the Flame Watcher (25 player)"
-                },
-                {
-                  "icon": "spell_frost_frostbrand",
-                  "id": 4585,
-                  "points": 10,
-                  "title": "Toravon the Ice Watcher (10 player)"
-                },
-                {
-                  "icon": "spell_frost_frostbrand",
-                  "id": 4586,
-                  "points": 10,
-                  "title": "Toravon the Ice Watcher (25 player)"
+                  "title": "Master of Wintergrasp"
                 },
                 {
                   "icon": "ability_mount_mammoth_black",
@@ -10828,15 +10791,62 @@
                   "id": 1718,
                   "points": 10,
                   "title": "Wintergrasp Veteran"
-                },
-                {
-                  "icon": "spell_frost_chillingblast",
-                  "id": 1752,
-                  "points": 10,
-                  "title": "Master of Wintergrasp"
                 }
               ],
               "name": ""
+            },
+            {
+              "items": [
+                {
+                  "icon": "inv_misc_statue_07",
+                  "id": 1722,
+                  "points": 10,
+                  "title": "Archavon the Stone Watcher (10 player)"
+                },
+                {
+                  "icon": "inv_misc_statue_07",
+                  "id": 1721,
+                  "points": 10,
+                  "title": "Archavon the Stone Watcher (25 player)"
+                },
+                {
+                  "icon": "inv_misc_statue_10",
+                  "id": 3136,
+                  "points": 10,
+                  "title": "Emalon the Storm Watcher (10 player)"
+                },
+                {
+                  "icon": "inv_misc_statue_10",
+                  "id": 3137,
+                  "points": 10,
+                  "title": "Emalon the Storm Watcher (25 player)"
+                },
+                {
+                  "icon": "spell_fire_totemofwrath",
+                  "id": 3836,
+                  "points": 10,
+                  "title": "Koralon the Flame Watcher (10 player)"
+                },
+                {
+                  "icon": "spell_fire_totemofwrath",
+                  "id": 3837,
+                  "points": 10,
+                  "title": "Koralon the Flame Watcher (25 player)"
+                },
+                {
+                  "icon": "spell_frost_frostbrand",
+                  "id": 4585,
+                  "points": 10,
+                  "title": "Toravon the Ice Watcher (10 player)"
+                },
+                {
+                  "icon": "spell_frost_frostbrand",
+                  "id": 4586,
+                  "points": 10,
+                  "title": "Toravon the Ice Watcher (25 player)"
+                }
+              ],
+              "name": "Vault of Archavon"
             }
           ]
         },
@@ -10847,6 +10857,12 @@
             {
               "id": "8cce520b",
               "items": [
+                {
+                  "icon": "achievement_battleground_battleforgilneas",
+                  "id": 5258,
+                  "points": 25,
+                  "title": "Master of the Battle for Gilneas"
+                },
                 {
                   "icon": "achievement_doublerainbow",
                   "id": 5262,
@@ -10930,12 +10946,6 @@
                   "id": 5246,
                   "points": 10,
                   "title": "Battle for Gilneas Veteran"
-                },
-                {
-                  "icon": "achievement_battleground_battleforgilneas",
-                  "id": 5258,
-                  "points": 25,
-                  "title": "Master of the Battle for Gilneas"
                 }
               ],
               "name": ""
@@ -10949,6 +10959,12 @@
             {
               "id": "e4f61970",
               "items": [
+                {
+                  "icon": "Spell_Nature_EarthShock",
+                  "id": 5223,
+                  "points": 25,
+                  "title": "Master of Twin Peaks"
+                },
                 {
                   "icon": "INV_Misc_Head_Dwarf_01",
                   "id": 5228,
@@ -11074,12 +11090,6 @@
                   "id": 5209,
                   "points": 10,
                   "title": "Twin Peaks Veteran"
-                },
-                {
-                  "icon": "Spell_Nature_EarthShock",
-                  "id": 5223,
-                  "points": 25,
-                  "title": "Master of Twin Peaks"
                 }
               ],
               "name": ""
@@ -11093,6 +11103,12 @@
             {
               "id": "8d21d88f",
               "items": [
+                {
+                  "icon": "achievement_battleground_silvershardmines",
+                  "id": 7106,
+                  "points": 10,
+                  "title": "Master of Silvershard Mines"
+                },
                 {
                   "icon": "achievement_battleground_silvershardmines",
                   "id": 6739,
@@ -11152,12 +11168,6 @@
                   "id": 7103,
                   "points": 10,
                   "title": "Greed is Good"
-                },
-                {
-                  "icon": "achievement_battleground_silvershardmines",
-                  "id": 7106,
-                  "points": 10,
-                  "title": "Master of Silvershard Mines"
                 }
               ],
               "name": ""
@@ -11171,6 +11181,12 @@
             {
               "id": "d99eb0d0",
               "items": [
+                {
+                  "icon": "achievement_battleground_templeofkotmogu",
+                  "id": 6981,
+                  "points": 10,
+                  "title": "Master of Temple of Kotmogu"
+                },
                 {
                   "icon": "achievement_battleground_templeofkotmogu",
                   "id": 6740,
@@ -11224,12 +11240,6 @@
                   "id": 6980,
                   "points": 10,
                   "title": "Temple of Kotmogu All-Star"
-                },
-                {
-                  "icon": "achievement_battleground_templeofkotmogu",
-                  "id": 6981,
-                  "points": 10,
-                  "title": "Master of Temple of Kotmogu"
                 }
               ],
               "name": ""
@@ -11242,6 +11252,12 @@
           "subcats": [
             {
               "items": [
+                {
+                  "icon": "ability_warrior_intensifyrage",
+                  "id": 12412,
+                  "points": 25,
+                  "title": "Master of Seething Shore"
+                },
                 {
                   "icon": "achievement_zone_sholazar_07",
                   "id": 12409,
@@ -11289,12 +11305,6 @@
                   "id": 12407,
                   "points": 20,
                   "title": "Seething Shore Perfection"
-                },
-                {
-                  "icon": "ability_warrior_intensifyrage",
-                  "id": 12412,
-                  "points": 25,
-                  "title": "Master of Seething Shore"
                 }
               ],
               "name": ""
@@ -11308,6 +11318,12 @@
             {
               "id": "1363cb3b",
               "items": [
+                {
+                  "icon": "achievement_bg_dg_master_of_the_deepwind_gorge",
+                  "id": 14175,
+                  "points": 10,
+                  "title": "Master of Deepwind Gorge"
+                },
                 {
                   "icon": "achievement_bg_abshutout",
                   "id": 8333,
@@ -11325,12 +11341,6 @@
                   "id": 8331,
                   "points": 10,
                   "title": "Deepwind Gorge Victory"
-                },
-                {
-                  "icon": "achievement_bg_dg_master_of_the_deepwind_gorge",
-                  "id": 14175,
-                  "points": 10,
-                  "title": "Master of Deepwind Gorge"
                 },
                 {
                   "icon": "achievement_cooking_masterofthesteamer",
@@ -11361,6 +11371,12 @@
           "subcats": [
             {
               "items": [
+                {
+                  "icon": "inv_achievement_battleground_earthen",
+                  "id": 40617,
+                  "points": 25,
+                  "title": "Deepholla"
+                },
                 {
                   "icon": "inv_achievement_battleground_earthen",
                   "id": 40210,
@@ -11420,12 +11436,6 @@
                   "id": 40616,
                   "points": 10,
                   "title": "Unexpected Arrivals"
-                },
-                {
-                  "icon": "inv_achievement_battleground_earthen",
-                  "id": 40617,
-                  "points": 25,
-                  "title": "Deepholla"
                 }
               ],
               "name": ""
@@ -15837,7 +15847,7 @@
                   "title": "Unbound Monstrosities"
                 }
               ],
-              "name": "World"
+              "name": "World Bosses"
             },
             {
               "id": "ba6fd32a",
@@ -18090,7 +18100,7 @@
                   "title": "The Legion Will NOT Conquer All"
                 }
               ],
-              "name": "World"
+              "name": "World Bosses"
             }
           ]
         },
@@ -19079,18 +19089,6 @@
               "name": "Siege of Orgrimmar"
             },
             {
-              "id": "ce08fda2",
-              "items": [
-                {
-                  "icon": "inv_pa_celestialmallet",
-                  "id": 8535,
-                  "points": 10,
-                  "title": "Celestial Challenge"
-                }
-              ],
-              "name": "Timeless Isle"
-            },
-            {
               "id": "b8465ad6",
               "items": [
                 {
@@ -19116,9 +19114,15 @@
                   "id": 8028,
                   "points": 10,
                   "title": "Praise the Sun!"
+                },
+                {
+                  "icon": "inv_pa_celestialmallet",
+                  "id": 8535,
+                  "points": 10,
+                  "title": "Celestial Challenge"
                 }
               ],
-              "name": "World"
+              "name": "World Bosses"
             }
           ]
         },
@@ -21110,7 +21114,7 @@
                   "title": "Earth, Wind & Fire (25 player)"
                 }
               ],
-              "name": "Wrath of the Lich King"
+              "name": "Vault of Archavon"
             },
             {
               "id": "1ea8e3b6",
@@ -21394,7 +21398,7 @@
               ],
               "name": "Icecrown Citadel (Normal) (10 player)"
             },
-            {
+                        {
               "id": "29e5f824",
               "items": [
                 {
@@ -21435,24 +21439,6 @@
                 }
               ],
               "name": "Icecrown Citadel (Heroic) (10 player)"
-            },
-            {
-              "id": "3275e1d6",
-              "items": [
-                {
-                  "icon": "Spell_Shadow_Twilight",
-                  "id": 4817,
-                  "points": 10,
-                  "title": "The Twilight Destroyer (10 player)"
-                },
-                {
-                  "icon": "Spell_Shadow_Twilight",
-                  "id": 4818,
-                  "points": 10,
-                  "title": "Heroic: The Twilight Destroyer (10 player)"
-                }
-              ],
-              "name": "The Ruby Sanctum (10 player)"
             },
             {
               "id": "84fe80fd",
@@ -21615,6 +21601,24 @@
                 }
               ],
               "name": "Icecrown Citadel (Heroic) (25 player)"
+            },
+            {
+              "id": "3275e1d6",
+              "items": [
+                {
+                  "icon": "Spell_Shadow_Twilight",
+                  "id": 4817,
+                  "points": 10,
+                  "title": "The Twilight Destroyer (10 player)"
+                },
+                {
+                  "icon": "Spell_Shadow_Twilight",
+                  "id": 4818,
+                  "points": 10,
+                  "title": "Heroic: The Twilight Destroyer (10 player)"
+                }
+              ],
+              "name": "The Ruby Sanctum (10 player)"
             },
             {
               "id": "c3f5b02c",
@@ -25183,7 +25187,12 @@
                   "id": 9422,
                   "points": 10,
                   "title": "The Search For Fact, Not Truth"
-                },
+                }
+              ],
+              "name": "Artifacts"
+            },
+            {
+              "items": [
                 {
                   "icon": "inv_misc_shovel_01",
                   "id": 10607,
@@ -25215,7 +25224,7 @@
                   "title": "Lengthy Legwork"
                 }
               ],
-              "name": "Counts"
+              "name": "Completion"
             },
             {
               "id": "69a2692d",
@@ -31905,7 +31914,7 @@
                   "title": "Thanks for the Carry!"
                 }
               ],
-              "name": "Mount Count"
+              "name": "Count"
             },
             {
               "id": "4d1e4719",
@@ -31928,6 +31937,12 @@
             {
               "id": "137378e0",
               "items": [
+                {
+                  "icon": "inv_jewelry_ring_42",
+                  "id": 10694,
+                  "points": 10,
+                  "title": "Fabulous"
+                },
                 {
                   "icon": "inv_misc_cape_18",
                   "id": 10687,
@@ -31999,12 +32014,6 @@
                   "id": 10688,
                   "points": 5,
                   "title": "Fashionista: Wrist"
-                },
-                {
-                  "icon": "inv_jewelry_ring_42",
-                  "id": 10694,
-                  "points": 10,
-                  "title": "Fabulous"
                 }
               ],
               "name": "Appearances"
@@ -32574,7 +32583,13 @@
                   "id": 16700,
                   "points": 5,
                   "title": "Renewed Proto-Drake Horns and Hair"
-                },
+                }
+              ],
+              "name": "Renewed Proto-Drake"
+            },
+            {
+              "items": [
+                
                 {
                   "icon": "inv_companionpterrordaxdrake",
                   "id": 16701,
@@ -32604,7 +32619,12 @@
                   "id": 16706,
                   "points": 5,
                   "title": "Windborne Velocidrake Back and Tail"
-                },
+                }
+              ],
+              "name": "Windborne Velocidrake"
+            },
+            {
+              "items": [
                 {
                   "icon": "inv_companiondrake",
                   "id": 16707,
@@ -32634,7 +32654,12 @@
                   "id": 16712,
                   "points": 5,
                   "title": "Highland Drake Head Features"
-                },
+                }
+              ],
+              "name": "Highland Drake"
+            },
+            {
+              "items": [
                 {
                   "icon": "inv_companionwyvern",
                   "id": 16723,
@@ -32666,7 +32691,7 @@
                   "title": "Cliffside Wylderdrake Head Features"
                 }
               ],
-              "name": ""
+              "name": "Cliffside Wylderdrake"
             }
           ]
         }
@@ -36651,7 +36676,12 @@
                   "id": 9128,
                   "points": 5,
                   "title": "Grand Master Draftsman"
-                },
+                }
+              ],
+              "name": "Blueprints"
+            },
+            {
+              "items": [
                 {
                   "icon": "inv_letter_01",
                   "id": 9405,
@@ -36671,7 +36701,7 @@
                   "title": "Working Many Orders"
                 }
               ],
-              "name": "Blueprints"
+              "name": "Work Orders"
             },
             {
               "id": "24b9b861",
@@ -40895,6 +40925,13 @@
                   "title": "Shadowlands Keystone Hero: Season Three"
                 },
                 {
+                  "icon": "achievement_challengemode_platinum",
+                  "id": 15691,
+                  "notObtainable": true,
+                  "points": 0,
+                  "title": "Cryptic Hero: Shadowlands Season 3"
+                },
+                {
                   "icon": "achievement_challengemode_silver",
                   "id": 15688,
                   "notObtainable": true,
@@ -40914,13 +40951,6 @@
                   "notObtainable": true,
                   "points": 0,
                   "title": "Shadowlands Keystone Master: Season Four"
-                },
-                {
-                  "icon": "achievement_challengemode_platinum",
-                  "id": 15691,
-                  "notObtainable": true,
-                  "points": 0,
-                  "title": "Cryptic Hero: Shadowlands Season 3"
                 },
                 {
                   "icon": "achievement_challengemode_platinum",

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -10331,6 +10331,7 @@
             "icon": "ability_mount_bigblizzardbear",
             "itemId": 43599,
             "name": "Big Blizzard Bear",
+            "resale": true,
             "spellid": 58983
           },
           {
@@ -10338,6 +10339,7 @@
             "icon": "inv_allianceshipmount",
             "itemId": 151618,
             "name": "Stormwind Skychaser",
+            "resale": true,
             "side": "A",
             "spellid": 245723
           },
@@ -10346,6 +10348,7 @@
             "icon": "inv_hordezeppelinmount",
             "itemId": 151617,
             "name": "Orgrimmar Interceptor",
+            "resale": true,
             "side": "H",
             "spellid": 245725
           },
@@ -10353,6 +10356,7 @@
             "ID": 1517,
             "icon": "4054329",
             "name": "Bound Blizzard",
+            "resale": true,
             "spellid": 358072
           }
         ],
@@ -10378,7 +10382,7 @@
             "icon": "inv_felstalkermount",
             "itemId": 128425,
             "name": "Illidari Felstalker",
-            "notObtainable": true,
+            "resale": true,
             "spellid": 189998
           },
           {
@@ -10386,7 +10390,7 @@
             "icon": "inv_dressedhorse",
             "itemId": 153539,
             "name": "Seabraid Stallion",
-            "notObtainable": true,
+            "resale": true,
             "side": "A",
             "spellid": 255695
           },
@@ -10395,7 +10399,7 @@
             "icon": "inv_armoredraptor",
             "itemId": 153540,
             "name": "Gilded Ravasaur",
-            "notObtainable": true,
+            "resale": true,
             "side": "H",
             "spellid": 255696
           },
@@ -10449,7 +10453,8 @@
             "ID": 2582,
             "icon": "inv_celestialserpentmount_jade",
             "name": "Shaohao's Sage Serpent",
-            "new": true,
+            "notObtainable": true,
+            "notReleased": true,
             "spellid": 1236262
           }
         ],
@@ -10596,6 +10601,7 @@
             "icon": "inv_motorcyclefelreavermount_fire",
             "itemId": 211087,
             "name": "Hateforged Blazecycle",
+            "resale": true,
             "spellid": 428067
           }
         ],
@@ -10677,6 +10683,7 @@
             "icon": "ability_mount_spectraltiger",
             "itemId": 49283,
             "name": "Spectral Tiger",
+            "resale": true,
             "spellid": 42776
           },
           {
@@ -10684,6 +10691,7 @@
             "icon": "ability_mount_spectraltiger",
             "itemId": 49284,
             "name": "Swift Spectral Tiger",
+            "resale": true,
             "spellid": 42777
           },
           {
@@ -10691,6 +10699,7 @@
             "icon": "inv_misc_missilesmall_blue",
             "itemId": 49285,
             "name": "X-51 Nether-Rocket",
+            "resale": true,
             "spellid": 46197
           },
           {
@@ -10712,6 +10721,7 @@
             "icon": "ability_druid_challangingroar",
             "itemId": 49282,
             "name": "Big Battle Bear",
+            "resale": true,
             "spellid": 51412
           },
           {
@@ -10719,6 +10729,7 @@
             "icon": "inv_egg_03",
             "itemId": 49290,
             "name": "Magic Rooster",
+            "resale": true,
             "spellid": 65917
           },
           {
@@ -10726,6 +10737,7 @@
             "icon": "ability_mount_drake_bronze",
             "itemId": 68008,
             "name": "Mottled Drake",
+            "resale": true,
             "spellid": 93623
           },
           {
@@ -10733,6 +10745,7 @@
             "icon": "ability_mount_raptor",
             "itemId": 69228,
             "name": "Savage Raptor",
+            "resale": true,
             "spellid": 97581
           },
           {
@@ -10740,6 +10753,7 @@
             "icon": "ability_hunter_pet_dragonhawk",
             "itemId": 68825,
             "name": "Amani Dragonhawk",
+            "resale": true,
             "spellid": 96503
           },
           {
@@ -10747,6 +10761,7 @@
             "icon": "ability_hunter_pet_tallstrider",
             "itemId": 71718,
             "name": "Swift Shorestrider",
+            "resale": true,
             "spellid": 101573
           },
           {
@@ -10754,6 +10769,7 @@
             "icon": "ability_mount_warhippogryph",
             "itemId": 72582,
             "name": "Corrupted Hippogryph",
+            "resale": true,
             "spellid": 102514
           },
           {
@@ -10761,6 +10777,7 @@
             "icon": "ability_mount_camel_gray",
             "itemId": 72575,
             "name": "White Riding Camel",
+            "resale": true,
             "spellid": 102488
           },
           {
@@ -10768,6 +10785,7 @@
             "icon": "ability_mount_feldrake",
             "itemId": 79771,
             "name": "Feldrake",
+            "resale": true,
             "spellid": 113120
           },
           {
@@ -10775,6 +10793,7 @@
             "icon": "inv_ghostlycharger",
             "itemId": 93671,
             "name": "Ghastly Charger",
+            "resale": true,
             "spellid": 136505
           }
         ],

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -581,7 +581,7 @@
             "spellid": 473188
           }
         ],
-        "name": "Paragon"
+        "name": "Paragon Reputation"
       },
       {
         "items": [

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -11814,6 +11814,7 @@
             "icon": "inv_pet_babymurlocs_blue",
             "itemId": 20371,
             "name": "Murky",
+            "resale": true,
             "spellid": 24696
           },
           {
@@ -11822,6 +11823,7 @@
             "icon": "inv_pet_grunty",
             "itemId": 46802,
             "name": "Grunty",
+            "resale": true,
             "spellid": 66030
           },
           {
@@ -11830,6 +11832,7 @@
             "icon": "inv_dragonwhelpcataclysm",
             "itemId": 67418,
             "name": "Deathy",
+            "resale": true,
             "spellid": 94070
           },
           {
@@ -11838,6 +11841,7 @@
             "icon": "inv_pet_diablobabymurloc",
             "itemId": 71726,
             "name": "Murkablo",
+            "resale": true,
             "spellid": 101606
           },
           {
@@ -11846,6 +11850,7 @@
             "icon": "inv_mace_1h_pandung_c_01",
             "itemId": 106244,
             "name": "Murkalot",
+            "resale": true,
             "spellid": 149792
           },
           {
@@ -11854,6 +11859,7 @@
             "icon": "inv_grommloc",
             "itemId": 118517,
             "name": "Grommloc",
+            "resale": true,
             "spellid": 177234
           },
           {
@@ -11862,6 +11868,7 @@
             "icon": "inv_dhmurloc",
             "itemId": 128427,
             "name": "Murkidan",
+            "resale": true,
             "spellid": 190036
           },
           {
@@ -11870,6 +11877,7 @@
             "icon": "inv_pet_alliancemurloc",
             "itemId": 141894,
             "name": "Knight-Captain Murky",
+            "resale": true,
             "spellid": 227052
           },
           {
@@ -11878,6 +11886,7 @@
             "icon": "inv_pet_hordemurloc",
             "itemId": 141895,
             "name": "Legionnaire Murky",
+            "resale": true,
             "spellid": 227051
           },
           {
@@ -11886,6 +11895,7 @@
             "icon": "inv_encrypted18",
             "itemId": null,
             "name": "Gillvanas",
+            "resale": true,
             "side": "H",
             "spellid": 307654
           },
@@ -11895,6 +11905,7 @@
             "icon": "inv_encrypted19",
             "itemId": null,
             "name": "Finduin",
+            "resale": true,
             "side": "A",
             "spellid": 307655
           },
@@ -11903,6 +11914,7 @@
             "creatureId": 175203,
             "icon": "inv_dragonwhelpoutland2_light",
             "name": "Moon-Touched Netherwhelp",
+            "notObtainable": true,
             "spellid": 344755
           },
           {
@@ -11910,6 +11922,7 @@
             "creatureId": 205467,
             "icon": "inv_murkyysera",
             "name": "Ysergle",
+            "resale": true,
             "spellid": 411448
           }
         ],
@@ -11924,6 +11937,7 @@
             "icon": "inv_sword_07",
             "itemId": 39656,
             "name": "Mini Tyrael",
+            "resale": true,
             "spellid": 53082
           }
         ],
@@ -11937,6 +11951,7 @@
             "icon": "inv_diablostone",
             "itemId": 13584,
             "name": "Mini Diablo",
+            "resale": true,
             "spellid": 17708
           },
           {
@@ -11945,6 +11960,7 @@
             "icon": "inv_belt_05",
             "itemId": 13583,
             "name": "Panda Cub",
+            "resale": true,
             "spellid": 17707
           },
           {
@@ -11953,6 +11969,7 @@
             "icon": "spell_shadow_summonfelhunter",
             "itemId": 13582,
             "name": "Zergling",
+            "resale": true,
             "spellid": 17709
           },
           {
@@ -11970,6 +11987,7 @@
             "icon": "inv_netherwhelp",
             "itemId": 25535,
             "name": "Netherwhelp",
+            "resale": true,
             "spellid": 32298
           },
           {
@@ -11978,6 +11996,7 @@
             "icon": "inv_pet_frostwyrm",
             "itemId": 39286,
             "name": "Frosty",
+            "resale": true,
             "spellid": 52615
           },
           {
@@ -11986,6 +12005,7 @@
             "icon": "inv_dragonwhelpcataclysm",
             "itemId": 62540,
             "name": "Lil' Deathwing",
+            "resale": true,
             "spellid": 87344
           },
           {
@@ -12010,6 +12030,7 @@
             "icon": "inv_felstalker_pet",
             "itemId": 128426,
             "name": "Nibbles",
+            "resale": true,
             "spellid": 190020
           },
           {
@@ -12018,6 +12039,7 @@
             "icon": "inv_babytortollan",
             "itemId": 153541,
             "name": "Tottle",
+            "resale": true,
             "spellid": 255702
           },
           {
@@ -12114,6 +12136,7 @@
             "icon": "inv_spear_05",
             "itemId": 76062,
             "name": "Fetish Shaman",
+            "resale": true,
             "spellid": 105633
           },
           {
@@ -12222,6 +12245,7 @@
             "icon": "inv_pet_futurebotpet_orange",
             "itemId": 228790,
             "name": "Thrillbot 9000",
+            "resale": true,
             "spellid": 463242
           },
           {
@@ -12230,6 +12254,7 @@
             "icon": "inv_pet_futurebotpet_purple",
             "itemId": 228793,
             "name": "Chillbot 9000",
+            "resale": true,
             "spellid": 463251
           }
         ],
@@ -12243,6 +12268,7 @@
             "icon": "inv_brokerworm_pink",
             "itemId": 228765,
             "name": "Gummi",
+            "resale": true,
             "spellid": 463148
           }
         ],
@@ -12364,6 +12390,7 @@
             "icon": "achievement_boss_xt002deconstructor_01",
             "itemId": 67128,
             "name": "Landro's Lil' XT",
+            "resale": true,
             "spellid": 93624
           },
           {
@@ -12372,6 +12399,7 @@
             "icon": "achievement_boss_kelthuzad_01",
             "itemId": 68840,
             "name": "Landro's Lichling",
+            "resale": true,
             "spellid": 96817
           },
           {
@@ -12380,6 +12408,7 @@
             "icon": "ability_mount_jungletiger",
             "itemId": 68841,
             "name": "Nightsaber Cub",
+            "resale": true,
             "spellid": 96819
           },
           {
@@ -12388,6 +12417,7 @@
             "icon": "inv_misc_fish_34",
             "itemId": 71624,
             "name": "Purple Puffer",
+            "resale": true,
             "spellid": 101493
           },
           {
@@ -12396,6 +12426,7 @@
             "icon": "spell_shadow_summonimp",
             "itemId": 72134,
             "name": "Gregarious Grell",
+            "resale": true,
             "spellid": 102317
           },
           {
@@ -12404,6 +12435,7 @@
             "icon": "spell_shadow_evileye",
             "itemId": 79744,
             "name": "Eye of the Legion",
+            "resale": true,
             "spellid": 112994
           },
           {
@@ -12412,6 +12444,7 @@
             "icon": "inv_scarab_clay",
             "itemId": 72153,
             "name": "Sand Scarab",
+            "resale": true,
             "spellid": 102353
           },
           {
@@ -12420,6 +12453,7 @@
             "icon": "inv_misc_book_18",
             "itemId": 93669,
             "name": "Gusting Grimoire",
+            "resale": true,
             "spellid": 136484
           }
         ],
@@ -12469,6 +12503,7 @@
             "icon": "inv_misc_pet_02",
             "itemId": 49662,
             "name": "Gryphon Hatchling",
+            "resale": true,
             "spellid": 69535
           },
           {
@@ -12477,6 +12512,7 @@
             "icon": "inv_misc_pet_04",
             "itemId": 49663,
             "name": "Wind Rider Cub",
+            "resale": true,
             "spellid": 69536
           },
           {
@@ -12493,6 +12529,7 @@
             "icon": "inv_babymurlo3frost",
             "itemId": 229366,
             "name": "Brrrgl",
+            "resale": true,
             "spellid": 464798
           },
           {
@@ -12501,6 +12538,7 @@
             "icon": "inv_babymurloc3bronze",
             "itemId": 238796,
             "name": "Thrrrdgl",
+            "resale": true,
             "spellid": 1226305
           }
         ],

--- a/static/data/planner.json
+++ b/static/data/planner.json
@@ -1015,6 +1015,7 @@
 			  },
 			  {
 				"capital":true,
+				"unavailable": true,
 				"steps": [
 				  {
 					"bosses": [
@@ -1357,6 +1358,7 @@
 			"notes":"Set Hearthstone to Faction Capital",
 			"steps": [
 				{
+					"unavailable": true,
 					"steps": [
 					  {
 						"bosses": [
@@ -1394,7 +1396,7 @@
 						"title": "Run Darkflame Cleft"
 					  }
 					],
-					"title": "Fly to Darkflame Cleft"
+					"title": "Flightpath to Ringing Deeps"
 				  },
 				  {
 					"steps": [

--- a/static/data/titles.json
+++ b/static/data/titles.json
@@ -284,7 +284,6 @@
             "icon": "achievement_dungeon_heroic_gloryoftheraider",
             "id": 42148,
             "name": "The Triple Threat",
-            "new": true,
             "titleId": 636,
             "type": "achievement"
           },

--- a/static/data/toys.json
+++ b/static/data/toys.json
@@ -7074,7 +7074,8 @@
             "ID": 252,
             "icon": "ability_mount_ridinghorse",
             "itemId": 69215,
-            "name": "War Party Hitching Post"
+            "name": "War Party Hitching Post",
+            "resale": true
           },
           {
             "ID": 7,
@@ -7086,13 +7087,15 @@
             "ID": 19,
             "icon": "trade_archaeology_uldumcanopicjar",
             "itemId": 72161,
-            "name": "Spurious Sarcophagus"
+            "name": "Spurious Sarcophagus",
+            "resale": true
           },
           {
             "ID": 233,
             "icon": "inv_misc_bag_10",
             "itemId": 71628,
-            "name": "Sack of Starfish"
+            "name": "Sack of Starfish",
+            "resale": true
           },
           {
             "ID": 4,
@@ -7104,7 +7107,8 @@
             "ID": 110,
             "icon": "inv_misc_missilesmall_purple",
             "itemId": 49703,
-            "name": "Perpetual Purple Firework"
+            "name": "Perpetual Purple Firework",
+            "resale": true
           },
           {
             "ID": 100,
@@ -7128,13 +7132,15 @@
             "ID": 215,
             "icon": "inv_misc_statue_02",
             "itemId": 54212,
-            "name": "Instant Statue Pedestal"
+            "name": "Instant Statue Pedestal",
+            "resale": true
           },
           {
             "ID": 12,
             "icon": "spell_fire_twilightfire",
             "itemId": 67097,
-            "name": "Grim Campfire"
+            "name": "Grim Campfire",
+            "resale": true
           },
           {
             "ID": 253,
@@ -7152,7 +7158,8 @@
             "ID": 203,
             "icon": "inv_misc_gem_goldendraenite_01",
             "itemId": 69227,
-            "name": "Fool's Gold"
+            "name": "Fool's Gold",
+            "resale": true
           },
           {
             "ID": 5,
@@ -7164,31 +7171,36 @@
             "ID": 128,
             "icon": "achievement_boss_illidan",
             "itemId": 79769,
-            "name": "Demon Hunter's Aspect"
+            "name": "Demon Hunter's Aspect",
+            "resale": true
           },
           {
             "ID": 102,
             "icon": "inv_misc_discoball_01",
             "itemId": 38301,
-            "name": "D.I.S.C.O."
+            "name": "D.I.S.C.O.",
+            "resale": true
           },
           {
             "ID": 111,
             "icon": "inv_misc_idol_01",
             "itemId": 49704,
-            "name": "Carved Ogre Idol"
+            "name": "Carved Ogre Idol",
+            "resale": true
           },
           {
             "ID": 448,
             "icon": "achievement_dungeon_outland_dungeonmaster",
             "itemId": 93672,
-            "name": "Dark Portal"
+            "name": "Dark Portal",
+            "resale": true
           },
           {
             "ID": 471,
             "icon": "ability_mage_netherwindpresence",
             "itemId": 54452,
-            "name": "Ethereal Portal"
+            "name": "Ethereal Portal",
+            "resale": true
           }
         ],
         "name": "Trading Card Game"
@@ -7200,28 +7212,29 @@
             "ID": 30,
             "icon": "inv_misc_head_murloc_01",
             "itemId": 33079,
-            "name": "Murloc Costume"
+            "name": "Murloc Costume",
+            "resale": true
           },
           {
             "ID": 823,
             "icon": "inv_misc_8xp_encrypted03",
             "itemId": 163987,
             "name": "Stormwind Champion's War Banner",
-            "notObtainable": true
+            "resale": true
           },
           {
             "ID": 824,
             "icon": "inv_misc_8xp_encrypted04",
             "itemId": 163986,
             "name": "Orgrimmar Hero's War Banner",
-            "notObtainable": true
+            "resale": true
           },
           {
             "ID": 1430,
             "icon": "item_blizzconbanner01",
             "itemId": 210042,
             "name": "Chilling Celebration Banner",
-            "notObtainable": true
+            "resale": true
           }
         ],
         "name": "Blizzcon"


### PR DESCRIPTION
**New Setting**
Added a new setting that hides all (unowned) Resale Exclusive items (TCG/Blizzcon/Collector's Edition/Past Promotions) as this was a common frustration as they technically were still obtainable but almost exclusive through either insane amounts of gold or real money purchases through 3rd parties.

**Planner**
Change for #706, planner now has a check if an attribute for 'unavailable' is present and will hide it if so. Currently applied to the Stonevault dungeon and Mechagon dungeon.

I'm considering expanding the planner much further but for now at least it can be corrected per season. Would like to add checkboxes to each row so the planner can be used more as a to-do list.

**Consistency updates**
Did a quick pass through a bunch of sections and tried to make things like naming and placement a bit more consistent.

