### PR TITLE
dataimporter: sort JSON keys numerically when possible

### DIFF
--- a/dataimporter/__main__.py
+++ b/dataimporter/__main__.py
@@ -14,6 +14,7 @@ from .toys import ToyFixer
 from .decors import DecorFixer
 
 from .providers import wago
+from .tools import sort_obj_numeric
 
 FIXERS = {
     'achievements': (AchievementFixer, ['achievements.json']),
@@ -111,11 +112,12 @@ def main():
             fixed_list = fixer.run()
         for fixed_content, path in zip(fixed_list, json_paths):
             with path.open('w', encoding='utf8') as json_file:
+                fixed_content = sort_obj_numeric(fixed_content)
                 json.dump(
                     fixed_content,
                     json_file,
                     indent=2,
-                    sort_keys=True,
+                    sort_keys=False,
                     ensure_ascii=False
                 )
                 json_file.write('\n')

--- a/dataimporter/tools.py
+++ b/dataimporter/tools.py
@@ -65,3 +65,20 @@ def iscat(dct, supercat=None, cat=None, subcat=None, *, error_absent=False):
             res['subcats'], subcat, 'items', error_absent
         )
     return res
+
+
+# Sort a JSON-encodable object so that all the keys of its dictionaries are
+# sorted by key lexicographically, like json.dumps(sort_keys=True), except
+# if the dictionary keys are all integers, sort them numerically instead.
+def sort_obj_numeric(obj):
+    if isinstance(obj, dict):
+        d = {k: sort_obj_numeric(v) for k, v in obj.items()}
+        if all(str(s).strip().isdigit() for s in d.keys()):
+            sorted_keys = sorted(d.keys(), key=lambda x: int(x))
+        else:
+            sorted_keys = sorted(d.keys())
+        return {k: d[k] for k in sorted_keys}
+    elif isinstance(obj, list):
+        return [sort_obj_numeric(i) for i in obj]
+    else:
+        return obj

--- a/static/data/decors.json
+++ b/static/data/decors.json
@@ -9828,7 +9828,7 @@
             "itemId": "252040",
             "name": "Sealed Sack of Roasted Kafa"
           },
-           {
+          {
             "ID": 8180,
             "icon": "7424583",
             "itemId": "251473",


### PR DESCRIPTION
Fixes the problem where running the fixer on factions would mess up the ordering.