### PR TITLE
Correction

### DIFF
--- a/static/data/mounts.json
+++ b/static/data/mounts.json
@@ -434,13 +434,6 @@
             "spellid": 171847
           },
           {
-            "ID": 593,
-            "icon": "ability_mount_clockworkhorse",
-            "itemId": 112326,
-            "name": "Warforged Nightmare",
-            "spellid": 163024
-          },
-          {
             "ID": 1051,
             "icon": "inv_skiff",
             "itemId": 160589,


### PR DESCRIPTION
Removed Warforged Nightmare from the celebration vendor list, as it is not included.