### PR TITLE
Various fixes for decor sources

### DIFF
--- a/static/data/decors.json
+++ b/static/data/decors.json
@@ -297,6 +297,12 @@
             "name": "Lightbloom Moss Mound"
           },
           {
+            "ID": 15494,
+            "icon": "7507178",
+            "itemId": "264259",
+            "name": "On'ohia's Call"
+          },
+          {
             "ID": 15757,
             "icon": "7514920",
             "itemId": "264493",
@@ -605,12 +611,6 @@
             "name": "Void Elf Barrel"
           },
           {
-            "ID": 18800,
-            "icon": "garrison_building_storehouse",
-            "itemId": "267209",
-            "name": "Open Void Elf Bedroll"
-          },
-          {
             "ID": 14603,
             "icon": "7487043",
             "itemId": "262473",
@@ -902,12 +902,6 @@
             "name": "Harandar Charcuterie Board"
           },
           {
-            "ID": 15494,
-            "icon": "7507178",
-            "itemId": "264259",
-            "name": "On'ohia's Call"
-          },
-          {
             "ID": 15497,
             "icon": "7506636",
             "itemId": "264262",
@@ -930,12 +924,6 @@
             "icon": "7416603",
             "itemId": "253485",
             "name": "Sin'dorei Honor Stone"
-          },
-          {
-            "ID": 1173,
-            "icon": "7416651",
-            "itemId": "243106",
-            "name": "Gemmed Eversong Lantern"
           },
           {
             "ID": 1442,
@@ -1040,6 +1028,12 @@
             "name": "Cosmic Kettle"
           },
           {
+            "ID": 18800,
+            "icon": "garrison_building_storehouse",
+            "itemId": "267209",
+            "name": "Open Void Elf Bedroll"
+          },
+          {
             "ID": 14631,
             "icon": "7515013",
             "itemId": "262606",
@@ -1068,6 +1062,12 @@
             "icon": "7509052",
             "itemId": "264334",
             "name": "Amani War Drum"
+          },
+          {
+            "ID": 10858,
+            "icon": "7425721",
+            "itemId": "255648",
+            "name": "Zul'Aman Ancestral Fountain"
           },
           {
             "ID": 15768,
@@ -1296,12 +1296,6 @@
             "name": "Veilroot Fountain"
           },
           {
-            "ID": 10858,
-            "icon": "7425721",
-            "itemId": "255648",
-            "name": "Zul'Aman Ancestral Fountain"
-          },
-          {
             "ID": 14806,
             "icon": "7489659",
             "itemId": "262957",
@@ -1366,10 +1360,22 @@
       {
         "items": [
           {
+            "ID": 15401,
+            "icon": "7504945",
+            "itemId": "263996",
+            "name": "Twilight Tabernacle"
+          },
+          {
             "ID": 15399,
             "icon": "7504910",
             "itemId": "263994",
             "name": "Fungal Chest"
+          },
+          {
+            "ID": 15460,
+            "icon": "7504940",
+            "itemId": "264175",
+            "name": "Amani Strongbox"
           },
           {
             "ID": 15455,
@@ -1378,10 +1384,22 @@
             "name": "Ancient Kaldorei Coffer"
           },
           {
-            "ID": 15460,
-            "icon": "7504940",
-            "itemId": "264175",
-            "name": "Amani Strongbox"
+            "ID": 15413,
+            "icon": "7504904",
+            "itemId": "264008",
+            "name": "Root-Wrapped Reliquary"
+          },
+          {
+            "ID": 15412,
+            "icon": "7504821",
+            "itemId": "264007",
+            "name": "Corewarden's Spoils"
+          },
+          {
+            "ID": 15400,
+            "icon": "7504914",
+            "itemId": "263995",
+            "name": "Delver's Bountiful Coffer"
           },
           {
             "ID": 15582,
@@ -1436,6 +1454,12 @@
       },
       {
         "items": [
+          {
+            "ID": 1173,
+            "icon": "7416651",
+            "itemId": "243106",
+            "name": "Gemmed Eversong Lantern"
+          },
           {
             "ID": 1195,
             "icon": "7416723",
@@ -1959,30 +1983,6 @@
             "icon": "7422947",
             "itemId": "246857",
             "name": "\"Shu'halo Perspective\" Painting"
-          },
-          {
-            "ID": 15400,
-            "icon": "7504914",
-            "itemId": "263995",
-            "name": "Delver's Bountiful Coffer"
-          },
-          {
-            "ID": 15401,
-            "icon": "7504945",
-            "itemId": "263996",
-            "name": "Twilight Tabernacle"
-          },
-          {
-            "ID": 15412,
-            "icon": "7504821",
-            "itemId": "264007",
-            "name": "Corewarden's Spoils"
-          },
-          {
-            "ID": 15413,
-            "icon": "7504904",
-            "itemId": "264008",
-            "name": "Root-Wrapped Reliquary"
           },
           {
             "ID": 12140,

--- a/static/data/decors.json
+++ b/static/data/decors.json
@@ -1360,12 +1360,6 @@
       {
         "items": [
           {
-            "ID": 15401,
-            "icon": "7504945",
-            "itemId": "263996",
-            "name": "Twilight Tabernacle"
-          },
-          {
             "ID": 15399,
             "icon": "7504910",
             "itemId": "263994",
@@ -1382,24 +1376,6 @@
             "icon": "7506226",
             "itemId": "264170",
             "name": "Ancient Kaldorei Coffer"
-          },
-          {
-            "ID": 15413,
-            "icon": "7504904",
-            "itemId": "264008",
-            "name": "Root-Wrapped Reliquary"
-          },
-          {
-            "ID": 15412,
-            "icon": "7504821",
-            "itemId": "264007",
-            "name": "Corewarden's Spoils"
-          },
-          {
-            "ID": 15400,
-            "icon": "7504914",
-            "itemId": "263995",
-            "name": "Delver's Bountiful Coffer"
           },
           {
             "ID": 15582,
@@ -2019,6 +1995,30 @@
             "icon": "7507184",
             "itemId": "264252",
             "name": "Zul'Aman Forest Hammock"
+          },
+          {
+            "ID": 15413,
+            "icon": "7504904",
+            "itemId": "264008",
+            "name": "Root-Wrapped Reliquary"
+          },
+          {
+            "ID": 15412,
+            "icon": "7504821",
+            "itemId": "264007",
+            "name": "Corewarden's Spoils"
+          },
+          {
+            "ID": 15400,
+            "icon": "7504914",
+            "itemId": "263995",
+            "name": "Delver's Bountiful Coffer"
+          },
+          {
+            "ID": 15401,
+            "icon": "7504945",
+            "itemId": "263996",
+            "name": "Twilight Tabernacle"
           }
         ],
         "name": "Vendor"

--- a/static/data/decors.json
+++ b/static/data/decors.json
@@ -115,12 +115,6 @@
       {
         "items": [
           {
-            "ID": 16965,
-            "icon": "7537089",
-            "itemId": "265545",
-            "name": "Cuddly Void Grrgle"
-          },
-          {
             "ID": 16818,
             "icon": "7531451",
             "itemId": "265394",
@@ -10771,6 +10765,13 @@
             "icon": "7497419",
             "itemId": "263298",
             "name": "Cuddly Alliance Blue Grrgle",
+            "notObtainable": true
+          },
+          {
+            "ID": 16965,
+            "icon": "7537089",
+            "itemId": "265545",
+            "name": "Cuddly Void Grrgle",
             "notObtainable": true
           }
         ],

--- a/static/data/decors.json
+++ b/static/data/decors.json
@@ -540,12 +540,6 @@
             "name": "Sealed Fungal Jar"
           },
           {
-            "ID": 2589,
-            "icon": "7423080",
-            "itemId": "246960",
-            "name": "Opened Fungal Jar"
-          },
-          {
             "ID": 14825,
             "icon": "7491978",
             "itemId": "263039",
@@ -609,12 +603,6 @@
             "icon": "7515817",
             "itemId": "264509",
             "name": "Void Elf Barrel"
-          },
-          {
-            "ID": 16097,
-            "icon": "7517855",
-            "itemId": "264720",
-            "name": "Void Elf Bedroll"
           },
           {
             "ID": 18800,
@@ -694,10 +682,81 @@
       {
         "items": [
           {
+            "ID": 22143,
+            "icon": "7814986",
+            "itemId": "273159",
+            "name": "Void Elf Scribe's Desk"
+          },
+          {
+            "ID": 22181,
+            "icon": "7815540",
+            "itemId": "273135",
+            "name": "Void Elf Floating Desk"
+          },
+          {
+            "ID": 22182,
+            "icon": "7815542",
+            "itemId": "273142",
+            "name": "Runic Parchment"
+          },
+          {
+            "ID": 22183,
+            "icon": "7815550",
+            "itemId": "273157",
+            "name": "Void Flame Candle"
+          },
+          {
+            "ID": 22388,
+            "icon": "7817533",
+            "itemId": "273147",
+            "name": "Void Inkwell"
+          },
+          {
+            "ID": 21598,
+            "icon": "7745282",
+            "itemId": "271158",
+            "name": "Dark Obelisk"
+          }
+        ],
+        "name": "Renown: Ritual Sites"
+      },
+      {
+        "items": [
+          {
             "ID": 2459,
             "icon": "7422803",
             "itemId": "246692",
             "name": "Murder Row Wine Decanter"
+          },
+          {
+            "ID": 14970,
+            "icon": "7493730",
+            "itemId": "263203",
+            "name": "Rack of Silvermoon Arms"
+          },
+          {
+            "ID": 14978,
+            "icon": "7493738",
+            "itemId": "263212",
+            "name": "Farstrider's Comfy Cushion"
+          },
+          {
+            "ID": 14979,
+            "icon": "7493746",
+            "itemId": "263216",
+            "name": "Gilded Lightwood Wardrobe"
+          },
+          {
+            "ID": 14995,
+            "icon": "7493718",
+            "itemId": "263224",
+            "name": "Gentle Floating Planter"
+          },
+          {
+            "ID": 15013,
+            "icon": "7493710",
+            "itemId": "263225",
+            "name": "Sunlit Glass Mirror"
           },
           {
             "ID": 7782,
@@ -1087,6 +1146,30 @@
             "icon": "7514980",
             "itemId": "264481",
             "name": "Earthhide Amani Tapestry"
+          },
+          {
+            "ID": 2299,
+            "icon": "7422591",
+            "itemId": "246458",
+            "name": "Grand Aethercharged Crystal"
+          },
+          {
+            "ID": 8877,
+            "icon": "7424733",
+            "itemId": "251914",
+            "name": "Sumptuous Berry Pie"
+          },
+          {
+            "ID": 16691,
+            "icon": "7525984",
+            "itemId": "265106",
+            "name": "Farstriders' Pride Statue"
+          },
+          {
+            "ID": 17294,
+            "icon": "7539441",
+            "itemId": "265631",
+            "name": "Farstriders' Glory Statue"
           }
         ],
         "name": "Quest"
@@ -1110,6 +1193,12 @@
             "icon": "7514974",
             "itemId": "264491",
             "name": "Voidbound Holding Cell"
+          },
+          {
+            "ID": 15756,
+            "icon": "7514978",
+            "itemId": "264492",
+            "name": "Chaotic Void Maw"
           },
           {
             "ID": 15758,
@@ -1824,6 +1913,30 @@
             "name": "\"The Light Blooms\" Unframed Painting"
           },
           {
+            "ID": 11323,
+            "icon": "7425977",
+            "itemId": "256923",
+            "name": "Amani Crafter's Tool Rack"
+          },
+          {
+            "ID": 15484,
+            "icon": "7507192",
+            "itemId": "264249",
+            "name": "Woodblock Stool"
+          },
+          {
+            "ID": 15489,
+            "icon": "7507188",
+            "itemId": "264254",
+            "name": "Three-Tier Zul'Aman Shelf"
+          },
+          {
+            "ID": 15851,
+            "icon": "7516204",
+            "itemId": "264655",
+            "name": "Amani Slate Bench"
+          },
+          {
             "ID": 14824,
             "icon": "7507297",
             "itemId": "263038",
@@ -1840,36 +1953,6 @@
             "icon": "7506550",
             "itemId": "264243",
             "name": "Firm Haranir Pillow"
-          },
-          {
-            "ID": 14970,
-            "icon": "7493730",
-            "itemId": "263203",
-            "name": "Rack of Silvermoon Arms"
-          },
-          {
-            "ID": 14978,
-            "icon": "7493738",
-            "itemId": "263212",
-            "name": "Farstrider's Comfy Cushion"
-          },
-          {
-            "ID": 14979,
-            "icon": "7493746",
-            "itemId": "263216",
-            "name": "Gilded Lightwood Wardrobe"
-          },
-          {
-            "ID": 14995,
-            "icon": "7493718",
-            "itemId": "263224",
-            "name": "Gentle Floating Planter"
-          },
-          {
-            "ID": 15013,
-            "icon": "7493710",
-            "itemId": "263225",
-            "name": "Sunlit Glass Mirror"
           },
           {
             "ID": 2523,
@@ -1902,52 +1985,40 @@
             "name": "Root-Wrapped Reliquary"
           },
           {
-            "ID": 21598,
-            "icon": "7745282",
-            "itemId": "271158",
-            "name": "Dark Obelisk"
+            "ID": 12140,
+            "icon": "7646655",
+            "itemId": "258535",
+            "name": "Simple Bone-Tied Charm"
           },
           {
-            "ID": 22143,
-            "icon": "7814986",
-            "itemId": "273159",
-            "name": "Void Elf Scribe's Desk"
+            "ID": 12141,
+            "icon": "7646668",
+            "itemId": "258536",
+            "name": "Windmark Tribal Charm"
           },
           {
-            "ID": 22181,
-            "icon": "7815540",
-            "itemId": "273135",
-            "name": "Void Elf Floating Desk"
+            "ID": 12142,
+            "icon": "7646665",
+            "itemId": "258537",
+            "name": "Amani Dreamer's Charm"
           },
           {
-            "ID": 22182,
-            "icon": "7815542",
-            "itemId": "273142",
-            "name": "Runic Parchment"
+            "ID": 12143,
+            "icon": "7646658",
+            "itemId": "258538",
+            "name": "Barebone Rope Charm"
           },
           {
-            "ID": 22183,
-            "icon": "7815550",
-            "itemId": "273157",
-            "name": "Void Flame Candle"
+            "ID": 15486,
+            "icon": "7679713",
+            "itemId": "264251",
+            "name": "Depthdiver's Cooking Spit"
           },
           {
-            "ID": 22388,
-            "icon": "7817533",
-            "itemId": "273147",
-            "name": "Void Inkwell"
-          },
-          {
-            "ID": 2299,
-            "icon": "7422591",
-            "itemId": "246458",
-            "name": "Grand Aethercharged Crystal"
-          },
-          {
-            "ID": 8877,
-            "icon": "7424733",
-            "itemId": "251914",
-            "name": "Sumptuous Berry Pie"
+            "ID": 15487,
+            "icon": "7507184",
+            "itemId": "264252",
+            "name": "Zul'Aman Forest Hammock"
           }
         ],
         "name": "Vendor"
@@ -4087,12 +4158,6 @@
             "icon": "7423465",
             "itemId": "247913",
             "name": "Ornate Suramar Table"
-          },
-          {
-            "ID": 15756,
-            "icon": "7514978",
-            "itemId": "264492",
-            "name": "Chaotic Void Maw"
           }
         ],
         "name": "Dungeon Drop"
@@ -11104,6 +11169,13 @@
             "notObtainable": true
           },
           {
+            "ID": 2589,
+            "icon": "7423080",
+            "itemId": "246960",
+            "name": "Opened Fungal Jar",
+            "notObtainable": true
+          },
+          {
             "ID": 3834,
             "icon": "7423176",
             "itemId": "247664",
@@ -12119,41 +12191,6 @@
             "notObtainable": true
           },
           {
-            "ID": 11323,
-            "icon": "7425977",
-            "itemId": "256923",
-            "name": "Amani Crafter's Tool Rack",
-            "notObtainable": true
-          },
-          {
-            "ID": 12140,
-            "icon": "7646655",
-            "itemId": "258535",
-            "name": "Simple Bone-Tied Charm",
-            "notObtainable": true
-          },
-          {
-            "ID": 12141,
-            "icon": "7646668",
-            "itemId": "258536",
-            "name": "Windmark Tribal Charm",
-            "notObtainable": true
-          },
-          {
-            "ID": 12142,
-            "icon": "7646665",
-            "itemId": "258537",
-            "name": "Amani Dreamer's Charm",
-            "notObtainable": true
-          },
-          {
-            "ID": 12143,
-            "icon": "7646658",
-            "itemId": "258538",
-            "name": "Barebone Rope Charm",
-            "notObtainable": true
-          },
-          {
             "ID": 14817,
             "icon": "7489655",
             "itemId": "263031",
@@ -12168,27 +12205,6 @@
             "notObtainable": true
           },
           {
-            "ID": 15484,
-            "icon": "7507192",
-            "itemId": "264249",
-            "name": "Woodblock Stool",
-            "notObtainable": true
-          },
-          {
-            "ID": 15487,
-            "icon": "7507184",
-            "itemId": "264252",
-            "name": "Zul'Aman Forest Hammock",
-            "notObtainable": true
-          },
-          {
-            "ID": 15489,
-            "icon": "7507188",
-            "itemId": "264254",
-            "name": "Three-Tier Zul'Aman Shelf",
-            "notObtainable": true
-          },
-          {
             "ID": 15598,
             "icon": "7506150",
             "itemId": "264352",
@@ -12200,13 +12216,6 @@
             "icon": "garrison_building_storehouse",
             "itemId": "264353",
             "name": "Empty Elegant Elven Bathtub",
-            "notObtainable": true
-          },
-          {
-            "ID": 15851,
-            "icon": "7516204",
-            "itemId": "264655",
-            "name": "Amani Slate Bench",
             "notObtainable": true
           },
           {
@@ -12284,13 +12293,6 @@
             "icon": null,
             "itemId": "113503",
             "name": "DO NOT USE - new asset coming - Well-Lit Incontinental Couch",
-            "notObtainable": true
-          },
-          {
-            "ID": 15486,
-            "icon": "7679713",
-            "itemId": "264251",
-            "name": "Depthdiver's Cooking Spit",
             "notObtainable": true
           },
           {
@@ -12406,20 +12408,6 @@
             "notObtainable": true
           },
           {
-            "ID": 16691,
-            "icon": "7525984",
-            "itemId": "265106",
-            "name": "Farstriders' Pride Statue",
-            "notObtainable": true
-          },
-          {
-            "ID": 17294,
-            "icon": "7539441",
-            "itemId": "265631",
-            "name": "Farstriders' Glory Statue",
-            "notObtainable": true
-          },
-          {
             "ID": 16039,
             "icon": null,
             "itemId": "264692",
@@ -12450,6 +12438,13 @@
             "name": "Spring Blossom Pond",
             "notObtainable": true,
             "notReleased": true
+          },
+          {
+            "ID": 16097,
+            "icon": "7517855",
+            "itemId": "264720",
+            "name": "Void Elf Bedroll",
+            "notObtainable": true
           },
           {
             "ID": 15070,


### PR DESCRIPTION
Fixed the following decor sources:
- Removed Opened Fungal Jar & Void Elf Bedroll.
- Created a new category for the "Renown: Ritual Sites" (to fit with the other Renown categories) and its 6 decor items.
- Moved the 5 items available from the 4 sub-factions of Silvermoon to the Reputation category (Murder Row Wine Decanter & Crimson Lightwood Privacy Screen were already there).
- Moved Grand Aethercharged Crystal, Sumptuous Berry Pie, Farstriders' Pride Statue, and Farstriders' Glory Statue to the Quest category.
- Moved Chaotic Void Maw from the "Legion:Dungeon" category to the "Midnight:Raid category".
- Moved the 4 Abundance items to "Vendor".
- Moved the 6 Abyss Anglers items to "Vendor".

Second commit with all the fixes I missed in the first one:
- Open Void Elf Bedroll -> Quest (instead of Renown).
- On'ohia's Call -> Achievement (instead of Quest).
- Gemmed Eversong Lantern -> Treasure (instead of Quest).
- Zul'Aman Ancestral Fountain -> Quest (instead of Dungeon).
- Moved all the chests items unlocked from the Season 1 of Delves from Vendor to Delves.