### PR TITLE
Marked Collector's Bounty boosted bosses in the planner

### DIFF
--- a/src/components/MountsPlanner.svelte
+++ b/src/components/MountsPlanner.svelte
@@ -100,7 +100,11 @@
                         {#each step.bosses as boss}
                             <tbody>
                                 <tr>
+                                    {#if boss.boosted}
+                                    <td class="mnt-plan-boss-col mnt-plan-boss-boosted">{boss.name}</td>
+                                    {:else}
                                     <td class="mnt-plan-boss-col">{boss.name}</td>
+                                    {/if}
                                     <td class="mnt-plan-mount-col">
                                         {#if boss.itemId}
                                             <a class="{anchorCss(boss)}" target="{settings.anchorTarget}" href="//{settings.WowHeadUrl}/item={ boss.itemId }">

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -293,6 +293,10 @@ body {
 	top: -2px;
 	margin-right: 4px;
   }
+  .mnt-plan-boss-boosted {
+    color: #D4AF37;
+    font-weight: bold;
+  }
   .mnt-plan-rare {
 	color: #0070dd;
   }

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -323,6 +323,13 @@
       {
         "items": [
           {
+            "ID": 439,
+            "icon": "ability_mount_tyraelmount",
+            "itemId": 76755,
+            "name": "Tyrael's Charger",
+            "spellid": 107203
+          },
+          {
             "ID": 2605,
             "icon": "inv_inariusmount",
             "itemId": 246264,
@@ -9386,13 +9393,6 @@
             "name": "Spectral Gryphon",
             "side": "A",
             "spellid": 107516
-          },
-          {
-            "ID": 439,
-            "icon": "ability_mount_tyraelmount",
-            "itemId": 76755,
-            "name": "Tyrael's Charger",
-            "spellid": 107203
           },
           {
             "ID": 454,

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -286,6 +286,19 @@
           }
         ],
         "name": "Dastardly Duos"
+      },
+      {
+        "items": [
+          {
+            "ID": 3580,
+            "creatureId": 205637,
+            "icon": "inv_demongoat_crimson",
+            "itemId": 206018,
+            "name": "Baa'lial",
+            "spellid": 411791
+          }
+        ],
+        "name": "Greedy Emissary"
       }
     ]
   },
@@ -12416,20 +12429,6 @@
           }
         ],
         "name": "Diablo III"
-      },
-      {
-        "items": [
-          {
-            "ID": 3580,
-            "creatureId": 205637,
-            "icon": "inv_demongoat_crimson",
-            "itemId": 206018,
-            "name": "Baa'lial",
-            "notObtainable": true,
-            "spellid": 411791
-          }
-        ],
-        "name": "Diablo IV"
       },
       {
         "items": [

--- a/static/data/planner.json
+++ b/static/data/planner.json
@@ -16,7 +16,8 @@
 					"mount": "Drake of the North Wind",
 					"name": "Altairus",
 					"note": "You can run Heroic once per day and up to 10x Normal an hour",
-					"spellId": 88742
+					"spellId": 88742,
+					"boosted": true
 				  }
 				],
 				"title": "Run Vortex Pinnacle"
@@ -30,7 +31,8 @@
 					"itemId": 63041,
 					"mount": "Drake of the South Wind",
 					"name": "Al'akir",
-					"spellId": 88744
+					"spellId": 88744,
+					"boosted": true
 				  }
 				],
 				"title": "Run Throne of the Four Winds"
@@ -92,7 +94,8 @@
 						"itemId": 49636,
 						"mount": "Onyxian Drake",
 						"name": "Onyxia",
-						"spellId": 69395
+						"spellId": 69395,
+						"boosted": true
 					  }
 					],
 					"title": "Run Onyxia"
@@ -118,7 +121,8 @@
 						"mount": "Invincible's Reins",
 						"name": "The Lich King",
 						"note": "Heroic 25 only",
-						"spellId": 72286
+						"spellId": 72286,
+						"boosted": true
 					  }
 					],
 					"title": "Run Icecrown Citadel"
@@ -137,7 +141,8 @@
 						"icon": "ability_mount_mammoth_black",
 						"itemId": 43959,
 						"mount": "Grand Black War Mammoth",
-						"name": "Koralon"
+						"name": "Koralon",
+						"boosted": true
 					  },
 					  {
 						"ID": "286",
@@ -146,7 +151,8 @@
 						"icon": "ability_mount_mammoth_black",
 						"itemId": 43959,
 						"mount": "Grand Black War Mammoth",
-						"name": "Toravon"
+						"name": "Toravon",
+						"boosted": true
 					  },
 					  {
 						"ID": "286",
@@ -155,7 +161,8 @@
 						"icon": "ability_mount_mammoth_black",
 						"itemId": 43959,
 						"mount": "Grand Black War Mammoth",
-						"name": "Archavon"
+						"name": "Archavon",
+						"boosted": true
 					  },
 					  {
 						"ID": "286",
@@ -164,43 +171,48 @@
 						"icon": "ability_mount_mammoth_black",
 						"itemId": 43959,
 						"mount": "Grand Black War Mammoth",
-						"name": "Emalon"
+						"name": "Emalon",
+						"boosted": true
 					  },
 					  {
 						"ID": "287",
+						"isAlliance": false,
 						"epic": true,
-						"isHorde": true,
 						"icon": "ability_mount_mammoth_black",
 						"itemId": 44083,
 						"mount": "Grand Black War Mammoth",
-						"name": "Koralon"
+						"name": "Koralon",
+						"boosted": true
 					  },
 					  {
 						"ID": "287",
+						"isAlliance": false,
 						"epic": true,
-						"isHorde": true,
 						"icon": "ability_mount_mammoth_black",
 						"itemId": 44083,
 						"mount": "Grand Black War Mammoth",
-						"name": "Toravon"
+						"name": "Toravon",
+						"boosted": true
 					  },
 					  {
 						"ID": "287",
+						"isAlliance": false,
 						"epic": true,
-						"isHorde": true,
 						"icon": "ability_mount_mammoth_black",
 						"itemId": 44083,
 						"mount": "Grand Black War Mammoth",
-						"name": "Archavon"
+						"name": "Archavon",
+						"boosted": true
 					  },
 					  {
 						"ID": "287",
+						"isAlliance": false,
 						"epic": true,
-						"isHorde": true,
 						"icon": "ability_mount_mammoth_black",
 						"itemId": 44083,
 						"mount": "Grand Black War Mammoth",
-						"name": "Emalon"
+						"name": "Emalon",
+						"boosted": true
 					  }
 					],
 					"title": "Run Vault of Archavon"
@@ -219,7 +231,8 @@
 						"itemId": 43952,
 						"mount": "Azure Drake",
 						"name": "Malygos",
-						"spellId": 59567
+						"spellId": 59567,
+						"boosted": true
 					  },
 					  {
 						"ID": "247",
@@ -228,7 +241,8 @@
 						"itemId": 43953,
 						"mount": "Blue Drake",
 						"name": "Malygos",
-						"spellId": 59568
+						"spellId": 59568,
+						"boosted": true
 					  }
 					],
 					"title": "Run Eye of Eternity"
@@ -278,7 +292,8 @@
 						"mount": "Blue Proto-Drake",
 						"name": "Skadi",
 						"note": "Heroic only",
-						"spellId": 59996
+						"spellId": 59996,
+						"boosted": true
 					  }
 					],
 					"title": "Run Utgarde Pinnacle"
@@ -298,7 +313,8 @@
 						"mount": "Mimiron's Head",
 						"name": "Yogg-Saron",
 						"note": "Requires no watchers up",
-						"spellId": 63796
+						"spellId": 63796,
+						"boosted": true
 					  }
 					],
 					"title": "Run Ulduar"
@@ -323,7 +339,8 @@
 						"itemId": 71665,
 						"mount": "Flametalon of Alysrazor",
 						"name": "Alysrazor",
-						"spellId": 101542
+						"spellId": 101542,
+						"boosted": true
 					  },
 					  {
 						"ID": "415",
@@ -332,10 +349,11 @@
 						"itemId": 69224,
 						"mount": "Egg of Millagazor",
 						"name": "Ragnaros",
-						"spellId": 97493
+						"spellId": 97493,
+						"boosted": true
 					  }
 					],
-					"title": "Run Firelands"
+					"title": "Run Firelands on both Normal and Heroic"
 				  }
 				],
 				"title": "Portal to Hyjal"
@@ -372,7 +390,8 @@
 						"itemId": 78919,
 						"mount": "Experiment 12-B",
 						"name": "Ultraxion",
-						"spellId": 110039
+						"spellId": 110039,
+						"boosted": true
 					  },
 					  {
 						"ID": "442",
@@ -381,7 +400,8 @@
 						"itemId": 77067,
 						"mount": "Blazing Drake",
 						"name": "Deathwing",
-						"spellId": 107842
+						"spellId": 107842,
+						"boosted": true
 					  },
 					  {
 						"ID": "444",
@@ -390,8 +410,9 @@
 						"itemId": 77069,
 						"mount": "Life-Binder's Handmaiden",
 						"name": "Deathwing",
-						"note": "Heroic (10 or 25)",
-						"spellId": 107845
+						"note": "Heroic only",
+						"spellId": 107845,
+						"boosted": true
 					  }
 					],
 					"title": "Run Dragon Soul"
@@ -416,8 +437,9 @@
 						"itemId": 63043,
 						"mount": "Vitreous Stone Drake",
 						"name": "Slabhide",
-						"note": "You can run heroic once and 9 normal",
-						"spellId": 88746
+						"note": "You can run Heroic once per day and up to 10x Normal an hour",
+						"spellId": 88746,
+						"boosted": true
 					  }
 					],
 					"title": "Run Stonecore"
@@ -443,7 +465,8 @@
 						"mount": "Raven Lord",
 						"name": "Anzu",
 						"note": "Heroic only",
-						"spellId": 41252
+						"spellId": 41252,
+						"boosted": true
 					  }
 					],
 					"title": "Run Sethekk Halls"
@@ -462,7 +485,8 @@
 						"itemId": 32458,
 						"mount": "Ashes of Al'ar",
 						"name": "Kael'thas",
-						"spellId": 40192
+						"spellId": 40192,
+						"boosted": true
 					  }
 					],
 					"title": "Run Tempest Keep"
@@ -484,7 +508,8 @@
 							"mount": "Swift White Hawkstrider",
 							"name": "Kael'thas",
 							"note": "Heroic only",
-							"spellId": 46628
+							"spellId": 46628,
+						"boosted": true
 						  }
 						],
 						"title": "Run Magister's Terrace"
@@ -520,7 +545,8 @@
 								"itemId": 13335,
 								"mount": "Deathcharger's Reins",
 								"name": "Rivendare",
-								"spellId": 17481
+								"spellId": 17481,
+								"boosted": true
 							  }
 							],
 							"title": "Run Stratholme"
@@ -553,7 +579,8 @@
 							"itemId": 30480,
 							"mount": "Fiery Warhorse's Reins",
 							"name": "Attumen",
-							"spellId": 36702
+							"spellId": 36702,
+							"boosted": true
 						  }
 						],
 						"title": "Run Karazhan"
@@ -568,7 +595,18 @@
 							"mount": "Midnight's Eternal Reins",
 							"name": "Attumen",
 							"note": "Mythic only",
-							"spellId": 229499
+							"spellId": 229499,
+							"boosted": true
+						  },
+						  {
+							"ID": "883",
+							"epic": true,
+							"icon": "inv_nightbane2mount",
+							"itemId": 142552,
+							"mount": "Smoldering Ember Wyrm",
+							"name": "Nightbane",
+							"note": "Mythic only, Timed Reward",
+							"spellId": 231428
 						  }
 						],
 						"title": "Run Return to Karazhan"
@@ -588,7 +626,8 @@
 							"mount": "Swift Zulian Panther",
 							"name": "Kilnara",
 							"note": "Heroic only",
-							"spellId": 96499
+							"spellId": 96499,
+							"boosted": true
 						  },
 						  {
 							"ID": "410",
@@ -598,7 +637,8 @@
 							"mount": "Armored Razzashi Raptor",
 							"name": "Mandokir",
 							"note": "Heroic only",
-							"spellId": 96491
+							"spellId": 96491,
+							"boosted": true
 						  }
 						],
 						"title": "Run Zul'Gurub"
@@ -684,8 +724,8 @@
 					"itemId": 87777,
 					"mount": "Reins of the Astral Cloud Serpent",
 					"name": "Elegon",
-					"note": "Normal/Heroic",
-					"spellId": 127170
+					"spellId": 127170,
+					"boosted": true
 				  }
 				],
 				"title": "Run Mogu'shan Vaults"
@@ -723,7 +763,8 @@
 						"mount": "Spawn of Horridon",
 						"name": "Horridon",
 						"note": "Normal/Heroic",
-						"spellId": 136471
+						"spellId": 136471,
+						"boosted": true
 					  },
 					  {
 						"ID": "543",
@@ -733,7 +774,8 @@
 						"mount": "Clutch of Ji-Kun",
 						"name": "Ji-Kun",
 						"note": "Normal/Heroic",
-						"spellId": 139448
+						"spellId": 139448,
+						"boosted": true
 					  }
 					],
 					"title": "Run Throne of Thunder"
@@ -756,7 +798,8 @@
 					"mount": "Kor'kron Juggernaut",
 					"name": "Garrosh Hellscream",
 					"note": "Mythic only",
-					"spellId": 148417
+					"spellId": 148417,
+					"boosted": true
 				  }
 				],
 				"title": "Run Siege of Orgrimmar"
@@ -801,7 +844,8 @@
 						"mount": "Felsteel Annihilator",
 						"name": "Archimonde",
 						"note": "Mythic only",
-						"spellId": 182912
+						"spellId": 182912,
+						"boosted": true
 					  }
 					],
 					"title": "Run Hellfire Citadel"
@@ -821,7 +865,8 @@
 						"mount": "Ironhoof Destroyer",
 						"name": "Blackhand",
 						"note": "Mythic only",
-						"spellId": 171621
+						"spellId": 171621,
+						"boosted": true
 					  }
 					],
 					"title": "Run Blackrock Foundry"
@@ -845,7 +890,8 @@
 					"mount": "Living Infernal Core",
 					"note": "Normal/Heroic/Mythic",
 					"name": "Gul'dan",
-					"spellId": 213134
+					"spellId": 213134,
+					"boosted": true
 				  },
 				  {
 					"ID": "633",
@@ -855,7 +901,8 @@
 					"mount": "Fiendish Hellfire Core",
 					"name": "Gul'dan",
 					"note": "Mythic only",
-					"spellId": 171827
+					"spellId": 171827,
+					"boosted": true
 				  }
 				],
 				"title": "Run Nighthold"
@@ -876,7 +923,8 @@
 					"mount": "Abyss Worm",
 					"note": "LFR/Normal/Heroic/Mythic",
 					"name": "Mistress Sassz'ine",
-					"spellId": 232519
+					"spellId": 232519,
+					"boosted": true
 				  }
 				],
 				"title": "Run Tomb of Sargeras"
@@ -899,7 +947,8 @@
 						"mount": "Antoran Charhound",
 						"note": "LFR/Normal/Heroic/Mythic",
 						"name": "Felhounds of Sargeras",
-						"spellId": 253088
+						"spellId": 253088,
+						"boosted": true
 					  },
 					  {
 						"ID": "954",
@@ -909,7 +958,8 @@
 						"mount": "Shackled Ur'zul",
 						"name": "Argus the Unmaker",
 						"note": "Mythic only",
-						"spellId": 243651
+						"spellId": 243651,
+						"boosted": true
 					  }
 					],
 					"title": "Run Antorus, the Burning Throne"
@@ -933,7 +983,8 @@
 					"mount": "G.M.O.D.",
 					"name": "High Tinker Mekkatorque",
 					"note": "LFR (Jaina)/Normal/Heroic/Mythic",
-					"spellId": 289083
+					"spellId": 289083,
+					"boosted": true
 				  },
 				  {
 					"ID": "1219",
@@ -943,7 +994,8 @@
 					"mount": "Glacial Tidestorm",
 					"name": "Jaina Proudmoore",
 					"note": "Mythic only",
-					"spellId": 289555
+					"spellId": 289555,
+					"boosted": true
 				  }
 				],
 				"title": "Run Battle of Dazar'alor"
@@ -965,7 +1017,8 @@
 						"mount": "Sharkbait's Favorite Crackers",
 						"name": "Harlan Sweete",
 						"note": "Mythic only",
-						"spellId": 254813
+						"spellId": 254813,
+						"boosted": true
 					  }
 					],
 					"title": "Run Freehold"
@@ -985,7 +1038,8 @@
 						"mount": "Mummified Raptor Skull",
 						"name": "Dazar, The First King",
 						"note": "Mythic only",
-						"spellId": 266058
+						"spellId": 266058,
+						"boosted": true
 					  }
 					],
 					"title": "Run King's Rest"
@@ -1005,7 +1059,8 @@
 						"mount": "Underrot Crawg Harness",
 						"name": "Unbound Abomination",
 						"note": "Mythic only",
-						"spellId": 273541
+						"spellId": 273541,
+						"boosted": true
 					  }
 					],
 					"title": "Run The Underrot"
@@ -1028,6 +1083,16 @@
 						"name": "HK-8 Aerial Oppression Unit",
 						"note": "Mythic only",
 						"spellId": 299158
+					  },
+					  {
+						"ID": "1227",
+						"epic": true,
+						"icon": "inv_hunterkillershipyellow",
+						"itemId": 168830,
+						"mount": "Aerial Unit R-21/X",
+						"name": "King Mechagon",
+						"note": "Hardmode only",
+						"spellId": 290718
 					  }
 					],
 					"title": "Run Mechagon: Junkyard"
@@ -1048,7 +1113,8 @@
 						"mount": "Ny'alotha Allseer",
 						"name": "N'zoth the Corruptor",
 						"note": "Mythic only",
-						"spellId": 308814
+						"spellId": 308814,
+						"boosted": true
 					  }
 					],
 					"title": "Run Ny'alotha the Waking City"
@@ -1075,7 +1141,8 @@
 						"mount": "Marrowfang",
 						"name": "Nalthor the Rimebinder",
 						"note": "Mythic only",
-						"spellId": 336036
+						"spellId": 336036,
+						"boosted": true
 					  }
 					],
 					"title": "Run Necrotic Wake"
@@ -1095,7 +1162,8 @@
 						"mount": "Cartel Master's Gearglider",
 						"name": "So'leah",
 						"note": "Heroic/Mythic",
-						"spellId": 353263
+						"spellId": 353263,
+						"boosted": true
 					  }
 					],
 					"title": "Run Tazavesh the Veiled Market"
@@ -1115,7 +1183,8 @@
 						  "mount": "Sanctum Gloomcharger",
 						  "name": "The Nine",
 						  "note": "LFR/Normal/Heroic/Mythic",
-						  "spellId": 354351
+						  "spellId": 354351,
+						"boosted": true
 						},
 						{
 						  "ID": "1471",
@@ -1125,7 +1194,8 @@
 						  "mount": "Vengeance",
 						  "name": "Lady Sylvanas Windrunner",
 						  "note": "Mythic only",
-						  "spellId": 351195
+						  "spellId": 351195,
+						"boosted": true
 						}
 					  ],
 					"title": "Run Sanctum of Domination"
@@ -1145,7 +1215,8 @@
 						"mount": "Zereth Overseer",
 						"name": "The Jailer",
 						"note": "Mythic only",
-						"spellId": 368158
+						"spellId": 368158,
+						"boosted": true
 					  }
 					],
 					"title": "Run Sepulcher of the First Ones"


### PR DESCRIPTION
Gave boosted bosses colour + bold in planner for easier tracking - might seek another solution for this in the future but wanted to put something out short term.
Moved returning diablo crossover rewards into limited time section.