### PR TITLE
Collector's Bounty Category

### DIFF
--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -362,49 +362,370 @@
     "subcats": [
       {
         "items": [
-
+          {
+            "ID": 69,
+            "icon": "ability_mount_undeadhorse",
+            "itemId": 13335,
+            "name": "Rivendare's Deathcharger",
+            "spellid": 17481
+          }
         ],
         "name": "Classic"
       },
       {
         "items": [
-
+          {
+            "ID": 185,
+            "icon": "inv-mount_raven_54",
+            "itemId": 32768,
+            "name": "Raven Lord",
+            "spellid": 41252
+          },
+          {
+            "ID": 213,
+            "icon": "ability_mount_cockatricemountelite_white",
+            "itemId": 35513,
+            "name": "Swift White Hawkstrider",
+            "spellid": 46628
+          },
+          {
+            "ID": 183,
+            "icon": "inv_misc_summerfest_brazierorange",
+            "itemId": 32458,
+            "name": "Ashes of Al'ar",
+            "spellid": 40192
+          },
+          {
+            "ID": 168,
+            "icon": "ability_mount_dreadsteed",
+            "itemId": 30480,
+            "name": "Fiery Warhorse",
+            "spellid": 36702
+          }
         ],
-        "name": "The Burning Crusade"
+        "name": "Burning Crusade"
       },
       {
         "items": [
-
+          {
+            "ID": 264,
+            "icon": "ability_mount_drake_proto",
+            "itemId": 44151,
+            "name": "Blue Proto-Drake",
+            "spellid": 59996
+          },
+          {
+            "ID": 246,
+            "icon": "ability_mount_drake_azure",
+            "itemId": 43952,
+            "name": "Azure Drake",
+            "spellid": 59567
+          },
+          {
+            "ID": 247,
+            "icon": "ability_mount_drake_azure",
+            "itemId": 43953,
+            "name": "Blue Drake",
+            "spellid": 59568
+          },
+          {
+            "ID": 286,
+            "icon": "ability_mount_mammoth_black_3seater",
+            "itemId": 43959,
+            "name": "Grand Black War Mammoth",
+            "side": "A",
+            "spellid": 61465
+          },
+          {
+            "ID": 287,
+            "icon": "ability_mount_mammoth_black_3seater",
+            "itemId": 44083,
+            "name": "Grand Black War Mammoth",
+            "side": "H",
+            "spellid": 61467
+          },
+          {
+            "ID": 304,
+            "icon": "inv_misc_enggizmos_03",
+            "itemId": 45693,
+            "name": "Mimiron's Head",
+            "spellid": 63796
+          },
+          {
+            "ID": 349,
+            "icon": "achievement_boss_onyxia",
+            "itemId": 49636,
+            "name": "Onyxian Drake",
+            "spellid": 69395
+          },
+          {
+            "ID": 363,
+            "icon": "ability_mount_pegasus",
+            "itemId": 50818,
+            "name": "Invincible",
+            "spellid": 72286
+          }
         ],
         "name": "Wrath of the Lich King"
       },
       {
         "items": [
-
+          {
+            "ID": 395,
+            "icon": "inv_misc_stormdragonpale",
+            "itemId": 63040,
+            "name": "Drake of the North Wind",
+            "spellid": 88742
+          },
+          {
+            "ID": 397,
+            "icon": "inv_misc_stonedragonblue",
+            "itemId": 63043,
+            "name": "Vitreous Stone Drake",
+            "spellid": 88746
+          },
+          {
+            "ID": 410,
+            "icon": "ability_mount_raptor",
+            "itemId": 68823,
+            "name": "Armored Razzashi Raptor",
+            "spellid": 96491
+          },
+          {
+            "ID": 411,
+            "icon": "ability_mount_blackpanther",
+            "itemId": 68824,
+            "name": "Swift Zulian Panther",
+            "spellid": 96499
+          },
+          {
+            "ID": 396,
+            "icon": "inv_misc_stormdragonpurple",
+            "itemId": 63041,
+            "name": "Drake of the South Wind",
+            "spellid": 88744
+          },
+          {
+            "ID": 425,
+            "icon": "ability_mount_fireravengodmount",
+            "itemId": 71665,
+            "name": "Flametalon of Alysrazor",
+            "spellid": 101542
+          },
+          {
+            "ID": 415,
+            "icon": "inv_misc_orb_05",
+            "itemId": 69224,
+            "name": "Pureblood Fire Hawk",
+            "spellid": 97493
+          },
+          {
+            "ID": 445,
+            "icon": "ability_mount_drake_twilight",
+            "itemId": 78919,
+            "name": "Experiment 12-B",
+            "spellid": 110039
+          },
+          {
+            "ID": 442,
+            "icon": "ability_mount_drake_red",
+            "itemId": 77067,
+            "name": "Blazing Drake",
+            "spellid": 107842
+          },
+          {
+            "ID": 444,
+            "icon": "ability_mount_drake_red",
+            "itemId": 77069,
+            "name": "Life-Binder's Handmaiden",
+            "spellid": 107845
+          }
+        ],
+        "name": "Cataclysm"
+      },
+      {
+        "items": [
+          {
+            "ID": 478,
+            "icon": "inv_celestialserpentmount",
+            "itemId": 87777,
+            "name": "Astral Cloud Serpent",
+            "spellid": 127170
+          },
+          {
+            "ID": 531,
+            "icon": "ability_mount_triceratopsmount",
+            "itemId": 93666,
+            "name": "Spawn of Horridon",
+            "spellid": 136471
+          },
+          {
+            "ID": 543,
+            "icon": "achievement_boss_ji-kun",
+            "itemId": 95059,
+            "name": "Clutch of Ji-Kun",
+            "spellid": 139448
+          },
+          {
+            "ID": 559,
+            "icon": "inv_mount_hordescorpiong",
+            "itemId": 104253,
+            "name": "Kor'kron Juggernaut",
+            "spellid": 148417
+          }
         ],
         "name": "Mists of Pandaria"
       },
       {
         "items": [
-
+          {
+            "ID": 613,
+            "icon": "inv_ironhordeclefthoof",
+            "itemId": 116660,
+            "name": "Ironhoof Destroyer",
+            "spellid": 171621
+          },
+          {
+            "ID": 751,
+            "icon": "ability_mount_felreavermount",
+            "itemId": 123890,
+            "name": "Felsteel Annihilator",
+            "spellid": 182912
+          }
         ],
         "name": "Warlords of Draenor"
       },
       {
         "items": [
-
+          {
+            "ID": 875,
+            "icon": "ability_mount_dreadsteed",
+            "itemId": 142236,
+            "name": "Midnight",
+            "spellid": 229499
+          },
+          {
+            "ID": 791,
+            "icon": "inv_infernalmount",
+            "itemId": 137574,
+            "name": "Felblaze Infernal",
+            "spellid": 213134
+          },
+          {
+            "ID": 633,
+            "icon": "inv_infernalmountred",
+            "itemId": 137575,
+            "name": "Hellfire Infernal",
+            "spellid": 171827
+          },
+          {
+            "ID": 899,
+            "icon": "inv_serpentmount_green",
+            "itemId": 143643,
+            "name": "Abyss Worm",
+            "spellid": 232519
+          },
+          {
+            "ID": 971,
+            "icon": "inv_felhound3_shadow_fire",
+            "itemId": 152816,
+            "name": "Antoran Charhound",
+            "spellid": 253088
+          },
+          {
+            "ID": 954,
+            "icon": "inv_soulhoundmount_blue",
+            "itemId": 152789,
+            "name": "Shackled Ur'zul",
+            "spellid": 243651
+          }
         ],
         "name": "Legion"
       },
       {
         "items": [
-
+          {
+            "ID": 1040,
+            "icon": "inv_armoredraptorundead",
+            "itemId": 159921,
+            "name": "Tomb Stalker",
+            "spellid": 266058
+          },
+          {
+            "ID": 1053,
+            "icon": "inv_bloodtrollbeast_mount_pale",
+            "itemId": 160829,
+            "name": "Underrot Crawg",
+            "spellid": 273541
+          },
+          {
+            "ID": 995,
+            "icon": "inv_parrotmount_red",
+            "itemId": 159842,
+            "name": "Sharkbait",
+            "spellid": 254813
+          },
+          {
+            "ID": 1217,
+            "icon": "achievement_dungeon_coinoperatedcrowdpummeler",
+            "itemId": 166518,
+            "name": "G.M.O.D.",
+            "spellid": 289083
+          },
+          {
+            "ID": 1219,
+            "icon": "inv_waterelementalmount",
+            "itemId": 166705,
+            "name": "Glacial Tidestorm",
+            "spellid": 289555
+          },
+          {
+            "ID": 1293,
+            "icon": "inv_eyeballjellyfishmount",
+            "itemId": 174872,
+            "name": "Ny'alotha Allseer",
+            "spellid": 308814
+          }
         ],
         "name": "Battle for Azeroth"
       },
       {
         "items": [
-
+          {
+            "ID": 1406,
+            "icon": "inv_maldraxxusflyermount_red",
+            "itemId": 181819,
+            "name": "Marrowfang",
+            "spellid": 336036
+          },
+          {
+            "ID": 1481,
+            "icon": "inv_brokermount_dark",
+            "itemId": 186638,
+            "name": "Cartel Master's Gearglider",
+            "spellid": 353263
+          },
+          {
+            "ID": 1500,
+            "icon": "ability_mount_mawhorsespikes_purple",
+            "itemId": 186656,
+            "name": "Sanctum Gloomcharger",
+            "spellid": 354351
+          },
+          {
+            "ID": 1471,
+            "icon": "inv_dragonhawkmountshadowlands",
+            "itemId": 186642,
+            "name": "Vengeance",
+            "spellid": 351195
+          },
+          {
+            "ID": 1587,
+            "icon": "inv_progenitorbotminemount",
+            "itemId": 190768,
+            "name": "Zereth Overseer",
+            "spellid": 368158
+          }
         ],
         "name": "Shadowlands"
       }
@@ -2300,51 +2621,16 @@
       {
         "items": [
           {
-            "ID": 1406,
-            "icon": "inv_maldraxxusflyermount_red",
-            "itemId": 181819,
-            "name": "Marrowfang",
-            "spellid": 336036
-          },
-          {
             "ID": 1445,
             "icon": "inv_nzothserpentmount_abomination",
             "name": "Slime Serpent",
             "spellid": 346141
-          },
-          {
-            "ID": 1481,
-            "icon": "inv_brokermount_dark",
-            "itemId": 186638,
-            "name": "Cartel Master's Gearglider",
-            "spellid": 353263
           }
         ],
         "name": "Dungeon Drop"
       },
       {
         "items": [
-          {
-            "ID": 1500,
-            "icon": "ability_mount_mawhorsespikes_purple",
-            "itemId": 186656,
-            "name": "Sanctum Gloomcharger",
-            "spellid": 354351
-          },
-          {
-            "ID": 1471,
-            "icon": "inv_dragonhawkmountshadowlands",
-            "itemId": 186642,
-            "name": "Vengeance",
-            "spellid": 351195
-          },
-          {
-            "ID": 1587,
-            "icon": "inv_progenitorbotminemount",
-            "itemId": 190768,
-            "name": "Zereth Overseer",
-            "spellid": 368158
-          },
           {
             "ID": 1552,
             "icon": "inv_progenitorbotminemount",
@@ -4043,27 +4329,6 @@
         "id": "8e8e5c12",
         "items": [
           {
-            "ID": 1040,
-            "icon": "inv_armoredraptorundead",
-            "itemId": 159921,
-            "name": "Tomb Stalker",
-            "spellid": 266058
-          },
-          {
-            "ID": 1053,
-            "icon": "inv_bloodtrollbeast_mount_pale",
-            "itemId": 160829,
-            "name": "Underrot Crawg",
-            "spellid": 273541
-          },
-          {
-            "ID": 995,
-            "icon": "inv_parrotmount_red",
-            "itemId": 159842,
-            "name": "Sharkbait",
-            "spellid": 254813
-          },
-          {
             "ID": 1252,
             "icon": "inv_mechagonspidertank_brass",
             "itemId": 168826,
@@ -4075,7 +4340,8 @@
             "icon": "inv_hunterkillershipyellow",
             "itemId": 168830,
             "name": "Aerial Unit R-21/X",
-            "spellid": 290718
+            "spellid": 290718,
+            "notObtainable": true
           }
         ],
         "name": "Dungeon Drop"
@@ -4083,27 +4349,6 @@
       {
         "id": "6815d547",
         "items": [
-          {
-            "ID": 1217,
-            "icon": "achievement_dungeon_coinoperatedcrowdpummeler",
-            "itemId": 166518,
-            "name": "G.M.O.D.",
-            "spellid": 289083
-          },
-          {
-            "ID": 1219,
-            "icon": "inv_waterelementalmount",
-            "itemId": 166705,
-            "name": "Glacial Tidestorm",
-            "spellid": 289555
-          },
-          {
-            "ID": 1293,
-            "icon": "inv_eyeballjellyfishmount",
-            "itemId": 174872,
-            "name": "Ny'alotha Allseer",
-            "spellid": 308814
-          },
           {
             "ID": 1265,
             "icon": "inv_voiddragonmount",
@@ -4561,13 +4806,6 @@
         "id": "8f65b39e",
         "items": [
           {
-            "ID": 875,
-            "icon": "ability_mount_dreadsteed",
-            "itemId": 142236,
-            "name": "Midnight",
-            "spellid": 229499
-          },
-          {
             "ID": 883,
             "icon": "inv_nightbane2mount",
             "itemId": 142552,
@@ -4580,41 +4818,6 @@
       {
         "id": "07298901",
         "items": [
-          {
-            "ID": 791,
-            "icon": "inv_infernalmount",
-            "itemId": 137574,
-            "name": "Felblaze Infernal",
-            "spellid": 213134
-          },
-          {
-            "ID": 633,
-            "icon": "inv_infernalmountred",
-            "itemId": 137575,
-            "name": "Hellfire Infernal",
-            "spellid": 171827
-          },
-          {
-            "ID": 899,
-            "icon": "inv_serpentmount_green",
-            "itemId": 143643,
-            "name": "Abyss Worm",
-            "spellid": 232519
-          },
-          {
-            "ID": 971,
-            "icon": "inv_felhound3_shadow_fire",
-            "itemId": 152816,
-            "name": "Antoran Charhound",
-            "spellid": 253088
-          },
-          {
-            "ID": 954,
-            "icon": "inv_soulhoundmount_blue",
-            "itemId": 152789,
-            "name": "Shackled Ur'zul",
-            "spellid": 243651
-          },
           {
             "ID": 978,
             "icon": "inv_mount_arcaneraven",
@@ -5236,20 +5439,6 @@
         "id": "9e0fd274",
         "items": [
           {
-            "ID": 613,
-            "icon": "inv_ironhordeclefthoof",
-            "itemId": 116660,
-            "name": "Ironhoof Destroyer",
-            "spellid": 171621
-          },
-          {
-            "ID": 751,
-            "icon": "ability_mount_felreavermount",
-            "itemId": 123890,
-            "name": "Felsteel Annihilator",
-            "spellid": 182912
-          },
-          {
             "ID": 764,
             "icon": "inv_moosemount",
             "itemId": 128422,
@@ -5556,34 +5745,6 @@
         "id": "c623e972",
         "items": [
           {
-            "ID": 478,
-            "icon": "inv_celestialserpentmount",
-            "itemId": 87777,
-            "name": "Astral Cloud Serpent",
-            "spellid": 127170
-          },
-          {
-            "ID": 531,
-            "icon": "ability_mount_triceratopsmount",
-            "itemId": 93666,
-            "name": "Spawn of Horridon",
-            "spellid": 136471
-          },
-          {
-            "ID": 543,
-            "icon": "achievement_boss_ji-kun",
-            "itemId": 95059,
-            "name": "Clutch of Ji-Kun",
-            "spellid": 139448
-          },
-          {
-            "ID": 559,
-            "icon": "inv_mount_hordescorpiong",
-            "itemId": 104253,
-            "name": "Kor'kron Juggernaut",
-            "spellid": 148417
-          },
-          {
             "ID": 558,
             "icon": "ability_mount_hordepvpmount",
             "itemId": 104246,
@@ -5851,39 +6012,11 @@
         "id": "22842c61",
         "items": [
           {
-            "ID": 395,
-            "icon": "inv_misc_stormdragonpale",
-            "itemId": 63040,
-            "name": "Drake of the North Wind",
-            "spellid": 88742
-          },
-          {
-            "ID": 397,
-            "icon": "inv_misc_stonedragonblue",
-            "itemId": 63043,
-            "name": "Vitreous Stone Drake",
-            "spellid": 88746
-          },
-          {
             "ID": 419,
             "icon": "ability_druid_challangingroar",
             "itemId": 69747,
             "name": "Amani Battle Bear",
             "spellid": 98204
-          },
-          {
-            "ID": 410,
-            "icon": "ability_mount_raptor",
-            "itemId": 68823,
-            "name": "Armored Razzashi Raptor",
-            "spellid": 96491
-          },
-          {
-            "ID": 411,
-            "icon": "ability_mount_blackpanther",
-            "itemId": 68824,
-            "name": "Swift Zulian Panther",
-            "spellid": 96499
           }
         ],
         "name": "Dungeon Drop"
@@ -5891,48 +6024,6 @@
       {
         "id": "16bcc6b5",
         "items": [
-          {
-            "ID": 396,
-            "icon": "inv_misc_stormdragonpurple",
-            "itemId": 63041,
-            "name": "Drake of the South Wind",
-            "spellid": 88744
-          },
-          {
-            "ID": 425,
-            "icon": "ability_mount_fireravengodmount",
-            "itemId": 71665,
-            "name": "Flametalon of Alysrazor",
-            "spellid": 101542
-          },
-          {
-            "ID": 415,
-            "icon": "inv_misc_orb_05",
-            "itemId": 69224,
-            "name": "Pureblood Fire Hawk",
-            "spellid": 97493
-          },
-          {
-            "ID": 445,
-            "icon": "ability_mount_drake_twilight",
-            "itemId": 78919,
-            "name": "Experiment 12-B",
-            "spellid": 110039
-          },
-          {
-            "ID": 442,
-            "icon": "ability_mount_drake_red",
-            "itemId": 77067,
-            "name": "Blazing Drake",
-            "spellid": 107842
-          },
-          {
-            "ID": 444,
-            "icon": "ability_mount_drake_red",
-            "itemId": 77069,
-            "name": "Life-Binder's Handmaiden",
-            "spellid": 107845
-          }
         ],
         "name": "Raid Drop"
       },
@@ -6417,13 +6508,6 @@
             "itemId": 43951,
             "name": "Bronze Drake",
             "spellid": 59569
-          },
-          {
-            "ID": 264,
-            "icon": "ability_mount_drake_proto",
-            "itemId": 44151,
-            "name": "Blue Proto-Drake",
-            "spellid": 59996
           }
         ],
         "name": "Dungeon Drop"
@@ -6431,20 +6515,6 @@
       {
         "id": "868bd4d4",
         "items": [
-          {
-            "ID": 246,
-            "icon": "ability_mount_drake_azure",
-            "itemId": 43952,
-            "name": "Azure Drake",
-            "spellid": 59567
-          },
-          {
-            "ID": 247,
-            "icon": "ability_mount_drake_azure",
-            "itemId": 43953,
-            "name": "Blue Drake",
-            "spellid": 59568
-          },
           {
             "ID": 250,
             "icon": "ability_mount_drake_twilight",
@@ -6458,43 +6528,6 @@
             "itemId": 43986,
             "name": "Black Drake",
             "spellid": 59650
-          },
-          {
-            "ID": 286,
-            "icon": "ability_mount_mammoth_black_3seater",
-            "itemId": 43959,
-            "name": "Grand Black War Mammoth",
-            "side": "A",
-            "spellid": 61465
-          },
-          {
-            "ID": 287,
-            "icon": "ability_mount_mammoth_black_3seater",
-            "itemId": 44083,
-            "name": "Grand Black War Mammoth",
-            "side": "H",
-            "spellid": 61467
-          },
-          {
-            "ID": 304,
-            "icon": "inv_misc_enggizmos_03",
-            "itemId": 45693,
-            "name": "Mimiron's Head",
-            "spellid": 63796
-          },
-          {
-            "ID": 349,
-            "icon": "achievement_boss_onyxia",
-            "itemId": 49636,
-            "name": "Onyxian Drake",
-            "spellid": 69395
-          },
-          {
-            "ID": 363,
-            "icon": "ability_mount_pegasus",
-            "itemId": 50818,
-            "name": "Invincible",
-            "spellid": 72286
           }
         ],
         "name": "Raid Drop"
@@ -6819,20 +6852,7 @@
       {
         "id": "5ef68855",
         "items": [
-          {
-            "ID": 185,
-            "icon": "inv-mount_raven_54",
-            "itemId": 32768,
-            "name": "Raven Lord",
-            "spellid": 41252
-          },
-          {
-            "ID": 213,
-            "icon": "ability_mount_cockatricemountelite_white",
-            "itemId": 35513,
-            "name": "Swift White Hawkstrider",
-            "spellid": 46628
-          }
+          
         ],
         "name": "Dungeon Drop"
       },
@@ -6840,26 +6860,12 @@
         "id": "3c2eeafd",
         "items": [
           {
-            "ID": 183,
-            "icon": "inv_misc_summerfest_brazierorange",
-            "itemId": 32458,
-            "name": "Ashes of Al'ar",
-            "spellid": 40192
-          },
-          {
             "ID": 199,
             "icon": "ability_druid_challangingroar",
             "itemId": 33809,
             "name": "Amani War Bear",
             "notObtainable": true,
             "spellid": 43688
-          },
-          {
-            "ID": 168,
-            "icon": "ability_mount_dreadsteed",
-            "itemId": 30480,
-            "name": "Fiery Warhorse",
-            "spellid": 36702
           }
         ],
         "name": "Raid Drop"
@@ -6895,13 +6901,7 @@
       {
         "id": "55035ac0",
         "items": [
-          {
-            "ID": 69,
-            "icon": "ability_mount_undeadhorse",
-            "itemId": 13335,
-            "name": "Rivendare's Deathcharger",
-            "spellid": 17481
-          }
+          
         ],
         "name": "Dungeon Drop"
       },

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -323,13 +323,6 @@
       {
         "items": [
           {
-            "ID": 439,
-            "icon": "ability_mount_tyraelmount",
-            "itemId": 76755,
-            "name": "Tyrael's Charger",
-            "spellid": 107203
-          },
-          {
             "ID": 2605,
             "icon": "inv_inariusmount",
             "itemId": 246264,
@@ -361,6 +354,59 @@
           }
         ],
         "name": "Blizzard Store"
+      }
+    ]
+  },
+  {
+    "name": "Collector's Bounty",
+    "subcats": [
+      {
+        "items": [
+
+        ],
+        "name": "Classic"
+      },
+      {
+        "items": [
+
+        ],
+        "name": "The Burning Crusade"
+      },
+      {
+        "items": [
+
+        ],
+        "name": "Wrath of the Lich King"
+      },
+      {
+        "items": [
+
+        ],
+        "name": "Mists of Pandaria"
+      },
+      {
+        "items": [
+
+        ],
+        "name": "Warlords of Draenor"
+      },
+      {
+        "items": [
+
+        ],
+        "name": "Legion"
+      },
+      {
+        "items": [
+
+        ],
+        "name": "Battle for Azeroth"
+      },
+      {
+        "items": [
+
+        ],
+        "name": "Shadowlands"
       }
     ]
   },
@@ -9393,6 +9439,13 @@
             "name": "Spectral Gryphon",
             "side": "A",
             "spellid": 107516
+          },
+          {
+            "ID": 439,
+            "icon": "ability_mount_tyraelmount",
+            "itemId": 76755,
+            "name": "Tyrael's Charger",
+            "spellid": 107203
           },
           {
             "ID": 454,


### PR DESCRIPTION
Added a temporary category to give an easier overview of everything that's boosted during this event.

Moved Tyrael's Charger back to Trading Post category because the wowhead comments saying it was available again seem to have been false/mistaken.