### PR TITLE
New Store Mounts

### DIFF
--- a/src/components/MountsPlanner.svelte
+++ b/src/components/MountsPlanner.svelte
@@ -296,8 +296,8 @@
 </div>
 {:else}
 <div style="font-size: 13px; margin-bottom: 12px; color: #888;">
-  📆 Next daily reset: {getNextDailyReset(region)}<br/>
-  📅 Next weekly reset: {getNextWeeklyReset(region)}
+  📆 Next daily reset: {getNextDailyReset($region)}<br/>
+  📅 Next weekly reset: {getNextWeeklyReset($region)}
 </div>
 <div class="mnt-controls">
   <div class="mnt-reset-buttons">

--- a/src/components/MountsPlanner.svelte
+++ b/src/components/MountsPlanner.svelte
@@ -56,12 +56,18 @@
       return checkedDate >= dailyReset;
     }
 
-    if (step.type === 'Raid') {
+    if (step.type === 'Raid' || step.type === 'WeeklyDungeon') {
       const currentDay = now.getUTCDay();
       const daysSinceReset = (currentDay + 7 - weeklyDay) % 7;
       const lastWeeklyReset = new Date(now);
       lastWeeklyReset.setUTCDate(now.getUTCDate() - daysSinceReset);
       lastWeeklyReset.setUTCHours(weeklyHourUTC, 0, 0, 0);
+      
+      // Extra condition for the day of reset
+      if (now < lastWeeklyReset) {
+        lastWeeklyReset.setUTCDate(lastWeeklyReset.getUTCDate() - 7);
+      }
+
       return checkedDate >= lastWeeklyReset;
     }
 
@@ -236,6 +242,12 @@
     steps.forEach((step, idx) => {
       if (step.type === type && step.checkedAt) {
         updated = uncheckStep(updated, idx);
+      }
+      if(type == "Dungeon") {
+        // Temporary bandaid fix to ensure both daily and weekly dungeons are reset
+        if (step.type === "WeeklyDungeon" && step.checkedAt) {
+          updated = uncheckStep(updated, idx);
+        }
       }
     });
     steps = updated;

--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -5292,6 +5292,13 @@
                   "new": true,
                   "points": 10,
                   "title": "Secrets of the K'areshi"
+                },
+                {
+                  "icon": "inv_sword_122",
+                  "id": 61017,
+                  "new": true,
+                  "points": 10,
+                  "title": "Phase-Lost-and-Found"
                 }
               ],
               "name": "K'aresh"
@@ -41989,7 +41996,7 @@
                   "new": true,
                   "notObtainable": true,
                   "points": 0,
-                  "title": "[PH] Hero: The War Within Season Three"
+                  "title": "Unbound Hero: The War Within Season Three"
                 }
               ],
               "name": "Mythic Keystone: The War Within"

--- a/static/data/achievements.json
+++ b/static/data/achievements.json
@@ -30099,61 +30099,71 @@
                   "icon": "inv_11xp_event_dastardlyduos_podium01_nocollision",
                   "id": 41810,
                   "points": 10,
-                  "title": "Winner's Podium"
+                  "title": "Winner's Podium",
+                  "notObtainable": true
                 },
                 {
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 41706,
                   "points": 50,
-                  "title": "Dastardly Duos Weekly High Score"
+                  "title": "Dastardly Duos Weekly High Score",
+                  "notObtainable": true
                 },
                 {
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 41707,
                   "points": 10,
-                  "title": "Dastardly Devices"
+                  "title": "Dastardly Devices",
+                  "notObtainable": true
                 },
                 {
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 41715,
                   "points": 10,
-                  "title": "Fiendishly Famous"
+                  "title": "Fiendishly Famous",
+                  "notObtainable": true
                 },
                 {
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 41716,
                   "points": 10,
-                  "title": "Duo Darling"
+                  "title": "Duo Darling",
+                  "notObtainable": true
                 },
                 {
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 41717,
                   "points": 10,
-                  "title": "Duos Underdog"
+                  "title": "Duos Underdog",
+                  "notObtainable": true
                 },
                 {
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 41722,
                   "points": 10,
-                  "title": "Inside Connections"
+                  "title": "Inside Connections",
+                  "notObtainable": true
                 },
                 {
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 41905,
                   "points": 10,
-                  "title": "Center of Attention"
+                  "title": "Center of Attention",
+                  "notObtainable": true
                 },
                 {
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 41916,
                   "points": 10,
-                  "title": "My Way, The Highway"
+                  "title": "My Way, The Highway",
+                  "notObtainable": true
                 },
                 {
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 41922,
                   "points": 10,
-                  "title": "Undefeatable"
+                  "title": "Undefeatable",
+                  "notObtainable": true
                 }
               ],
               "name": ""
@@ -30164,31 +30174,36 @@
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 41948,
                   "points": 10,
-                  "title": "Defeat the Dastardlies"
+                  "title": "Defeat the Dastardlies",
+                  "notObtainable": true
                 },
                 {
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 41949,
                   "points": 10,
-                  "title": "Defeat the Dastardlies"
+                  "title": "Defeat the Dastardlies",
+                  "notObtainable": true
                 },
                 {
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 41950,
                   "points": 10,
-                  "title": "Defeat the Dastardlies"
+                  "title": "Defeat the Dastardlies",
+                  "notObtainable": true
                 },
                 {
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 41951,
                   "points": 10,
-                  "title": "Defeat the Dastardlies"
+                  "title": "Defeat the Dastardlies",
+                  "notObtainable": true
                 },
                 {
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 41952,
                   "points": 10,
-                  "title": "Defeat the Dastardlies"
+                  "title": "Defeat the Dastardlies",
+                  "notObtainable": true
                 }
               ],
               "name": "Bosses"
@@ -30199,19 +30214,22 @@
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 42002,
                   "points": 10,
-                  "title": "Bullhorn of Plenty"
+                  "title": "Bullhorn of Plenty",
+                  "notObtainable": true
                 },
                 {
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 42003,
                   "points": 10,
-                  "title": "Bullhorn of More Plenty"
+                  "title": "Bullhorn of More Plenty",
+                  "notObtainable": true
                 },
                 {
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 42004,
                   "points": 10,
-                  "title": "Bullhorn of Most Plenty"
+                  "title": "Bullhorn of Most Plenty",
+                  "notObtainable": true
                 }
               ],
               "name": "Bullhorns"
@@ -46611,7 +46629,8 @@
                   "icon": "achievement_worldevent_dastardlyduos",
                   "id": 41995,
                   "points": 0,
-                  "title": "Boot Hill"
+                  "title": "Boot Hill",
+                  "notObtainable": true
                 }
               ],
               "name": "Dastardly Duos"

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -165,14 +165,14 @@
             "itemId": 243596,
             "name": "Wailing Banshee's Charger",
             "spellid": 1235819
-          },          
+          },
           {
             "ID": 2600,
             "icon": "ability_mount_felboarmount",
             "itemId": 245936,
             "name": "Unarmored Deathtusk Felboar",
             "spellid": 1240003
-          }          
+          }
         ],
         "name": "Trading Post: July"
       },
@@ -191,20 +191,6 @@
             "itemId": 224574,
             "name": "Savage Ebony Battle Turtle",
             "spellid": 453255
-          },
-          {
-            "ID": 571,
-            "icon": "ability_mount_ironchimera",
-            "itemId": 107951,
-            "name": "Iron Skyreaver",
-            "spellid": 153489
-          },
-          {
-            "ID": 1579,
-            "icon": "inv_sharkraymount_4",
-            "itemId": 190539,
-            "name": "Coral-Stalker Waveray",
-            "spellid": 367620
           }
         ],
         "name": "Promotions"
@@ -273,6 +259,7 @@
           {
             "ID": 2570,
             "icon": "inv_viciousvoidcreepermount_blue",
+            "itemId": "243157",
             "name": "Vicious Void Creeper",
             "new": true,
             "side": "A",
@@ -281,6 +268,7 @@
           {
             "ID": 2571,
             "icon": "inv_viciousvoidcreepermount_orange",
+            "itemId": "243159",
             "name": "Vicious Void Creeper",
             "new": true,
             "side": "H",
@@ -289,24 +277,13 @@
           {
             "ID": 2326,
             "icon": "inv_felbatgladiatormount_purple",
+            "itemId": "232617",
             "name": "Astral Gladiator's Fel Bat",
             "new": true,
             "spellid": 472157
           }
         ],
         "name": "War Within: Season 3"
-      },
-      {
-        "items": [
-          {
-            "ID": 2531,
-            "icon": "inv_misc_fish_turtle_01",
-            "itemId": 239020,
-            "name": "Tyrannotort",
-            "spellid": 1227076
-          }
-        ],
-        "name": "Dastardly Duos"
       },
       {
         "items": [
@@ -346,11 +323,11 @@
       {
         "items": [
           {
-            "ID": 2526,
-            "icon": "inv_chimerafiremount_green",
-            "itemId": 238966,
-            "name": "Felborn Cormaera",
-            "spellid": 1226851
+            "ID": 2145,
+            "icon": "inv_goblinsurfboardmount_blue",
+            "itemId": 221270,
+            "name": "Kickin' Kezan Waveshredder",
+            "spellid": 446352
           }
         ],
         "name": "Blizzard Store"
@@ -364,11 +341,11 @@
         "items": [
           {
             "ID": 69,
+            "bounty": true,
             "icon": "ability_mount_undeadhorse",
             "itemId": 13335,
             "name": "Rivendare's Deathcharger",
-            "spellid": 17481,
-            "bounty": true
+            "spellid": 17481
           }
         ],
         "name": "Classic"
@@ -377,35 +354,35 @@
         "items": [
           {
             "ID": 185,
+            "bounty": true,
             "icon": "inv-mount_raven_54",
             "itemId": 32768,
             "name": "Raven Lord",
-            "spellid": 41252,
-            "bounty": true
+            "spellid": 41252
           },
           {
             "ID": 213,
+            "bounty": true,
             "icon": "ability_mount_cockatricemountelite_white",
             "itemId": 35513,
             "name": "Swift White Hawkstrider",
-            "spellid": 46628,
-            "bounty": true
+            "spellid": 46628
           },
           {
             "ID": 183,
+            "bounty": true,
             "icon": "inv_misc_summerfest_brazierorange",
             "itemId": 32458,
             "name": "Ashes of Al'ar",
-            "spellid": 40192,
-            "bounty": true
+            "spellid": 40192
           },
           {
             "ID": 168,
+            "bounty": true,
             "icon": "ability_mount_dreadsteed",
             "itemId": 30480,
             "name": "Fiery Warhorse",
-            "spellid": 36702,
-            "bounty": true
+            "spellid": 36702
           }
         ],
         "name": "Burning Crusade"
@@ -414,69 +391,69 @@
         "items": [
           {
             "ID": 264,
+            "bounty": true,
             "icon": "ability_mount_drake_proto",
             "itemId": 44151,
             "name": "Blue Proto-Drake",
-            "spellid": 59996,
-            "bounty": true
+            "spellid": 59996
           },
           {
             "ID": 246,
+            "bounty": true,
             "icon": "ability_mount_drake_azure",
             "itemId": 43952,
             "name": "Azure Drake",
-            "spellid": 59567,
-            "bounty": true
+            "spellid": 59567
           },
           {
             "ID": 247,
+            "bounty": true,
             "icon": "ability_mount_drake_azure",
             "itemId": 43953,
             "name": "Blue Drake",
-            "spellid": 59568,
-            "bounty": true
+            "spellid": 59568
           },
           {
             "ID": 286,
+            "bounty": true,
             "icon": "ability_mount_mammoth_black_3seater",
             "itemId": 43959,
             "name": "Grand Black War Mammoth",
             "side": "A",
-            "spellid": 61465,
-            "bounty": true
+            "spellid": 61465
           },
           {
             "ID": 287,
+            "bounty": true,
             "icon": "ability_mount_mammoth_black_3seater",
             "itemId": 44083,
             "name": "Grand Black War Mammoth",
             "side": "H",
-            "spellid": 61467,
-            "bounty": true
+            "spellid": 61467
           },
           {
             "ID": 304,
+            "bounty": true,
             "icon": "inv_misc_enggizmos_03",
             "itemId": 45693,
             "name": "Mimiron's Head",
-            "spellid": 63796,
-            "bounty": true
+            "spellid": 63796
           },
           {
             "ID": 349,
+            "bounty": true,
             "icon": "achievement_boss_onyxia",
             "itemId": 49636,
             "name": "Onyxian Drake",
-            "spellid": 69395,
-            "bounty": true
+            "spellid": 69395
           },
           {
             "ID": 363,
+            "bounty": true,
             "icon": "ability_mount_pegasus",
             "itemId": 50818,
             "name": "Invincible",
-            "spellid": 72286,
-            "bounty": true
+            "spellid": 72286
           }
         ],
         "name": "Wrath of the Lich King"
@@ -485,83 +462,83 @@
         "items": [
           {
             "ID": 395,
+            "bounty": true,
             "icon": "inv_misc_stormdragonpale",
             "itemId": 63040,
             "name": "Drake of the North Wind",
-            "spellid": 88742,
-            "bounty": true
+            "spellid": 88742
           },
           {
             "ID": 397,
+            "bounty": true,
             "icon": "inv_misc_stonedragonblue",
             "itemId": 63043,
             "name": "Vitreous Stone Drake",
-            "spellid": 88746,
-            "bounty": true
+            "spellid": 88746
           },
           {
             "ID": 410,
+            "bounty": true,
             "icon": "ability_mount_raptor",
             "itemId": 68823,
             "name": "Armored Razzashi Raptor",
-            "spellid": 96491,
-            "bounty": true
+            "spellid": 96491
           },
           {
             "ID": 411,
+            "bounty": true,
             "icon": "ability_mount_blackpanther",
             "itemId": 68824,
             "name": "Swift Zulian Panther",
-            "spellid": 96499,
-            "bounty": true
+            "spellid": 96499
           },
           {
             "ID": 396,
+            "bounty": true,
             "icon": "inv_misc_stormdragonpurple",
             "itemId": 63041,
             "name": "Drake of the South Wind",
-            "spellid": 88744,
-            "bounty": true
+            "spellid": 88744
           },
           {
             "ID": 425,
+            "bounty": true,
             "icon": "ability_mount_fireravengodmount",
             "itemId": 71665,
             "name": "Flametalon of Alysrazor",
-            "spellid": 101542,
-            "bounty": true
+            "spellid": 101542
           },
           {
             "ID": 415,
+            "bounty": true,
             "icon": "inv_misc_orb_05",
             "itemId": 69224,
             "name": "Pureblood Fire Hawk",
-            "spellid": 97493,
-            "bounty": true
+            "spellid": 97493
           },
           {
             "ID": 445,
+            "bounty": true,
             "icon": "ability_mount_drake_twilight",
             "itemId": 78919,
             "name": "Experiment 12-B",
-            "spellid": 110039,
-            "bounty": true
+            "spellid": 110039
           },
           {
             "ID": 442,
+            "bounty": true,
             "icon": "ability_mount_drake_red",
             "itemId": 77067,
             "name": "Blazing Drake",
-            "spellid": 107842,
-            "bounty": true
+            "spellid": 107842
           },
           {
             "ID": 444,
+            "bounty": true,
             "icon": "ability_mount_drake_red",
             "itemId": 77069,
             "name": "Life-Binder's Handmaiden",
-            "spellid": 107845,
-            "bounty": true
+            "spellid": 107845
           }
         ],
         "name": "Cataclysm"
@@ -570,35 +547,35 @@
         "items": [
           {
             "ID": 478,
+            "bounty": true,
             "icon": "inv_celestialserpentmount",
             "itemId": 87777,
             "name": "Astral Cloud Serpent",
-            "spellid": 127170,
-            "bounty": true
+            "spellid": 127170
           },
           {
             "ID": 531,
+            "bounty": true,
             "icon": "ability_mount_triceratopsmount",
             "itemId": 93666,
             "name": "Spawn of Horridon",
-            "spellid": 136471,
-            "bounty": true
+            "spellid": 136471
           },
           {
             "ID": 543,
+            "bounty": true,
             "icon": "achievement_boss_ji-kun",
             "itemId": 95059,
             "name": "Clutch of Ji-Kun",
-            "spellid": 139448,
-            "bounty": true
+            "spellid": 139448
           },
           {
             "ID": 559,
+            "bounty": true,
             "icon": "inv_mount_hordescorpiong",
             "itemId": 104253,
             "name": "Kor'kron Juggernaut",
-            "spellid": 148417,
-            "bounty": true
+            "spellid": 148417
           }
         ],
         "name": "Mists of Pandaria"
@@ -607,19 +584,19 @@
         "items": [
           {
             "ID": 613,
+            "bounty": true,
             "icon": "inv_ironhordeclefthoof",
             "itemId": 116660,
             "name": "Ironhoof Destroyer",
-            "spellid": 171621,
-            "bounty": true
+            "spellid": 171621
           },
           {
             "ID": 751,
+            "bounty": true,
             "icon": "ability_mount_felreavermount",
             "itemId": 123890,
             "name": "Felsteel Annihilator",
-            "spellid": 182912,
-            "bounty": true
+            "spellid": 182912
           }
         ],
         "name": "Warlords of Draenor"
@@ -628,51 +605,51 @@
         "items": [
           {
             "ID": 875,
+            "bounty": true,
             "icon": "ability_mount_dreadsteed",
             "itemId": 142236,
             "name": "Midnight",
-            "spellid": 229499,
-            "bounty": true
+            "spellid": 229499
           },
           {
             "ID": 791,
+            "bounty": true,
             "icon": "inv_infernalmount",
             "itemId": 137574,
             "name": "Felblaze Infernal",
-            "spellid": 213134,
-            "bounty": true
+            "spellid": 213134
           },
           {
             "ID": 633,
+            "bounty": true,
             "icon": "inv_infernalmountred",
             "itemId": 137575,
             "name": "Hellfire Infernal",
-            "spellid": 171827,
-            "bounty": true
+            "spellid": 171827
           },
           {
             "ID": 899,
+            "bounty": true,
             "icon": "inv_serpentmount_green",
             "itemId": 143643,
             "name": "Abyss Worm",
-            "spellid": 232519,
-            "bounty": true
+            "spellid": 232519
           },
           {
             "ID": 971,
+            "bounty": true,
             "icon": "inv_felhound3_shadow_fire",
             "itemId": 152816,
             "name": "Antoran Charhound",
-            "spellid": 253088,
-            "bounty": true
+            "spellid": 253088
           },
           {
             "ID": 954,
+            "bounty": true,
             "icon": "inv_soulhoundmount_blue",
             "itemId": 152789,
             "name": "Shackled Ur'zul",
-            "spellid": 243651,
-            "bounty": true
+            "spellid": 243651
           }
         ],
         "name": "Legion"
@@ -681,51 +658,51 @@
         "items": [
           {
             "ID": 1040,
+            "bounty": true,
             "icon": "inv_armoredraptorundead",
             "itemId": 159921,
             "name": "Tomb Stalker",
-            "spellid": 266058,
-            "bounty": true
+            "spellid": 266058
           },
           {
             "ID": 1053,
+            "bounty": true,
             "icon": "inv_bloodtrollbeast_mount_pale",
             "itemId": 160829,
             "name": "Underrot Crawg",
-            "spellid": 273541,
-            "bounty": true
+            "spellid": 273541
           },
           {
             "ID": 995,
+            "bounty": true,
             "icon": "inv_parrotmount_red",
             "itemId": 159842,
             "name": "Sharkbait",
-            "spellid": 254813,
-            "bounty": true
+            "spellid": 254813
           },
           {
             "ID": 1217,
+            "bounty": true,
             "icon": "achievement_dungeon_coinoperatedcrowdpummeler",
             "itemId": 166518,
             "name": "G.M.O.D.",
-            "spellid": 289083,
-            "bounty": true
+            "spellid": 289083
           },
           {
             "ID": 1219,
+            "bounty": true,
             "icon": "inv_waterelementalmount",
             "itemId": 166705,
             "name": "Glacial Tidestorm",
-            "spellid": 289555,
-            "bounty": true
+            "spellid": 289555
           },
           {
             "ID": 1293,
+            "bounty": true,
             "icon": "inv_eyeballjellyfishmount",
             "itemId": 174872,
             "name": "Ny'alotha Allseer",
-            "spellid": 308814,
-            "bounty": true
+            "spellid": 308814
           }
         ],
         "name": "Battle for Azeroth"
@@ -734,43 +711,43 @@
         "items": [
           {
             "ID": 1406,
+            "bounty": true,
             "icon": "inv_maldraxxusflyermount_red",
             "itemId": 181819,
             "name": "Marrowfang",
-            "spellid": 336036,
-            "bounty": true
+            "spellid": 336036
           },
           {
             "ID": 1481,
+            "bounty": true,
             "icon": "inv_brokermount_dark",
             "itemId": 186638,
             "name": "Cartel Master's Gearglider",
-            "spellid": 353263,
-            "bounty": true
+            "spellid": 353263
           },
           {
             "ID": 1500,
+            "bounty": true,
             "icon": "ability_mount_mawhorsespikes_purple",
             "itemId": 186656,
             "name": "Sanctum Gloomcharger",
-            "spellid": 354351,
-            "bounty": true
+            "spellid": 354351
           },
           {
             "ID": 1471,
+            "bounty": true,
             "icon": "inv_dragonhawkmountshadowlands",
             "itemId": 186642,
             "name": "Vengeance",
-            "spellid": 351195,
-            "bounty": true
+            "spellid": 351195
           },
           {
             "ID": 1587,
+            "bounty": true,
             "icon": "inv_progenitorbotminemount",
             "itemId": 190768,
             "name": "Zereth Overseer",
-            "spellid": 368158,
-            "bounty": true
+            "spellid": 368158
           }
         ],
         "name": "Shadowlands"
@@ -841,6 +818,7 @@
           {
             "ID": 2549,
             "icon": "inv_kareshflyermount_black",
+            "itemId": "242714",
             "name": "Umbral K'arroc",
             "new": true,
             "spellid": 1233511
@@ -848,6 +826,7 @@
           {
             "ID": 2511,
             "icon": "inv_voidflyermount_red",
+            "itemId": "237485",
             "name": "Terror of the Night",
             "new": true,
             "spellid": 1223191
@@ -1071,6 +1050,22 @@
             "itemId": 238829,
             "name": "Radiant Imperial Lynx",
             "spellid": 1226421
+          },
+          {
+            "ID": 2556,
+            "icon": "inv_voidcreepermount_red",
+            "itemId": 242729,
+            "name": "Ruby Void Creeper",
+            "new": true,
+            "spellid": 1233546
+          },
+          {
+            "ID": 2510,
+            "icon": "inv_voidflyermount_purple",
+            "itemId": 237484,
+            "name": "Terror of the Wastes",
+            "new": true,
+            "spellid": 1223187
           }
         ],
         "name": "Renown"
@@ -1137,6 +1132,22 @@
             "itemId": 229940,
             "name": "Flarendo the Furious",
             "spellid": 466011
+          },
+          {
+            "ID": 1483,
+            "icon": "inv_brokermount_silver",
+            "itemId": 186640,
+            "name": "Vandal's Gearglider",
+            "new": true,
+            "spellid": 353265
+          },
+          {
+            "ID": 2555,
+            "icon": "inv_voidcreepermount_blue",
+            "itemId": 242728,
+            "name": "The Bone Freezer",
+            "spellid": 1233542,
+            "new": true
           }
         ],
         "name": "Raid Renown"
@@ -1303,6 +1314,14 @@
             "name": "Resplendent K'arroc",
             "new": true,
             "spellid": 1221132
+          },
+          {
+            "ID": 2655,
+            "icon": "inv_kareshroamermount_yellow",
+            "itemId": 250240,
+            "name": "Phase-Lost Slateback",
+            "new": true,
+            "spellid": 1250578
           }
         ],
         "name": "Rare Spawn"
@@ -1418,20 +1437,20 @@
             "spellid": 1218316
           },
           {
-            "ID": 2552,
-            "icon": "inv_kareshflyermount_purple",
-            "itemId": 242717,
-            "name": "Lavender K'arroc",
-            "new": true,
-            "spellid": 1233518
-          },
-          {
             "ID": 2557,
             "icon": "inv_voidcreepermount_yellow",
             "itemId": 242730,
             "name": "Acidic Void Creeper",
             "new": true,
             "spellid": 1233547
+          },
+          {
+            "ID": 2552,
+            "icon": "inv_kareshflyermount_purple",
+            "itemId": 242717,
+            "name": "Lavender K'arroc",
+            "new": true,
+            "spellid": 1233518
           }
         ],
         "name": "Vendor"
@@ -1444,43 +1463,6 @@
             "itemId": 233489,
             "name": "Prismatic Snapdragon",
             "spellid": 474086
-          }
-        ],
-        "name": "Daily Activities"
-      },
-      {
-        "items": [
-          {
-            "ID": 2510,
-            "icon": "inv_voidflyermount_purple",
-            "itemId": 237484,
-            "name": "Terror of the Wastes",
-            "new": true,
-            "spellid": 1223187
-          },
-          {
-            "ID": 2556,
-            "icon": "inv_voidcreepermount_red",
-            "itemId": 242729,
-            "name": "Ruby Void Creeper",
-            "new": true,
-            "spellid": 1233546
-          },
-          {
-            "ID": 1482,
-            "icon": "inv_brokermount_light",
-            "itemId": 186639,
-            "name": "Xy Trustee's Gearglider",
-            "new": true,
-            "spellid": 353264
-          },
-          {
-            "ID": 1483,
-            "icon": "inv_brokermount_silver",
-            "itemId": 186640,
-            "name": "Vandal's Gearglider",
-            "new": true,
-            "spellid": 353265
           },
           {
             "ID": 2560,
@@ -1489,6 +1471,19 @@
             "name": "Blue Barry",
             "new": true,
             "spellid": 1233559
+          }
+        ],
+        "name": "Daily Activities"
+      },
+      {
+        "items": [
+          {
+            "ID": 1482,
+            "icon": "inv_brokermount_light",
+            "itemId": 186639,
+            "name": "Xy Trustee's Gearglider",
+            "new": true,
+            "spellid": 353264
           }
         ],
         "name": "Unknown"
@@ -10147,15 +10142,6 @@
             "spellid": 213349
           },
           {
-            "ID": 2145,
-            "icon": "inv_goblinsurfboardmount_blue",
-            "itemId": 221270,
-            "name": "Kickin' Kezan Waveshredder",
-            "notObtainable": true,
-            "notReleased": true,
-            "spellid": 446352
-          },
-          {
             "ID": 2186,
             "icon": "inv_oldgodfishmount_blue",
             "itemId": 223282,
@@ -10507,6 +10493,19 @@
       {
         "items": [
           {
+            "ID": 2531,
+            "icon": "inv_misc_fish_turtle_01",
+            "itemId": 239020,
+            "name": "Tyrannotort",
+            "notObtainable": true,
+            "spellid": 1227076
+          }
+        ],
+        "name": "Dastardly Duos"
+      },
+      {
+        "items": [
+          {
             "ID": 482,
             "icon": "ability_mount_cranemount",
             "itemId": 87784,
@@ -10820,6 +10819,14 @@
             "spellid": 142878
           },
           {
+            "ID": 571,
+            "icon": "ability_mount_ironchimera",
+            "itemId": 107951,
+            "name": "Iron Skyreaver",
+            "notObtainable": true,
+            "spellid": 153489
+          },
+          {
             "ID": 600,
             "icon": "inv_ravenlordmount",
             "itemId": 109013,
@@ -11051,6 +11058,21 @@
             "itemId": 238994,
             "name": "Archmage's Great Raven",
             "spellid": 1226983
+          },
+          {
+            "ID": 2526,
+            "icon": "inv_chimerafiremount_green",
+            "itemId": 238966,
+            "name": "Felborn Cormaera",
+            "notObtainable": true,
+            "spellid": 1226851
+          },
+          {
+            "ID": 2532,
+            "icon": "6694822",
+            "itemId": 239076,
+            "name": "Herald of Sa'bak",
+            "spellid": 1227192
           }
         ],
         "name": "Blizzard Store"
@@ -11330,6 +11352,19 @@
           }
         ],
         "name": "Mountain Dew"
+      },
+      {
+        "items": [
+          {
+            "ID": 1579,
+            "icon": "inv_sharkraymount_4",
+            "itemId": 190539,
+            "name": "Coral-Stalker Waveray",
+            "resale": true,
+            "spellid": 367620
+          }
+        ],
+        "name": "Razer"
       },
       {
         "id": "ed0e4736",

--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -9675,7 +9675,6 @@
             "icon": "inv_sandbeemount",
             "itemId": 232624,
             "name": "Timely Buzzbee",
-            "notObtainable": true,
             "spellid": 471538
           },
           {

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -262,30 +262,9 @@
             "itemId": 224576,
             "name": "Lil' Flameo",
             "spellid": 453266
-          },
-          {
-            "ID": 4690,
-            "creatureId": 233481,
-            "icon": "inv_babynaga2_purple",
-            "itemId": 232519,
-            "name": "Razeshi B.",
-            "spellid": 470914
           }
         ],
         "name": "Promotions"
-      },
-      {
-        "items": [
-          {
-            "ID": 4806,
-            "creatureId": 241346,
-            "icon": "inv_ironstarlettepet",
-            "itemId": 239019,
-            "name": "Spicy Mean-Ball",
-            "spellid": 1227066
-          }
-        ],
-        "name": "Dastardly Duos"
       },
       {
         "items": [
@@ -430,7 +409,7 @@
             "creatureId": 231451,
             "icon": "inv_toygorilla_blue",
             "itemId": 232843,
-            "name": "Gorillion",
+            "name": "Mega-Mecha Gorilla",
             "spellid": 471935
           },
           {
@@ -11710,6 +11689,20 @@
       {
         "items": [
           {
+            "ID": 4806,
+            "creatureId": 241346,
+            "icon": "inv_ironstarlettepet",
+            "itemId": 239019,
+            "name": "Spicy Mean-Ball",
+            "notObtainable": true,
+            "spellid": 1227066
+          }
+        ],
+        "name": "Dastardly Duos"
+      },
+      {
+        "items": [
+          {
             "ID": 4579,
             "creatureId": 223785,
             "icon": "inv_yakpet",
@@ -12525,6 +12518,20 @@
           }
         ],
         "name": "Mountain Dew"
+      },
+      {
+        "items": [
+          {
+            "ID": 4690,
+            "creatureId": 233481,
+            "icon": "inv_babynaga2_purple",
+            "itemId": 232519,
+            "name": "Razeshi B.",
+            "resale": true,
+            "spellid": 470914
+          }
+        ],
+        "name": "Razer"
       },
       {
         "items": [

--- a/static/data/pets.json
+++ b/static/data/pets.json
@@ -11985,6 +11985,14 @@
             "spellid": 419467
           },
           {
+            "ID": 4796,
+            "creatureId": 241416,
+            "icon": "6694821",
+            "itemId": 239082,
+            "name": "Sa'bak's Blessed",
+            "spellid": 127902
+          },
+          {
             "ID": 4730,
             "creatureId": 236016,
             "icon": "inv_clockworkbeagle_purple",

--- a/static/data/planner.json
+++ b/static/data/planner.json
@@ -633,7 +633,7 @@
                         }
                       ],
                       "title": "Run Return to Karazhan",
-                      "type": "Dungeon"
+                      "type": "WeeklyDungeon"
                     }
                   ],
                   "title": "Fly to Deadwind Pass"
@@ -1072,7 +1072,7 @@
                     }
                   ],
                   "title": "Run Freehold",
-                  "type": "Dungeon"
+                  "type": "WeeklyDungeon"
                 }
               ],
               "title": "Walk to Tiragarde Sound"
@@ -1094,7 +1094,7 @@
                     }
                   ],
                   "title": "Run King's Rest",
-                  "type": "Dungeon"
+                  "type": "WeeklyDungeon"
                 }
               ],
               "title": "Walk to Zuldazar"
@@ -1116,7 +1116,7 @@
                     }
                   ],
                   "title": "Run The Underrot",
-                  "type": "Dungeon"
+                  "type": "WeeklyDungeon"
                 }
               ],
               "title": "Walk to Nazmir"
@@ -1154,7 +1154,7 @@
                     }
                   ],
                   "title": "Run Mechagon: Junkyard",
-                  "type": "Dungeon"
+                  "type": "WeeklyDungeon"
                 }
               ],
               "title": "Portal to Zandalar / Kul'Tiras and take the Teleporter / Flight Path to Mechagon"
@@ -1205,7 +1205,7 @@
                     }
                   ],
                   "title": "Run Necrotic Wake",
-                  "type": "Dungeon"
+                  "type": "WeeklyDungeon"
                 }
               ],
               "title": "Flightpath to Bastion"
@@ -1221,7 +1221,7 @@
                       "itemId": 186638,
                       "mount": "Cartel Master's Gearglider",
                       "name": "So'leah",
-                      "note": "Heroic/Mythic",
+                      "note": "Heroic (Repeatable)/Mythic",
                       "spellId": 353263,
                       "boosted": true
                     }
@@ -1510,7 +1510,7 @@
                     }
                   ],
                   "title": "Run The Stonevault",
-                  "type": "Dungeon"
+                  "type": "WeeklyDungeon"
                 }
               ],
               "title": "Flightpath to The Ringing Deeps"
@@ -1531,7 +1531,7 @@
                     }
                   ],
                   "title": "Run Darkflame Cleft",
-                  "type": "Dungeon"
+                  "type": "WeeklyDungeon"
                 }
               ],
               "title": "Flightpath to Ringing Deeps"

--- a/static/data/toys.json
+++ b/static/data/toys.json
@@ -153,19 +153,25 @@
       {
         "items": [
           {
-            "ID": 1573,
-            "icon": "inv_banner_01",
-            "itemId": 239007,
-            "name": "Dastardly Banner"
+            "ID": 609,
+            "icon": "diabloanniversary_tomeoftownportal",
+            "itemId": 142542,
+            "name": "Tome of Town Portal"
           },
           {
-            "ID": 1574,
-            "icon": "inv_11xp_event_dastardlyduos_podium01_nocollision",
-            "itemId": 239018,
-            "name": "Winner's Podium"
+            "ID": 605,
+            "icon": "inv_axe_2h_undeadguitar_c_01",
+            "itemId": 143543,
+            "name": "Twelve-String Guitar"
+          },
+          {
+            "ID": 1331,
+            "icon": "inv_misc_nightmarebanner",
+            "itemId": 206008,
+            "name": "Nightmare Banner"
           }
         ],
-        "name": "Dastardly Duos"
+        "name": "Greedy Emissary"
       }
     ]
   },
@@ -282,6 +288,13 @@
             "icon": "inv_helm_misc_fireworkpartyhat",
             "itemId": 235220,
             "name": "Fireworks Hat"
+          },
+          {
+            "ID": 1592,
+            "icon": "inv_letter_13",
+            "itemId": 245970,
+            "name": "P.O.S.T. Master's Express Hearthstone",
+            "new": true
           }
         ],
         "name": "Treasure"
@@ -639,13 +652,6 @@
             "new": true
           },
           {
-            "ID": 1592,
-            "icon": "inv_letter_13",
-            "itemId": 245970,
-            "name": "P.O.S.T. Master's Express Hearthstone",
-            "new": true
-          },
-          {
             "ID": 1600,
             "icon": "inv_chest_armor_explorer_d_01",
             "itemId": 244792,
@@ -657,6 +663,41 @@
             "icon": "inv_plate_broker_c_01_helm",
             "itemId": 249713,
             "name": "Cartel Transmorpher",
+            "new": true
+          },
+          {
+            "ID": 1603,
+            "icon": "spell_arcane_prismaticcloak",
+            "itemId": 246903,
+            "name": "Guise of the Phase Diver",
+            "new": true
+          },
+          {
+            "ID": 1604,
+            "icon": "ability_racial_etherealconnection",
+            "itemId": 246905,
+            "name": "Overtuned K'areshi Goggles",
+            "new": true
+          },
+          {
+            "ID": 1605,
+            "icon": "inv_112_raidtrinkets_etherealenergystoragebarrel_terra",
+            "itemId": 246908,
+            "name": "K'areshi Supply Crate",
+            "new": true
+          },
+          {
+            "ID": 1606,
+            "icon": "inv_misc_enlightenedbrokers_paragoncache01",
+            "itemId": 246907,
+            "name": "Broker Supply Crate",
+            "new": true
+          },
+          {
+            "ID": 1610,
+            "icon": "inv_misc_bandage_netherweave",
+            "itemId": 250722,
+            "name": "Ethereal Stall",
             "new": true
           }
         ],
@@ -7062,6 +7103,25 @@
         "name": "Plunderstorm"
       },
       {
+        "items": [
+          {
+            "ID": 1573,
+            "icon": "inv_banner_01",
+            "itemId": 239007,
+            "name": "Dastardly Banner",
+            "notObtainable": true
+          },
+          {
+            "ID": 1574,
+            "icon": "inv_11xp_event_dastardlyduos_podium01_nocollision",
+            "itemId": 239018,
+            "name": "Winner's Podium",
+            "notObtainable": true
+          }
+        ],
+        "name": "Dastardly Duos"
+      },
+      {
         "id": "6edf78f8",
         "items": [
           {
@@ -7362,27 +7422,6 @@
       {
         "id": "c0f754ff",
         "items": [
-          {
-            "ID": 609,
-            "icon": "diabloanniversary_tomeoftownportal",
-            "itemId": 142542,
-            "name": "Tome of Town Portal",
-            "notObtainable": true
-          },
-          {
-            "ID": 605,
-            "icon": "inv_axe_2h_undeadguitar_c_01",
-            "itemId": 143543,
-            "name": "Twelve-String Guitar",
-            "notObtainable": true
-          },
-          {
-            "ID": 1331,
-            "icon": "inv_misc_nightmarebanner",
-            "itemId": 206008,
-            "name": "Nightmare Banner",
-            "notObtainable": true
-          }
         ],
         "name": "Diablo 20th Anniversary"
       },
@@ -7465,42 +7504,6 @@
           }
         ],
         "name": "WoW Classic"
-      }
-    ]
-  },
-  {
-    "id": "25509538",
-    "name": "TODO",
-    "subcats": [
-      {
-        "id": "1a006cd3",
-        "items": [
-          {
-            "ID": 1603,
-            "icon": "spell_arcane_prismaticcloak",
-            "itemId": 246903,
-            "name": "Guise of the Phase Diver"
-          },
-          {
-            "ID": 1604,
-            "icon": "ability_racial_etherealconnection",
-            "itemId": 246905,
-            "name": "Overtuned K'areshi Goggles"
-          },
-          {
-            "ID": 1605,
-            "icon": "inv_112_raidtrinkets_etherealenergystoragebarrel_terra",
-            "itemId": 246908,
-            "name": "K'areshi Supply Crate"
-          },
-          {
-            "ID": 1606,
-            "icon": "inv_misc_enlightenedbrokers_paragoncache01",
-            "itemId": 246907,
-            "name": "Broker Supply Crate"
-          }
-        ],
-        "name": "Unknown"
       }
     ]
   }


### PR DESCRIPTION
Planner fixes and changes;
- Dungeons are now separated between daily and weekly dungeons (since all dungeons were getting reset daily)
- Added check for Weekly reset so that it doesn't instantly uncheck anything that's marked on the day of, but in the hours before, reset.

New Content:
- Added the new Store Mounts and pet
- Updated and added new 11.2 things for preview

Misc;
- Added Greedy Emissary Toys into Limited Time section as they are available again.
- Corrected 'Timely Buzzbee', which is once again available through any timewalking vendor.
- Marked 'Dastardly Duos' content as unobtainable
- Moved Razer Promotion things out of Limited Time section as the promotion is no longer available (still listed on the site but ingame items aren't offered)